### PR TITLE
Update code block styling with white background and padding

### DIFF
--- a/docs/app/routes/__root.tsx
+++ b/docs/app/routes/__root.tsx
@@ -243,8 +243,10 @@ pre {
 }
 
 pre code {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
   background: #fff;
-  padding: 16px;
 }
 
 blockquote {

--- a/docs/app/routes/__root.tsx
+++ b/docs/app/routes/__root.tsx
@@ -234,7 +234,8 @@ pre {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 0.82rem;
   line-height: 1.6;
-  background: var(--code-bg);
+  background: #fff;
+  padding: 16px;
   border: 1px solid var(--border);
   border-radius: 4px;
   overflow-x: auto;

--- a/docs/app/routes/__root.tsx
+++ b/docs/app/routes/__root.tsx
@@ -235,7 +235,6 @@ pre {
   font-size: 0.82rem;
   line-height: 1.6;
   background: #fff;
-  padding: 16px;
   border: 1px solid var(--border);
   border-radius: 4px;
   overflow-x: auto;
@@ -243,9 +242,10 @@ pre {
   box-shadow: 2px 2px 2px 2px rgb(0 0 255 / 0.1);
 }
 
-pre code {
-  background: none;
-  padding: 0;
+pre code,
+pre code.hljs {
+  background: #fff;
+  padding: 16px;
 }
 
 blockquote {

--- a/docs/app/routes/__root.tsx
+++ b/docs/app/routes/__root.tsx
@@ -242,8 +242,7 @@ pre {
   box-shadow: 2px 2px 2px 2px rgb(0 0 255 / 0.1);
 }
 
-pre code,
-pre code.hljs {
+pre code {
   background: #fff;
   padding: 16px;
 }


### PR DESCRIPTION
## Summary
Updated the styling of `<pre>` code blocks to improve readability and visual consistency by changing the background color and adding padding.

## Changes
- Changed code block background from `var(--code-bg)` to a fixed white (`#fff`) color
- Added `16px` padding to code blocks for better spacing around the content
- Maintains existing border, border-radius, and overflow properties

## Details
This change ensures code blocks have a consistent white background regardless of theme variables, and provides better visual separation between the code content and the block's border. The 16px padding improves readability by creating breathing room around the code text.

https://claude.ai/code/session_01G73WquVn3d7ThbsHwZawG2