### PR TITLE
Release v0.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Both register through the same `sceneRegistry` in `scene.ts`. The runner (`runne
 - `team-manager.ts` — `TeamManager` with pool acquire/release for parallel execution
 - `runner.ts` — `SceneRunner` with scene discovery, browser init, lifecycle hooks
 - `cli.ts` — CLI entry point, report generation (HTML/JSON)
+- `keyboard.ts` — `NavigationModeRotation`, `tabToElement()`, `pressEnter()`, `clearAndType()`, fuzzy-finger helpers (`fuzzyFingerClick`, `fuzzyFingerFill`, `fuzzyFingerCheck`), `FuzzyFingerError`
 - `config.ts` — `loadConfig()`, `findConfigFile()`, `defineConfig()`, team discovery
 - `types.ts` — All type definitions (`ScenetestConfig`, `SequentialActorHandle`, `ActionChain`, `ConcurrentActorHandle`, `SceneContext`, etc.)
 

--- a/docs/app/sections.ts
+++ b/docs/app/sections.ts
@@ -25,6 +25,12 @@ export const guides: SectionItem[] = [
   },
 
   {
+    slug: 'conditional-handling',
+    title: 'Conditional Handling',
+    description:
+      'Use if() to dismiss optional UI like modals and banners, and warnIf() to flag unexpected paths without failing the test.',
+  },
+  {
     slug: 'building-teams',
     title: 'Teams of Actors',
     description:

--- a/docs/app/sections.ts
+++ b/docs/app/sections.ts
@@ -61,7 +61,7 @@ export const reference: SectionItem[] = [
     slug: 'cli',
     title: 'CLI Reference',
     description:
-      'Command-line options, configuration file format, team discovery, device rotation, swarm mode, and report output.',
+      'Command-line options, configuration file format, team discovery, device rotation, keyboard navigation, fuzzy-finger touch simulation, swarm mode, and report output.',
   },
   {
     slug: 'concurrent-and-classic',

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=https://scenetest.github.io/scenetest-js/">
+    <meta http-equiv="refresh" content="0; url=https://scenetest.msnook.xyz">
     <script type="text/javascript">
-        window.location.replace("https://scenetest.github.io/scenetest-js/");
+        window.location.replace("https://scenetest.msnook.xyz");
     </script>
     <title>Redirecting...</title>
 </head>
 <body>
-    <p>If you are not redirected automatically, please <a href="https://scenetest.github.io/scenetest-js/">click here</a>.</p>
+    <p>If you are not redirected automatically, please <a href="https://scenetest.msnook.xyz">click here</a>.</p>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=https://scenetest.github.io/scenetest-js/">
+    <script type="text/javascript">
+        window.location.replace("https://scenetest.github.io/scenetest-js/");
+    </script>
+    <title>Redirecting...</title>
+</head>
+<body>
+    <p>If you are not redirected automatically, please <a href="https://scenetest.github.io/scenetest-js/">click here</a>.</p>
+</body>
+</html>

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/docs",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "sideEffects": false,
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "pnpm --filter @scenetest/checks --filter @scenetest/checks-react --filter @scenetest/checks-panel build && vite build",
     "start": "node .output/server/index.mjs"
   },
   "dependencies": {

--- a/docs/public/design/cli-v2.md
+++ b/docs/public/design/cli-v2.md
@@ -286,6 +286,12 @@ defineConfig({
   reportDir: './scenetest-reports',
   reportFormat: 'html', // 'html' | 'json' | 'both'
 
+  // Keyboard navigation (ON by default)
+  noKeyboardActor: false, // Set true to disable keyboard actor rotation
+
+  // Fuzzy-finger touch simulation (OFF by default)
+  fuzzyFingers: false,    // Set true to enable imprecise touch (~1 in 5 clicks miss)
+
   // Actor teams are auto-discovered from actors.ts or actors/*.ts
   // (not defined in config)
 

--- a/docs/public/design/writing-tests.md
+++ b/docs/public/design/writing-tests.md
@@ -124,6 +124,12 @@ export default defineConfig({
   },
   reportDir: './scenetest-reports',
   reportFormat: 'html',
+
+  // Keyboard navigation (ON by default — actors rotate pointer/keyboard)
+  // noKeyboardActor: true,   // Uncomment to disable
+
+  // Fuzzy-finger touch simulation (OFF by default)
+  // fuzzyFingers: true,      // Uncomment to enable imprecise touch (~1 in 5 clicks miss)
 })
 ```
 

--- a/docs/public/guides/conditional-handling.md
+++ b/docs/public/guides/conditional-handling.md
@@ -1,0 +1,122 @@
+# Conditional Handling
+
+Real applications have UI that doesn't always appear. A welcome modal shows up on first login but not on repeat visits. A cookie banner depends on region. A feature announcement rolls out to 50% of users. Your test script can't predict whether these will show up, but it needs to handle them if they do.
+
+`if()` and `warnIf()` are the tools for this. They both watch for a selector during the actor's actions, but respond differently: `if()` intervenes (clicks a dismiss button, fills a form), while `warnIf()` just records a note.
+
+## if() — Handle It If It Appears
+
+`if()` registers a **conditional monitor**. You give it a selector and a set of actions. If that selector becomes visible while the actor is doing something else, the monitor fires: it pauses the current action, runs the sub-actions, then resumes.
+
+```typescript [concurrent]
+scene('user reaches dashboard', ({ actor }) => {
+  const user = actor('user')
+
+  user.openTo('/app')
+
+  // If a welcome modal pops up at any point, dismiss it
+  user.if('welcome-modal', a => a.click('dismiss'))
+
+  user.see('dashboard')
+  user.see('sidebar').click('settings')
+})
+```
+
+```typescript [classic driver]
+test('user reaches dashboard', async ({ actor }) => {
+  const user = await actor('user')
+
+  await user.openTo('/app')
+
+  // If a welcome modal pops up during the next action, dismiss it
+  user.if('welcome-modal', async () => {
+    await user.click('dismiss')
+  })
+
+  await user.see('dashboard')
+})
+```
+
+```scenetest [markdown]
+# user reaches dashboard
+
+user:
+- openTo /app
+- if welcome-modal
+    click dismiss
+- see dashboard
+- see sidebar
+- click settings
+```
+
+### What happens at runtime
+
+There are two phases: **declaration** (when your script runs) and **drain** (when the browser acts).
+
+**Declaration:** When the runner hits `user.if('welcome-modal', ...)`, nothing happens in the browser. The callback runs immediately, but the actor's internal queue is temporarily redirected — so `a.click('dismiss')` pushes to a *separate sub-action list* attached to the monitor, not to the actor's main queue. Your main action sequence is unaffected.
+
+**Drain:** As the actor works through its queue (`see('dashboard')`, `click('settings')`, etc.), a polling loop runs alongside each action. Every 50ms it checks: is `welcome-modal` visible? If yes, the monitor fires — the sub-actions (`click('dismiss')`) execute inline, pausing the current action, then the action resumes. The monitor is **one-shot**: once it fires, it stops polling. If the modal never appears, the monitor never fires and has zero cost beyond the polling.
+
+### When does it poll?
+
+The monitor watches during **every action that comes after it** in the actor's queue. It doesn't watch retroactively — only actions declared after the `if()` call are monitored. This is why you typically declare `if()` early, before the actions where the optional UI might appear.
+
+### Lifecycle difference between models
+
+In the **concurrent model** (`scene()`), the monitor is persistent — it polls during every subsequent action until it fires or the scene ends.
+
+In the **classic driver** (`test()`), watchers are cleared after each `await`. So `if()` only watches during the *immediately next* awaited action. If you need it to watch across multiple actions, re-register it.
+
+For a full side-by-side comparison, see the [Concurrent and Classic Mode reference](/reference/concurrent-and-classic#conditional-monitors-if).
+
+## warnIf() — Flag It, Don't Fix It
+
+Sometimes you don't want to handle the optional UI — you want to know it appeared. `warnIf()` records a warning but doesn't intervene:
+
+```typescript [concurrent]
+scene('returning user sees dashboard', ({ actor }) => {
+  const user = actor('user')
+
+  // This user's seed data has dismiss_welcome=true,
+  // so the modal shouldn't appear. Warn if it does.
+  user.warnIf('welcome-modal', 'user should have dismiss flag set')
+
+  user.openTo('/app')
+  user.see('dashboard')
+})
+```
+
+```typescript [classic driver]
+test('returning user sees dashboard', async ({ actor }) => {
+  const user = await actor('user')
+
+  user.warnIf('welcome-modal', 'user should have dismiss flag set')
+
+  await user.openTo('/app')
+  await user.see('dashboard')
+})
+```
+
+Unlike `if()`, warnings **persist for the entire scene** in both models. They're recorded in `SceneReport.warnings` and show up in reports, but they don't fail the test.
+
+Warnings are useful for:
+- **Seed data issues** — a user that shouldn't see onboarding is seeing it
+- **A/B test monitoring** — tracking which variant an actor hit
+- **Deprecation paths** — flagging when old UI surfaces unexpectedly
+
+## Choosing Between if() and warnIf()
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| Modal that must be dismissed to proceed | `if()` | The test will hang without intervention |
+| Cookie banner that blocks interaction | `if()` | Need to clear it to reach the UI underneath |
+| Onboarding flow that shouldn't appear for this user | `warnIf()` | Test still passes, but you want to know |
+| Feature flag variant you want to track | `warnIf()` | Informational, not actionable |
+| Error toast that indicates a real bug | Neither | Use `notSee('error-toast')` — this should fail the test |
+
+## Tips
+
+- **Declare `if()` early.** It only monitors actions that come *after* it in the queue. Put it before the actions where the optional UI might appear.
+- **Keep sub-actions short.** A monitor fires inline during another action. A single `click('dismiss')` or `click('accept')` is ideal. Don't put a multi-step flow inside a monitor.
+- **One-shot is usually right.** Monitors fire once and stop. If the same element keeps reappearing, that's likely a bug in the app, not something to handle silently.
+- **`warnIf()` is cheap.** Sprinkle warnings for anything that *shouldn't* happen but *might*. They cost nothing when the selector doesn't match.

--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -158,27 +158,7 @@ await user.see('other-section')
 
 ## Conditional Handling
 
-Use `if()` to register a watcher for elements that may or may not appear. If the selector becomes visible during the next `await`, the callback runs:
-
-```typescript
-// Handle a welcome modal that sometimes appears
-user.if('welcome-modal', () => user.click('dismiss'))
-await user.see('dashboard')  // If modal appears, it gets dismissed first
-```
-
-Watchers are cleared after each `await`, so they only apply to the immediately following action.
-
-## Script Warnings
-
-Use `warnIf()` to flag unexpected paths without failing the test. Unlike `if()`, warnings persist for the entire scene:
-
-```typescript
-user.warnIf('welcome-modal', 'user should have dismiss flag set')
-await user.openTo('/dashboard')
-await user.see('main-content')
-```
-
-Warnings are reported separately in `SceneReport.warnings` and are useful for tracking deprecation paths, flaky conditions, and A/B test monitoring.
+Use `if()` to handle optional UI (modals, banners, announcements) that may or may not appear, and `warnIf()` to flag unexpected paths without failing the test. See the [Conditional Handling guide](/guides/conditional-handling) for a full walkthrough of when and how to use each.
 
 ## Writing Effective Scene Specs
 

--- a/docs/public/reference/actor-api.md
+++ b/docs/public/reference/actor-api.md
@@ -309,6 +309,8 @@ user.click(selector?: Selector): ConcurrentActorHandle | ActionChain
 
 Clicks the element matching the selector within the current scope. When called with **no selector** (bare `click`), clicks the current scope element itself.
 
+In **keyboard mode**, this becomes Tab-to-element → Enter. With **fuzzy-fingers** enabled (pointer mode only), ~1 in 5 clicks intentionally miss first, then correct. See [Keyboard Navigation Mode](/reference/cli#keyboard-navigation-mode) and [Fuzzy-Finger Touch Simulation](/reference/cli#fuzzy-finger-touch-simulation).
+
 ```typescript [concurrent]
 user.click('submit-button')
 user.click('user-card action-menu')   // nested selector
@@ -332,6 +334,8 @@ user.typeInto(selector: Selector, value: string): ConcurrentActorHandle | Action
 
 Clears and types text into the input matching the selector within the current scope.
 
+In **keyboard mode**, this tabs to the input, selects all (Ctrl+A), deletes, then types character by character. With **fuzzy-fingers** enabled, the initial focus click may miss first.
+
 ```typescript [concurrent]
 user.typeInto('email-input', 'alice@example.com')
 user.typeInto('search-form query', 'scenetest')   // nested selector
@@ -349,6 +353,8 @@ user.check(selector: Selector): ConcurrentActorHandle | ActionChain
 
 Checks a checkbox matching the selector within the current scope.
 
+In **keyboard mode**, this tabs to the checkbox and presses Space. With **fuzzy-fingers** enabled, the initial focus click may miss first.
+
 ```typescript [concurrent]
 user.check('terms-checkbox')
 user.check('settings-form notifications-toggle')
@@ -365,6 +371,8 @@ user.select(selector: Selector, value: string): ConcurrentActorHandle | ActionCh
 ```
 
 Selects an option by value in a dropdown matching the selector within the current scope.
+
+In **keyboard mode**, this tabs to the select element, then uses the browser's native `selectOption()` API.
 
 ```typescript [concurrent]
 user.select('country-dropdown', 'us')
@@ -613,6 +621,18 @@ test('friend request flow', async ({ actor }) => {
   await receiver.see('friend-request-notification')
 })
 ```
+
+## Navigation Modes
+
+Each actor is assigned a **navigation mode** — either `pointer` (default mouse/touch) or `keyboard` (Tab + Enter/Space). The mode is assigned automatically by the `NavigationModeRotation` and is transparent to spec authors: the same `click()`, `typeInto()`, `check()`, and `select()` calls work in both modes.
+
+This is ON by default. To disable keyboard actor rotation, pass `--no-keyboard-actor` or set `noKeyboardActor: true` in config. See [Keyboard Navigation Mode](/reference/cli#keyboard-navigation-mode) for details.
+
+### Fuzzy-Finger Touch Simulation
+
+When `fuzzyFingers: true` is set in config (or `--fuzzy-fingers` is passed), pointer-mode actors simulate imprecise human touch. ~1 in 5 interactions intentionally miss the target, pause 100ms, then click correctly. If the mis-click causes the target to vanish (neighbor activated), a `FuzzyFingerError` is thrown.
+
+See [Fuzzy-Finger Touch Simulation](/reference/cli#fuzzy-finger-touch-simulation) for details on strategies and error handling.
 
 ## Selectors
 

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -21,6 +21,8 @@ scenetest --swarm              # Run swarm mode (all teams, all scenes)
 | `--report <dir>` | Report output directory (default: `./scenetest-reports`) |
 | `--format <fmt>` | Report format: `html`, `json`, or `both` (default: `html`) |
 | `--devices` | Enable device rotation (assign rotating mobile/tablet/desktop devices to actors) |
+| `--no-keyboard-actor` | Disable keyboard-only actor rotation (keyboard navigation is ON by default) |
+| `--fuzzy-fingers` | Enable fuzzy-finger touch simulation (imprecise human touch, ~1 in 5 clicks miss) |
 | `--swarm` | Force swarm mode — run all teams against all scenes to classify failures |
 
 ## Configuration File
@@ -68,6 +70,16 @@ export default defineConfig({
   // devices: [
   //   { name: 'iPhone 14', category: 'mobile', contextOptions: { ... } },
   // ],
+
+  // Keyboard navigation (ON by default)
+  // Actors rotate between pointer and keyboard modes.
+  // Keyboard actors navigate via Tab and activate via Enter/Space.
+  noKeyboardActor: false,       // Set true to disable keyboard actor rotation
+
+  // Fuzzy-finger touch simulation (OFF by default)
+  // When enabled, pointer-mode actors occasionally mis-click (~1 in 5),
+  // pause 100ms, then click correctly — simulating imprecise human touch.
+  fuzzyFingers: false,          // Set true to enable
 
   // Swarm mode
   swarm: {
@@ -157,6 +169,67 @@ Device assignments appear in reports:
     [user] assigned device: iPhone 14 (mobile)
     [admin] assigned device: Desktop 1920x1080 (desktop)
 ```
+
+## Keyboard Navigation Mode
+
+By default, scenetest rotates actors between two navigation modes:
+
+- **`pointer`** — standard mouse/touch interaction (Playwright's normal `.click()`, `.fill()`, etc.)
+- **`keyboard`** — navigate via Tab key and activate via Enter/Space
+
+This rotation is **ON by default**. In the default pool `['pointer', 'keyboard']`, half your actors use keyboard navigation. This surfaces keyboard-accessibility issues (missing `tabindex`, non-focusable elements, broken tab order) without any extra test configuration.
+
+**How it works:** When an actor is in keyboard mode, every `click()` call becomes a series of Tab presses to reach the target element, followed by Enter. Every `typeInto()` tabs to the input, then types. Every `check()` tabs to the checkbox, then presses Space. The same spec works in both modes — test authors don't need to think about it.
+
+**Disabling:** Pass `--no-keyboard-actor` on the CLI or set `noKeyboardActor: true` in config.
+
+**What shows in reports:**
+
+```
+✓ user logs in (1523ms)
+    [user] navigationMode: keyboard
+    [admin] (pointer, default)
+```
+
+Only non-default modes (keyboard) are shown in reports. Pointer mode is the default and is omitted.
+
+**Keyboard actions used internally:**
+
+| Actor DSL method | Keyboard-mode implementation |
+|------------------|------------------------------|
+| `click(selector)` | Tab to element → Enter |
+| `typeInto(selector, value)` | Tab to element → Ctrl+A → Backspace → type characters |
+| `check(selector)` | Tab to element → Space |
+| `select(selector, value)` | Tab to element → `selectOption()` (native browser API) |
+
+## Fuzzy-Finger Touch Simulation
+
+When enabled, pointer-mode actors simulate imprecise human touch input. Approximately 1 in 5 clicks (~20%) intentionally miss the target, pause 100ms (human noticing the miss), then click correctly.
+
+**This is OFF by default.** Enable with `--fuzzy-fingers` on the CLI or `fuzzyFingers: true` in config.
+
+**Purpose:** Surface touch-target problems in your UI:
+
+- **Undersized targets** — WCAG 2.5.8 requires a minimum 24×24 CSS-px touch target. The `miss-center` strategy clicks 15px from the element's center. If that misses, the target is too small.
+- **Crowded targets** — The `miss-edge` strategy clicks 3px outside the element's bounding box. If that activates a neighbor, targets are packed too tightly.
+
+**How it works:**
+
+1. ~80% of clicks go through normally (no mis-click)
+2. ~20% of clicks: pick a strategy (alternating `miss-center` / `miss-edge`), click the wrong spot, pause 100ms, then click the correct element
+3. If the correct click succeeds → move on silently (humans miss all the time)
+4. If the correct click fails because the element vanished (the mis-click activated a neighbor) → throw `FuzzyFingerError`
+
+**`FuzzyFingerError` details:**
+
+```
+FuzzyFingerError: Fuzzy-finger failure on "close-btn":
+  target too close to neighbor (mis-click 3px outside edge activated adjacent element)
+```
+
+The error includes the strategy (`miss-center` or `miss-edge`), the selector, and the original error. Only thrown when the UI has a real touch-target problem — not on normal failures.
+
+**Applies to:** `click()`, `typeInto()`, `check()` — only for pointer-mode actors. Keyboard-mode actors are unaffected.
 
 ## Swarm Mode
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scenetest-monorepo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A local-first testing framework for the Vite ecosystem",
   "license": "MIT",
   "private": true,

--- a/packages/checks-panel/package.json
+++ b/packages/checks-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-panel",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Observer panel for scenetest - displays assertions in real-time",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-react/package.json
+++ b/packages/checks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-solid/package.json
+++ b/packages/checks-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-solid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Solid bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-svelte/package.json
+++ b/packages/checks-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-svelte",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Svelte bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-vue/package.json
+++ b/packages/checks-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-vue",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Vue bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/eslint-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "ESLint plugin for scenetest - accessibility and testing best practices",
   "type": "module",
   "license": "MIT",

--- a/packages/playwright-scenetest/package.json
+++ b/packages/playwright-scenetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/playwright",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Playwright fixtures for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes-panel/package.json
+++ b/packages/scenes-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes-panel",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Scene recorder for scenetest - records user interactions as DSL",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -43,7 +43,7 @@
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {

--- a/packages/scenes/src/__tests__/reactive.test.ts
+++ b/packages/scenes/src/__tests__/reactive.test.ts
@@ -7,7 +7,7 @@ import type { TimelineEntry, ScriptWarning } from '../types.js'
 // Helpers — minimal Playwright mocks
 // ---------------------------------------------------------------------------
 
-function mockLocator(visible = true) {
+function mockLocator(visible = false) {
   return {
     waitFor: vi.fn().mockResolvedValue(undefined),
     isVisible: vi.fn().mockResolvedValue(visible),
@@ -326,10 +326,9 @@ describe('ConcurrentActorHandleImpl', () => {
 
       actor.do(async () => { order.push('after') })
 
-      // We need the monitor to actually detect "modal" as visible.
-      // Since we're using mocks, the resolveSelector won't find anything,
-      // so the monitor won't fire.  This test verifies the flow completes
-      // without the monitor firing (no visible selector).
+      // The mock locator returns isVisible=false by default, so the
+      // monitor won't fire.  This test verifies the flow completes
+      // without the monitor firing (selector not visible).
       await actor.drain()
 
       expect(order).toEqual(['action-start', 'action-end', 'after'])

--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -30,6 +30,7 @@ program
   .option('--no-keyboard-actor', 'Disable keyboard-only actor rotation (keyboard navigation is ON by default)')
   .option('--fuzzy-fingers', 'Enable fuzzy-finger touch behavior (simulates imprecise human touch ~1 in 5 clicks)')
   .option('--swarm', 'Force swarm mode: run all teams against all scenes to classify failures')
+  .option('--no-panel', 'Suppress the dev panel in the browser (useful for CI / headless runs)')
   .action(async (scenes: string[], options: CLIOptions) => {
     try {
       // Load config and discover actor teams
@@ -53,6 +54,9 @@ program
       }
       if (options.fuzzyFingers) {
         config.fuzzyFingers = true
+      }
+      if (options.noPanel) {
+        config.noPanel = true
       }
 
       // Interactive UI mode

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -151,7 +151,7 @@ export class SceneRunner {
       try {
         // Create session
         const fuzzyFingers = !!this.config.fuzzyFingers
-        const session = await this.teamManager.createSession(teamIndex, actionTimeout, warnAfter, this.config.baseUrl, fuzzyFingers)
+        const session = await this.teamManager.createSession(teamIndex, actionTimeout, warnAfter, this.config.baseUrl, fuzzyFingers, this.config.noPanel)
 
         try {
           // Log which scene is starting
@@ -296,7 +296,8 @@ export class SceneRunner {
       this.config.baseUrl,
       trigger,
       this.config.server as Record<string, unknown> | undefined,
-      fuzzyFingers
+      fuzzyFingers,
+      this.config.noPanel
     )
 
     // Build a RunReport that includes the swarm results

--- a/packages/scenes/src/swarm.ts
+++ b/packages/scenes/src/swarm.ts
@@ -148,7 +148,8 @@ export async function runSwarm(
   baseUrl: string | undefined,
   trigger: 'auto' | 'manual',
   server?: Record<string, unknown>,
-  fuzzyFingers: boolean = false
+  fuzzyFingers: boolean = false,
+  noPanel?: boolean
 ): Promise<SwarmReport> {
   const resolved = resolveSwarmConfig(config)
   const totalTeams = teamManager.totalCount
@@ -211,7 +212,8 @@ export async function runSwarm(
             actionTimeout,
             warnAfter,
             baseUrl,
-            fuzzyFingers
+            fuzzyFingers,
+            noPanel
           )
 
           try {

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -189,7 +189,8 @@ export class TeamManager {
     actionTimeout: number,
     warnAfter: number,
     baseUrl?: string,
-    fuzzyFingers: boolean = false
+    fuzzyFingers: boolean = false,
+    noPanel?: boolean
   ): Promise<TeamSession> {
     if (!this.browser) {
       throw new Error('Browser not set. Call setBrowser() first.')
@@ -206,7 +207,8 @@ export class TeamManager {
       this.deviceRotation,
       this.warmupCache,
       this.navigationModeRotation,
-      fuzzyFingers
+      fuzzyFingers,
+      noPanel
     )
   }
 }
@@ -239,7 +241,8 @@ export class TeamSession {
     private deviceRotation?: DeviceRotation | null,
     private warmupCache: WarmupCache = new WarmupCache(),
     private navigationModeRotation?: NavigationModeRotation | null,
-    private fuzzyFingers: boolean = false
+    private fuzzyFingers: boolean = false,
+    private noPanel?: boolean
   ) {
     this.meta = meta
   }
@@ -352,6 +355,13 @@ export class TeamSession {
     const context = await this.browser.newContext(contextOptions)
     const page = await context.newPage()
 
+    // Suppress dev panel if --no-panel was passed
+    if (this.noPanel) {
+      await page.addInitScript(() => {
+        ;(window as unknown as Record<string, unknown>).__scenetest_panel = true
+      })
+    }
+
     // Track device name and navigation mode for assertions
     const deviceName = device?.name
     const navigationMode = navMode !== 'pointer' ? navMode : undefined
@@ -455,6 +465,13 @@ export class TeamSession {
     const contextOptions = await this.buildContextOptions(role, device)
     const context = await this.browser.newContext(contextOptions)
     const page = await context.newPage()
+
+    // Suppress dev panel if --no-panel was passed
+    if (this.noPanel) {
+      await page.addInitScript(() => {
+        ;(window as unknown as Record<string, unknown>).__scenetest_panel = true
+      })
+    }
 
     // Track device name and navigation mode for assertions
     const deviceName = device?.name

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -232,6 +232,13 @@ export interface ScenetestConfig extends BaseConfig {
    */
   swarm?: SwarmConfig
 
+  /**
+   * Suppress the dev panel in the browser.
+   * When true, the observer panel is prevented from initializing on pages
+   * created by the runner. Assertions still flow to the CLI reporter.
+   */
+  noPanel?: boolean
+
   /** Hook: before all scenes run */
   beforeAll?: () => Promise<void>
 
@@ -988,4 +995,7 @@ export interface CLIOptions {
 
   /** Force swarm mode (run all teams against all scenes) */
   swarm?: boolean
+
+  /** Suppress the dev panel in the browser (useful for CI / headless runs) */
+  noPanel?: boolean
 }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -42,7 +42,7 @@
     "@scenetest/scenes-panel": "workspace:*"
   },
   "peerDependencies": {
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@types/babel__traverse": "^7.20.5",

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -241,20 +241,27 @@ export function scenetest(options: ScenetestPluginOptions = {}): Plugin {
     },
 
     load(id) {
+      // Virtual modules return { code, moduleType } so Vite 8's Rolldown
+      // bundler knows these are JS modules (it infers type from file extension,
+      // and virtual module IDs may not have one). This is backward-compatible
+      // with Vite 5/6/7 which ignore the moduleType property.
       if (id === RESOLVED_VIRTUAL_MODULE_ID) {
-        return generateVirtualModuleCode()
+        return { code: generateVirtualModuleCode(), moduleType: 'js' }
       }
       // Virtual module that bootstraps the observer panel
       if (id === OBSERVER_VIRTUAL_ID) {
         const gitHash = getGitHash()
         const version = getVersion()
-        return `window.__SCENETEST_GIT_HASH__ = ${JSON.stringify(gitHash)};
+        return {
+          code: `window.__SCENETEST_GIT_HASH__ = ${JSON.stringify(gitHash)};
 window.__SCENETEST_VERSION__ = ${JSON.stringify(version)};
-import '${OBSERVER_MODULE}';`
+import '${OBSERVER_MODULE}';`,
+          moduleType: 'js',
+        }
       }
       // Virtual module that bootstraps the recorder panel
       if (id === RECORDER_VIRTUAL_ID) {
-        return `import '${RECORDER_MODULE}';`
+        return { code: `import '${RECORDER_MODULE}';`, moduleType: 'js' }
       }
       return null
     },

--- a/packages/vscode-scenetest/package.json
+++ b/packages/vscode-scenetest/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-scenetest",
   "displayName": "Scenetest",
   "description": "Syntax highlighting for Scenetest scene specs (.spec.md)",
-  "version": "0.1.3",
+  "version": "0.3.0",
   "publisher": "scenetest",
   "license": "MIT",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,8 +298,8 @@ importers:
         specifier: ^1.40.0
         version: 1.58.1
       vite:
-        specifier: ^5.0.0
-        version: 5.4.21(@types/node@20.19.30)
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+        version: 7.3.1(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
     devDependencies:
       '@types/node':
         specifier: ^20.10.0

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd .. && pnpm --filter @scenetest/checks build && pnpm --filter @scenetest/checks-react build && pnpm --filter @scenetest/checks-panel build && cd docs && NITRO_PRESET=vercel pnpm build",
-  "installCommand": "cd .. && pnpm install"
+  "buildCommand": "pnpm --filter @scenetest/checks --filter @scenetest/checks-react --filter @scenetest/checks-panel build && NITRO_PRESET=vercel pnpm --filter @scenetest/docs build",
+  "installCommand": "pnpm install",
+  "outputDirectory": "docs/.output"
 }


### PR DESCRIPTION
## Summary
- Support Vite 8 in peerDependencies and add moduleType for Rolldown
- Add `--no-panel` CLI option to suppress dev panel during headless runs
- Fix Vercel build (stale cd, pre-build workspace deps)
- Fix conditional monitor tests and add conditional handling guide (`if()`, `warnIf()`)
- Document keyboard navigation mode and fuzzy-finger touch simulation
- Bump all package versions to 0.3.0

## Test plan
- [ ] `pnpm build` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm -r test` passes
- [ ] Verify `--no-panel` flag works in headless runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)