### PR TITLE
Add browser console error capture and reporting

### DIFF
--- a/packages/scenes/src/__tests__/swarm.test.ts
+++ b/packages/scenes/src/__tests__/swarm.test.ts
@@ -23,6 +23,7 @@ function makeSceneReport(
       timestamp: Date.now(),
     })),
     warnings: [],
+    consoleErrors: [],
     timeline: [],
     duration: 100,
   }
@@ -43,6 +44,7 @@ function makeRunReport(scenes: SceneReport[]): RunReport {
         failed: scenes.reduce((sum, s) => sum + s.assertions.filter((a) => !a.result).length, 0),
       },
       warnings: 0,
+      consoleErrors: 0,
     },
   }
 }

--- a/packages/scenes/src/__tests__/team-manager.test.ts
+++ b/packages/scenes/src/__tests__/team-manager.test.ts
@@ -16,6 +16,9 @@ function mockPage() {
   return {
     goto: vi.fn().mockResolvedValue(undefined),
     exposeFunction: vi.fn().mockResolvedValue(undefined),
+    on: vi.fn(),
+    url: vi.fn().mockReturnValue('http://localhost:3000'),
+    addInitScript: vi.fn().mockResolvedValue(undefined),
     locator: vi.fn().mockReturnValue({
       waitFor: vi.fn().mockResolvedValue(undefined),
       click: vi.fn().mockResolvedValue(undefined),

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -49,6 +49,7 @@ export type {
   RunReport,
   AssertionResult,
   ScriptWarning,
+  ConsoleError,
   Selector,
   ConcurrentActorHandle,
   FlowContext,

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -151,7 +151,7 @@ export class SceneRunner {
       try {
         // Create session
         const fuzzyFingers = !!this.config.fuzzyFingers
-        const session = await this.teamManager.createSession(teamIndex, actionTimeout, warnAfter, this.config.baseUrl, fuzzyFingers, this.config.noPanel)
+        const session = await this.teamManager.createSession(teamIndex, actionTimeout, warnAfter, this.config.baseUrl, fuzzyFingers, this.config.noPanel, this.config.consoleErrors)
 
         try {
           // Log which scene is starting
@@ -197,6 +197,17 @@ export class SceneRunner {
           if (report.error) {
             console.log(`    Error: ${report.error}`)
           }
+
+          if (report.consoleErrors.length > 0) {
+            console.log(`    ⚠ ${report.consoleErrors.length} console error(s)`)
+            for (const ce of report.consoleErrors.slice(0, 5)) {
+              const prefix = ce.type === 'warning' ? 'warn' : 'error'
+              console.log(`      └─ [${ce.actor}] console.${prefix}: ${ce.message.slice(0, 200)}`)
+            }
+            if (report.consoleErrors.length > 5) {
+              console.log(`      └─ ... and ${report.consoleErrors.length - 5} more`)
+            }
+          }
         } finally {
           // Close session
           await session.close()
@@ -220,6 +231,7 @@ export class SceneRunner {
     )
     const failedAssertions = totalAssertions - passedAssertions
     const totalWarnings = sceneReports.reduce((sum, r) => sum + r.warnings.length, 0)
+    const totalConsoleErrors = sceneReports.reduce((sum, r) => sum + r.consoleErrors.length, 0)
 
     const report: RunReport = {
       timestamp: new Date().toISOString(),
@@ -235,6 +247,7 @@ export class SceneRunner {
           failed: failedAssertions,
         },
         warnings: totalWarnings,
+        consoleErrors: totalConsoleErrors,
       },
     }
 
@@ -284,6 +297,7 @@ export class SceneRunner {
           failed: 0,
           assertions: { total: 0, passed: 0, failed: 0 },
           warnings: 0,
+          consoleErrors: 0,
         },
       }
     }
@@ -300,7 +314,8 @@ export class SceneRunner {
       trigger,
       this.config.server as Record<string, unknown> | undefined,
       fuzzyFingers,
-      this.config.noPanel
+      this.config.noPanel,
+      this.config.consoleErrors
     )
 
     // Build a RunReport that includes the swarm results
@@ -314,6 +329,7 @@ export class SceneRunner {
         failed: swarmReport.summary.broken + swarmReport.summary.flaky + swarmReport.summary.seedDataEdgeCase,
         assertions: { total: 0, passed: 0, failed: 0 },
         warnings: 0,
+        consoleErrors: 0,
       },
       swarm: swarmReport,
     }
@@ -337,6 +353,7 @@ export class SceneRunner {
           failed: 0,
           assertions: { total: 0, passed: 0, failed: 0 },
           warnings: 0,
+          consoleErrors: 0,
         },
       }
     }
@@ -547,6 +564,22 @@ export function printSummary(report: RunReport): void {
 
   if (report.summary.assertions.failed > 0) {
     console.log(`\n  ⚠ ${report.summary.assertions.failed} assertion(s) failed`)
+  }
+
+  if (report.summary.consoleErrors > 0) {
+    console.log(`\n  🔴 ${report.summary.consoleErrors} browser console error(s)`)
+    for (const scene of report.scenes) {
+      if (scene.consoleErrors.length > 0) {
+        console.log(`    ${scene.name}: ${scene.consoleErrors.length} error(s)`)
+        for (const ce of scene.consoleErrors.slice(0, 3)) {
+          const prefix = ce.type === 'warning' ? 'warn' : 'error'
+          console.log(`      └─ [${ce.actor}] console.${prefix}: ${ce.message.slice(0, 150)}`)
+        }
+        if (scene.consoleErrors.length > 3) {
+          console.log(`      └─ ... and ${scene.consoleErrors.length - 3} more`)
+        }
+      }
+    }
   }
 
   if (report.summary.failed > 0) {

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -201,8 +201,8 @@ export class SceneRunner {
           if (report.consoleErrors.length > 0) {
             console.log(`    ⚠ ${report.consoleErrors.length} console error(s)`)
             for (const ce of report.consoleErrors.slice(0, 5)) {
-              const prefix = ce.type === 'warning' ? 'warn' : 'error'
-              console.log(`      └─ [${ce.actor}] console.${prefix}: ${ce.message.slice(0, 200)}`)
+              const label = ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
+              console.log(`      └─ [${ce.actor}] ${label}: ${ce.message.slice(0, 200)}`)
             }
             if (report.consoleErrors.length > 5) {
               console.log(`      └─ ... and ${report.consoleErrors.length - 5} more`)
@@ -572,8 +572,8 @@ export function printSummary(report: RunReport): void {
       if (scene.consoleErrors.length > 0) {
         console.log(`    ${scene.name}: ${scene.consoleErrors.length} error(s)`)
         for (const ce of scene.consoleErrors.slice(0, 3)) {
-          const prefix = ce.type === 'warning' ? 'warn' : 'error'
-          console.log(`      └─ [${ce.actor}] console.${prefix}: ${ce.message.slice(0, 150)}`)
+          const label = ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
+          console.log(`      └─ [${ce.actor}] ${label}: ${ce.message.slice(0, 150)}`)
         }
         if (scene.consoleErrors.length > 3) {
           console.log(`      └─ ... and ${scene.consoleErrors.length - 3} more`)

--- a/packages/scenes/src/scene.ts
+++ b/packages/scenes/src/scene.ts
@@ -134,6 +134,7 @@ export async function runScene(
     actors,
     assertions: session.assertions,
     warnings: session.warnings,
+    consoleErrors: session.consoleErrors,
     timeline: session.timeline,
     duration: Date.now() - start,
     error,

--- a/packages/scenes/src/swarm.ts
+++ b/packages/scenes/src/swarm.ts
@@ -149,7 +149,8 @@ export async function runSwarm(
   trigger: 'auto' | 'manual',
   server?: Record<string, unknown>,
   fuzzyFingers: boolean = false,
-  noPanel?: boolean
+  noPanel?: boolean,
+  consoleErrors?: boolean | 'error' | 'warn'
 ): Promise<SwarmReport> {
   const resolved = resolveSwarmConfig(config)
   const totalTeams = teamManager.totalCount
@@ -213,7 +214,8 @@ export async function runSwarm(
             warnAfter,
             baseUrl,
             fuzzyFingers,
-            noPanel
+            noPanel,
+            consoleErrors
           )
 
           try {

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -1,5 +1,5 @@
 import type { Browser, BrowserContext, Page } from 'playwright'
-import type { TeamConfig, ActorConfig, AssertionResult, TimelineEntry, ScriptWarning, ResolvedTeam, TeamMeta, PageFactory } from './types.js'
+import type { TeamConfig, ActorConfig, AssertionResult, TimelineEntry, ScriptWarning, ConsoleError, ResolvedTeam, TeamMeta, PageFactory } from './types.js'
 import type { DeviceProfile } from './devices.js'
 import type { StorageState } from './warmup.js'
 import { WarmupCache } from './warmup.js'
@@ -190,7 +190,8 @@ export class TeamManager {
     warnAfter: number,
     baseUrl?: string,
     fuzzyFingers: boolean = false,
-    noPanel?: boolean
+    noPanel?: boolean,
+    consoleErrors?: boolean | 'error' | 'warn'
   ): Promise<TeamSession> {
     if (!this.browser) {
       throw new Error('Browser not set. Call setBrowser() first.')
@@ -208,7 +209,8 @@ export class TeamManager {
       this.warmupCache,
       this.navigationModeRotation,
       fuzzyFingers,
-      noPanel
+      noPanel,
+      consoleErrors
     )
   }
 }
@@ -226,9 +228,13 @@ export class TeamSession {
   readonly timeline: TimelineEntry[] = []
   readonly assertions: AssertionResult[] = []
   readonly warnings: ScriptWarning[] = []
+  readonly consoleErrors: ConsoleError[] = []
 
   /** Team metadata (name, tags) */
   readonly meta: TeamMeta
+
+  /** Which console message types to capture */
+  private consoleErrorMode: false | 'error' | 'warn'
 
   constructor(
     private browser: Browser,
@@ -242,9 +248,33 @@ export class TeamSession {
     private warmupCache: WarmupCache = new WarmupCache(),
     private navigationModeRotation?: NavigationModeRotation | null,
     private fuzzyFingers: boolean = false,
-    private noPanel?: boolean
+    private noPanel?: boolean,
+    consoleErrors?: boolean | 'error' | 'warn'
   ) {
     this.meta = meta
+    // Default: capture errors
+    this.consoleErrorMode = consoleErrors === false ? false : consoleErrors === 'warn' ? 'warn' : 'error'
+  }
+
+  /**
+   * Wire console error listener on a page for a given actor role.
+   */
+  private wireConsoleListener(page: Page, role: string): void {
+    if (this.consoleErrorMode === false) return
+
+    const captureWarnings = this.consoleErrorMode === 'warn'
+    page.on('console', (msg) => {
+      const type = msg.type()
+      if (type === 'error' || (captureWarnings && type === 'warning')) {
+        this.consoleErrors.push({
+          message: msg.text(),
+          actor: role,
+          timestamp: Date.now(),
+          type: type === 'warning' ? 'warning' : 'error',
+          url: page.url(),
+        })
+      }
+    })
   }
 
   /**
@@ -376,6 +406,9 @@ export class TeamSession {
       this.assertions.push(enriched)
     })
 
+    // Wire console error listener
+    this.wireConsoleListener(page, role)
+
     this.contexts.set(role, context)
 
     // Log assignments
@@ -425,6 +458,9 @@ export class TeamSession {
         const enriched = { ...result, actor: role, ...(deviceName ? { device: deviceName } : {}) }
         this.assertions.push(enriched)
       })
+
+      // Wire console error listener
+      this.wireConsoleListener(page, role)
 
       this.contexts.set(role, context)
 
@@ -487,6 +523,9 @@ export class TeamSession {
       }
       this.assertions.push(enriched)
     })
+
+    // Wire console error listener
+    this.wireConsoleListener(page, role)
 
     // Create page factory for switchDevice support
     const pageFactory = this.createPageFactory(role)

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -257,7 +257,7 @@ export class TeamSession {
   }
 
   /**
-   * Wire console error listener on a page for a given actor role.
+   * Wire console error and uncaught exception listeners on a page.
    */
   private wireConsoleListener(page: Page, role: string): void {
     if (this.consoleErrorMode === false) return
@@ -271,9 +271,22 @@ export class TeamSession {
           actor: role,
           timestamp: Date.now(),
           type: type === 'warning' ? 'warning' : 'error',
+          source: 'console',
           url: page.url(),
         })
       }
+    })
+
+    // Capture uncaught exceptions and unhandled promise rejections
+    page.on('pageerror', (error: Error) => {
+      this.consoleErrors.push({
+        message: error.message,
+        actor: role,
+        timestamp: Date.now(),
+        type: 'error',
+        source: 'pageerror',
+        url: page.url(),
+      })
     })
   }
 

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -239,6 +239,15 @@ export interface ScenetestConfig extends BaseConfig {
    */
   noPanel?: boolean
 
+  /**
+   * Capture browser console errors and surface them in the CLI output.
+   *
+   * - `true` or `'error'`: capture `console.error` messages only (default: `true`)
+   * - `'warn'`: capture both `console.error` and `console.warn` messages
+   * - `false`: disable console error detection entirely
+   */
+  consoleErrors?: boolean | 'error' | 'warn'
+
   /** Hook: before all scenes run */
   beforeAll?: () => Promise<void>
 
@@ -284,6 +293,24 @@ export interface AssertionResult {
 }
 
 /**
+ * Browser console error captured during a scene.
+ * These surface uncaught exceptions, failed network requests,
+ * and other runtime errors logged by the application under test.
+ */
+export interface ConsoleError {
+  /** The console message text */
+  message: string
+  /** Which actor's browser produced this error */
+  actor: string
+  /** When the error was logged */
+  timestamp: number
+  /** Console message type (error, warning) */
+  type: 'error' | 'warning'
+  /** URL of the page when the error occurred */
+  url?: string
+}
+
+/**
  * Script-level warning (not an assertion failure).
  * These indicate unexpected paths in the test script itself,
  * not failures in the application under test.
@@ -326,6 +353,7 @@ export interface SceneReport {
   actors: Record<string, { key: string; username?: string; device?: string; navigationMode?: string }>
   assertions: AssertionResult[]
   warnings: ScriptWarning[]
+  consoleErrors: ConsoleError[]
   timeline: TimelineEntry[]
   duration: number
   error?: string
@@ -348,6 +376,7 @@ export interface RunReport {
       failed: number
     }
     warnings: number
+    consoleErrors: number
   }
   /** Present when this run was triggered by swarm mode */
   swarm?: SwarmReport

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -306,6 +306,12 @@ export interface ConsoleError {
   timestamp: number
   /** Console message type (error, warning) */
   type: 'error' | 'warning'
+  /**
+   * Where the error originated:
+   * - `'console'` — explicit `console.error()` / `console.warn()` call
+   * - `'pageerror'` — uncaught exception or unhandled promise rejection
+   */
+  source?: 'console' | 'pageerror'
   /** URL of the page when the error occurred */
   url?: string
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to capture browser console errors and warnings during scene execution and surface them in CLI output and reports. This helps identify runtime errors, failed network requests, and other issues logged by the application under test.

## Key Changes

- **New `ConsoleError` type** in `types.ts` to represent captured console messages with metadata (message text, actor, timestamp, type, URL)

- **Console error configuration** via new `consoleErrors` option in `ScenetestConfig`:
  - `true` or `'error'`: capture `console.error` messages only (default)
  - `'warn'`: capture both `console.error` and `console.warn` messages
  - `false`: disable console error detection

- **Console listener wiring** in `TeamSession`:
  - Added `wireConsoleListener()` method that attaches Playwright's `console` event listener to each page
  - Listener captures errors/warnings based on configured mode and stores them in `consoleErrors` array
  - Listener is attached in three places where pages are created (standard actor setup, device switching, and page factory)

- **Report integration**:
  - `SceneReport` now includes `consoleErrors` array
  - `RunReport` summary tracks total `consoleErrors` count
  - Console errors are passed through swarm mode execution

- **CLI output**:
  - Per-scene console error summary with up to 5 errors displayed (truncated to 200 chars)
  - Overall summary showing total console errors with per-scene breakdown (up to 3 errors per scene)
  - Uses 🔴 emoji to highlight console errors in summary

- **Test updates**: Mock page objects updated to support `on()`, `url()`, and `addInitScript()` methods

## Implementation Details

- Console listener mode is determined in `TeamSession` constructor and stored as `consoleErrorMode` (false | 'error' | 'warn')
- Each captured error includes the actor role, timestamp, message type, and page URL for debugging context
- Console errors are independent of assertion failures and warnings—they surface separately in reports
- The feature is opt-in via configuration and defaults to capturing errors only

https://claude.ai/code/session_016hEc3h5EFK2ms5SFG9iYhy