### PR TITLE
Add setup directive and multi-line cleanup support (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,138 @@
+# Changelog
+
+All notable changes to Scenetest are documented here.
+
+---
+
+## [0.3.1] — 2026-04-02
+
+Patch release addressing field feedback from the [sunlo.app](https://sunlo.app) team.
+These were all real blockers or sharp edges they hit writing specs against a
+Supabase + TanStack Router app.
+
+### New features
+
+#### `setup:` directive for per-scene state seeding
+
+Scenes can now declare a `setup:` expression that runs **after** pre-cleanup
+but **before** scene steps. Use it when a scene requires a specific database
+state that differs from the seed data baseline:
+
+```markdown
+## review mode shows 2-buttons
+
+cleanup: supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')
+setup: supabase.from('user_deck').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')
+
+learner:
+- openTo /review
+- see 2-buttons-mode
+```
+
+Execution order: `cleanup (before)` → `setup` → scene steps → `cleanup (after)`.
+
+#### Multiple `cleanup:` (and `setup:`) lines per scene
+
+Multiple `cleanup:` directives are now collected as an array and all executed,
+in order. Previously, only the last line was kept.
+
+```markdown
+cleanup: supabase.from('request_comment').delete().eq('uid', '[friend.key]')
+cleanup: supabase.from('notification').delete().eq('uid', '[learner.key]')
+```
+
+#### `[team.field]` interpolation in `cleanup:` / `setup:`
+
+`[team.field]` tokens now resolve correctly in cleanup and setup expressions
+using the team's `tags` metadata. Previously only `[role.field]` (actor
+credential fields) worked.
+
+```markdown
+cleanup: supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')
+```
+
+Requires the team to define `tags: { lang: 'kan' }` (or similar) in `defineTeam()`.
+
+#### `[testStart]` interpolation in `cleanup:` / `setup:`
+
+`[testStart]` is now a built-in interpolation token that resolves to the ISO
+8601 timestamp captured just before the scene's cleanup/setup runs. Use it to
+scope cleanup to rows created during the test:
+
+```markdown
+cleanup: supabase.from('request_comment').delete().eq('uid', '[friend.key]').gte('created_at', '[testStart]')
+```
+
+#### `pressKey` DSL action
+
+New action: `pressKey <key>` sends a raw keyboard event via
+`page.keyboard.press()`. Works in both `.spec.md` and TypeScript scenes.
+
+```markdown
+learner:
+- openTo /review
+- see intro-dialog
+- pressKey Escape
+- see review-page
+```
+
+```ts
+learner.pressKey('Escape')
+```
+
+Accepts any [Playwright key name](https://playwright.dev/docs/api/class-keyboard)
+(`Escape`, `Enter`, `Tab`, `ArrowDown`, etc.).
+
+### Bug fixes
+
+#### `if` conditional monitors now fire for already-visible elements
+
+Previously, `if <selector>` only detected elements that appeared *during* a
+concurrent polling window while an action was executing. If the element was
+already visible when the action started (e.g. a localStorage-gated intro
+dialog), the monitor could miss it.
+
+`executeWithMonitors` now performs a synchronous pre-check of all pending
+conditional monitors at the start of every action, before the polling loop
+begins. If the selector is already visible, the monitor fires immediately —
+the main action does not start until the sub-actions complete.
+
+```markdown
+if dismiss-review-intro
+  - click
+- see review-setup-page
+```
+
+This now correctly dismisses the overlay even if it is already present when
+the `if` line is registered.
+
+### Breaking changes
+
+#### `RegisteredScene.cleanup` type changed from `string` to `string[]`
+
+This affects TypeScript code that directly reads `registered.cleanup`. The
+property is now `string[] | undefined` (populated only for markdown scenes).
+
+If you were checking `if (scene.cleanup)` — continue to do so; an empty array
+is falsy-equivalent for iteration. If you were reading it as a string, update
+to iterate the array.
+
+---
+
+## [0.3.0] — 2026-03-22
+
+Initial public release.
+
+- CLI runner with Playwright
+- `scene()` concurrent-actor model and `test()` sequential model
+- Inline assertion system (`should()`, `failed()`)
+- `.spec.md` markdown scene format
+- `cleanup:` pre/post cleanup directives
+- `[role.field]` interpolation
+- Keyboard actor rotation (accessibility testing)
+- Fuzzy-finger touch simulation
+- Device rotation
+- Swarm mode
+- Vite plugin (dev panel injection, production stripping)
+- ESLint plugin (`prefer-aria-label` rule)
+- VS Code extension (syntax highlighting for `.spec.md`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scenetest-monorepo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A local-first testing framework for the Vite ecosystem",
   "license": "MIT",
   "private": true,

--- a/packages/checks-panel/package.json
+++ b/packages/checks-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-panel",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Observer panel for scenetest - displays assertions in real-time",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-react/package.json
+++ b/packages/checks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-react",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "React bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-solid/package.json
+++ b/packages/checks-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-solid",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Solid bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-svelte/package.json
+++ b/packages/checks-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-svelte",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Svelte bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-vue/package.json
+++ b/packages/checks-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-vue",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Vue bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/eslint-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ESLint plugin for scenetest - accessibility and testing best practices",
   "type": "module",
   "license": "MIT",

--- a/packages/playwright-scenetest/package.json
+++ b/packages/playwright-scenetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/playwright",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Playwright fixtures for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes-panel/package.json
+++ b/packages/scenes-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes-panel",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scene recorder for scenetest - records user interactions as DSL",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/src/__tests__/dsl.test.ts
+++ b/packages/scenes/src/__tests__/dsl.test.ts
@@ -83,6 +83,7 @@ function createSpyTarget(): DslTarget & { calls: string[] } {
     up(s?: string) { calls.push(`up:${s ?? '(root)'}`); return this },
     prev() { calls.push('prev'); return this },
     scrollToBottom() { calls.push('scrollToBottom'); return this },
+    pressKey(k: string) { calls.push(`pressKey:${k}`); return this },
   }
 }
 

--- a/packages/scenes/src/__tests__/dsl.test.ts
+++ b/packages/scenes/src/__tests__/dsl.test.ts
@@ -166,6 +166,12 @@ describe('parseAction', () => {
     expect(parseAction('waitFor data-ready')).toEqual({ action: 'waitFor', value: 'data-ready' })
   })
 
+  it('parses pressKey as value-only action', () => {
+    expect(parseAction('pressKey Escape')).toEqual({ action: 'pressKey', value: 'Escape' })
+    expect(parseAction('pressKey Enter')).toEqual({ action: 'pressKey', value: 'Enter' })
+    expect(parseAction('pressKey Tab')).toEqual({ action: 'pressKey', value: 'Tab' })
+  })
+
   it('throws on empty input', () => {
     expect(() => parseAction('')).toThrow('Empty action line')
     expect(() => parseAction('   ')).toThrow('Empty action line')
@@ -260,6 +266,18 @@ describe('applyDslAction', () => {
     ;(target as any).waitFor = (m: string) => { target.calls.push(`waitFor:${m}`) }
     applyDslAction(target, { action: 'waitFor', value: 'setup-done' })
     expect(target.calls).toEqual(['waitFor:setup-done'])
+  })
+
+  it('dispatches pressKey', () => {
+    const target = createSpyTarget()
+    applyDslAction(target, { action: 'pressKey', value: 'Escape' })
+    expect(target.calls).toEqual(['pressKey:Escape'])
+  })
+
+  it('throws when pressKey is missing key name', () => {
+    const target = createSpyTarget()
+    expect(() => applyDslAction(target, { action: 'pressKey' }))
+      .toThrow('pressKey requires a key name')
   })
 
   it('throws on unknown action', () => {

--- a/packages/scenes/src/__tests__/markdown-scene.test.ts
+++ b/packages/scenes/src/__tests__/markdown-scene.test.ts
@@ -552,9 +552,9 @@ learner:
 `
     const scenes = parseMarkdownScenes(content, '/test/cleanup.spec.md')
     expect(scenes).toHaveLength(1)
-    expect(scenes[0].cleanup).toBe(
+    expect(scenes[0].cleanup).toEqual([
       "supabase.from('user_deck').delete().eq('uid', '[learner.key]').eq('lang', 'spa')"
-    )
+    ])
     expect(scenes[0].blocks).toHaveLength(1)
     expect(scenes[0].blocks[0].role).toBe('learner')
   })
@@ -569,7 +569,7 @@ cleanup: something
 - see dashboard
 `
     const scenes = parseMarkdownScenes(content, '/test/cleanup-late.spec.md')
-    expect(scenes[0].cleanup).toBeUndefined()
+    expect(scenes[0].cleanup).toEqual([])
     // cleanup: is treated as a macro since it's inside an actor block
   })
 
@@ -584,7 +584,7 @@ learner:
 `
     const scenes = parseMarkdownScenes(content, '/test/cleanup-h1.spec.md')
     expect(scenes).toHaveLength(1)
-    expect(scenes[0].cleanup).toBe('db.clear()')
+    expect(scenes[0].cleanup).toEqual(['db.clear()'])
   })
 
   it('supports cleanup: per scene in multi-scene file', () => {
@@ -607,8 +607,91 @@ learner:
 `
     const scenes = parseMarkdownScenes(content, '/test/cleanup-multi.spec.md')
     expect(scenes).toHaveLength(2)
-    expect(scenes[0].cleanup).toBe("supabase.from('decks').delete().eq('uid', '[learner.key]')")
-    expect(scenes[1].cleanup).toBeUndefined()
+    expect(scenes[0].cleanup).toEqual(["supabase.from('decks').delete().eq('uid', '[learner.key]')"])
+    expect(scenes[1].cleanup).toEqual([])
+  })
+
+  it('supports multiple cleanup: lines per scene (all collected as array)', () => {
+    const content = `
+## comment with notification
+
+cleanup: supabase.from('request_comment').delete().eq('uid', '[friend.key]')
+cleanup: supabase.from('notification').delete().eq('uid', '[learner.key]')
+
+friend:
+- openTo /requests
+learner:
+- openTo /notifications
+`
+    const scenes = parseMarkdownScenes(content, '/test/multi-cleanup.spec.md')
+    expect(scenes).toHaveLength(1)
+    expect(scenes[0].cleanup).toEqual([
+      "supabase.from('request_comment').delete().eq('uid', '[friend.key]')",
+      "supabase.from('notification').delete().eq('uid', '[learner.key]')",
+    ])
+  })
+
+  it('parses setup: directive before actor cues', () => {
+    const content = `
+## review mode shows 2-buttons
+
+cleanup: supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]')
+setup: supabase.from('user_deck').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]')
+
+learner:
+- openTo /review
+- see review-setup-page
+`
+    const scenes = parseMarkdownScenes(content, '/test/setup.spec.md')
+    expect(scenes).toHaveLength(1)
+    expect(scenes[0].cleanup).toEqual([
+      "supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]')",
+    ])
+    expect(scenes[0].setup).toEqual([
+      "supabase.from('user_deck').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]')",
+    ])
+    expect(scenes[0].blocks[0].role).toBe('learner')
+  })
+
+  it('supports multiple setup: lines per scene', () => {
+    const content = `
+## multi-table setup
+
+setup: supabase.from('table_a').insert({ uid: '[user.key]' })
+setup: supabase.from('table_b').insert({ uid: '[user.key]' })
+
+user:
+- openTo /
+`
+    const scenes = parseMarkdownScenes(content, '/test/multi-setup.spec.md')
+    expect(scenes[0].setup).toEqual([
+      "supabase.from('table_a').insert({ uid: '[user.key]' })",
+      "supabase.from('table_b').insert({ uid: '[user.key]' })",
+    ])
+  })
+
+  it('setup: defaults to empty array when not specified', () => {
+    const content = `
+# plain scene
+user:
+- openTo /
+`
+    const scenes = parseMarkdownScenes(content, '/test/no-setup.spec.md')
+    expect(scenes[0].setup).toEqual([])
+  })
+
+  it('ignores setup: after actor cues have started', () => {
+    const content = `
+# test
+
+user:
+- openTo /
+setup: something
+- see dashboard
+`
+    const scenes = parseMarkdownScenes(content, '/test/setup-late.spec.md')
+    // setup: inside an actor block is treated as a macro invocation, not a directive
+    expect(scenes[0].setup).toEqual([])
   })
 })
 

--- a/packages/scenes/src/__tests__/reactive.test.ts
+++ b/packages/scenes/src/__tests__/reactive.test.ts
@@ -375,6 +375,71 @@ describe('ConcurrentActorHandleImpl', () => {
       // Main queue unaffected
       expect(actor.pending).toBe(0)
     })
+
+    it('fires sub-actions immediately when element is already visible at action start', async () => {
+      // This tests the pre-check path: the element is visible before the action runs.
+      // The monitor should fire at the beginning of executeWithMonitors, not via concurrent polling.
+      const visibleLocator = mockLocator(true) // always visible
+      const page = mockPage()
+      page.locator = vi.fn().mockReturnValue(visibleLocator)
+
+      const { actor } = createTestActor('user', { page: page as any })
+      const order: string[] = []
+
+      actor.if('dismiss-intro', a => {
+        a.do(async () => { order.push('dismissed') })
+      })
+
+      actor.do(async () => { order.push('main-action') })
+
+      await actor.drain()
+
+      // 'dismissed' should appear before 'main-action' because the pre-check
+      // fires the monitor synchronously at the start of the action
+      expect(order).toEqual(['dismissed', 'main-action'])
+    })
+
+    it('monitor fires only once even if element remains visible', async () => {
+      const visibleLocator = mockLocator(true)
+      const page = mockPage()
+      page.locator = vi.fn().mockReturnValue(visibleLocator)
+
+      const { actor } = createTestActor('user', { page: page as any })
+      const fired: number[] = []
+
+      actor.if('persistent-banner', a => {
+        a.do(async () => { fired.push(1) })
+      })
+
+      // Multiple actions — monitor should only fire once (one-shot)
+      actor.do(async () => {})
+      actor.do(async () => {})
+      actor.do(async () => {})
+
+      await actor.drain()
+
+      expect(fired).toHaveLength(1)
+    })
+  })
+
+  describe('pressKey()', () => {
+    it('queues a pressKey action that calls page.keyboard.press', async () => {
+      const { actor, page } = createTestActor()
+      const keyboard = { press: vi.fn().mockResolvedValue(undefined) }
+      ;(page as any).keyboard = keyboard
+
+      actor.pressKey('Escape')
+      await actor.drain()
+
+      expect(keyboard.press).toHaveBeenCalledWith('Escape')
+    })
+
+    it('is chainable and returns this', () => {
+      const { actor } = createTestActor()
+      const result = actor.pressKey('Enter')
+      expect(result).toBe(actor)
+      expect(actor.pending).toBe(1)
+    })
   })
 })
 

--- a/packages/scenes/src/__tests__/runner.test.ts
+++ b/packages/scenes/src/__tests__/runner.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runCleanup, runSetup } from '../runner.js'
+import type { RegisteredScene } from '../types.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeScene(overrides: Partial<RegisteredScene> = {}): RegisteredScene {
+  return {
+    name: 'test scene',
+    file: '/test/scene.spec.md',
+    fn: async () => {},
+    cleanup: [],
+    setup: [],
+    ...overrides,
+  }
+}
+
+const team = {
+  learner: { key: 'learner-123', username: 'alice', email: 'alice@test.com' },
+  friend:  { key: 'friend-456', username: 'bob',   email: 'bob@test.com' },
+}
+
+const teamMeta = {
+  name: 'Kannada Team',
+  tags: { lang: 'kan', region: 'asia' },
+}
+
+const testStart = '2026-04-02T10:00:00.000Z'
+
+// ---------------------------------------------------------------------------
+// runCleanup
+// ---------------------------------------------------------------------------
+
+describe('runCleanup', () => {
+  it('does nothing when cleanup is empty', async () => {
+    const scene = makeScene()
+    const server = { supabase: { ran: false } }
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(server.supabase.ran).toBe(false)
+  })
+
+  it('evaluates a single cleanup expression with server in scope', async () => {
+    const calls: string[] = []
+    const server = {
+      db: {
+        delete: (table: string) => { calls.push(`delete:${table}`); return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({ cleanup: ["db.delete('user_deck')"] })
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(calls).toEqual(["delete:user_deck"])
+  })
+
+  it('runs all expressions when multiple cleanup: lines specified', async () => {
+    const calls: string[] = []
+    const server = {
+      db: {
+        delete: (table: string) => { calls.push(`delete:${table}`); return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({
+      cleanup: ["db.delete('comments')", "db.delete('notifications')"],
+    })
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(calls).toEqual(['delete:comments', 'delete:notifications'])
+  })
+
+  it('interpolates [role.field] tokens', async () => {
+    let capturedKey = ''
+    const server = {
+      db: {
+        deleteByKey: (key: string) => { capturedKey = key; return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({ cleanup: ["db.deleteByKey('[learner.key]')"] })
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(capturedKey).toBe('learner-123')
+  })
+
+  it('interpolates [team.field] tokens from team metadata tags', async () => {
+    let capturedLang = ''
+    const server = {
+      db: {
+        deleteByLang: (lang: string) => { capturedLang = lang; return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({ cleanup: ["db.deleteByLang('[team.lang]')"] })
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(capturedLang).toBe('kan')
+  })
+
+  it('interpolates [testStart] with the ISO timestamp', async () => {
+    let capturedTs = ''
+    const server = {
+      db: {
+        deleteAfter: (ts: string) => { capturedTs = ts; return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({ cleanup: ["db.deleteAfter('[testStart]')"] })
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(capturedTs).toBe(testStart)
+  })
+
+  it('logs a warning and skips when no server config', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const scene = makeScene({ cleanup: ["db.delete('x')"] })
+    await runCleanup(scene, team, teamMeta, undefined, testStart)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no server config'))
+    warnSpy.mockRestore()
+  })
+
+  it('logs a warning but does not throw when expression errors', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const server = {
+      db: {
+        badCall: () => { throw new Error('db connection refused') },
+      },
+    }
+    const scene = makeScene({ cleanup: ['db.badCall()'] })
+    await expect(runCleanup(scene, team, teamMeta, server, testStart)).resolves.toBeUndefined()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('db connection refused'))
+    warnSpy.mockRestore()
+  })
+
+  it('throws interpolation error and logs warning for unknown role', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const server = { db: {} }
+    const scene = makeScene({ cleanup: ["db.fn('[ghost.key]')"] })
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ghost'))
+    warnSpy.mockRestore()
+  })
+
+  it('throws interpolation error and logs warning for unknown team tag', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const server = { db: {} }
+    const scene = makeScene({ cleanup: ["db.fn('[team.notexist]')"] })
+    await runCleanup(scene, team, teamMeta, server, testStart)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('notexist'))
+    warnSpy.mockRestore()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runSetup
+// ---------------------------------------------------------------------------
+
+describe('runSetup', () => {
+  it('does nothing when setup is empty', async () => {
+    const calls: string[] = []
+    const server = { db: { update: (t: string) => { calls.push(t); return Promise.resolve() } } }
+    const scene = makeScene()
+    await runSetup(scene, team, teamMeta, server, testStart)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('evaluates each setup expression in order', async () => {
+    const calls: string[] = []
+    const server = {
+      db: {
+        update: (t: string) => { calls.push(`update:${t}`); return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({
+      setup: ["db.update('step1')", "db.update('step2')"],
+    })
+    await runSetup(scene, team, teamMeta, server, testStart)
+    expect(calls).toEqual(['update:step1', 'update:step2'])
+  })
+
+  it('interpolates [role.field] and [team.field] in setup expressions', async () => {
+    const captured: string[] = []
+    const server = {
+      db: {
+        seed: (key: string, lang: string) => {
+          captured.push(`${key}:${lang}`)
+          return Promise.resolve()
+        },
+      },
+    }
+    const scene = makeScene({ setup: ["db.seed('[learner.key]', '[team.lang]')"] })
+    await runSetup(scene, team, teamMeta, server, testStart)
+    expect(captured).toEqual(['learner-123:kan'])
+  })
+
+  it('logs a warning but does not throw on error, continues remaining expressions', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const calls: string[] = []
+    const server = {
+      db: {
+        bad: () => { throw new Error('setup failed') },
+        ok: () => { calls.push('ok'); return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({ setup: ['db.bad()', 'db.ok()'] })
+    await runSetup(scene, team, teamMeta, server, testStart)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('setup failed'))
+    expect(calls).toEqual(['ok'])
+    warnSpy.mockRestore()
+  })
+})

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -385,6 +385,12 @@ class ActionChainImpl implements ActionChain {
     })
   }
 
+  pressKey(key: string): ActionChain {
+    return this.addAction('pressKey', key, async () => {
+      await this.page.keyboard.press(key)
+    })
+  }
+
   do(fn: (page: Page) => Promise<void>): ActionChain {
     return this.addAction('do', 'custom', async () => {
       await fn(this.page)
@@ -788,6 +794,10 @@ export class SequentialActorHandleImpl implements SequentialActorHandle {
 
   waitFor(message: string): ActionChain {
     return this.createChain().waitFor(message)
+  }
+
+  pressKey(key: string): ActionChain {
+    return this.createChain().pressKey(key)
   }
 
   do(fn: (page: Page) => Promise<void>): ActionChain {

--- a/packages/scenes/src/dsl.ts
+++ b/packages/scenes/src/dsl.ts
@@ -122,7 +122,7 @@ export function parseAction(line: string): ParsedAction {
   const selectorOnlyActions = ['see', 'seeInView', 'notSee', 'click', 'check', 'seeToast', 'up']
 
   // Actions that take a value only (no selector)
-  const valueOnlyActions = ['openTo', 'seeText', 'wait', 'emit', 'waitFor', 'switchDevice']
+  const valueOnlyActions = ['openTo', 'seeText', 'wait', 'emit', 'waitFor', 'switchDevice', 'pressKey']
 
   // Actions that take selector + value (everything after first selector word is value)
   const selectorValueActions = ['typeInto', 'select', 'warnIf']
@@ -281,6 +281,11 @@ export function applyDslAction(target: DslTarget, parsed: ParsedAction): void {
     case 'waitFor':
       if (!value) throw new Error('waitFor requires a message')
       target.waitFor(value)
+      break
+
+    case 'pressKey':
+      if (!value) throw new Error('pressKey requires a key name (e.g. Escape, Enter, Tab)')
+      target.pressKey(value)
       break
 
     default:

--- a/packages/scenes/src/markdown-scene.ts
+++ b/packages/scenes/src/markdown-scene.ts
@@ -69,8 +69,10 @@ import { sceneRegistry, setCurrentFile } from './scene.js'
 export interface MarkdownScene {
   name: string
   group?: string
-  /** Pre-cleanup expression from `cleanup:` directive */
-  cleanup?: string
+  /** Pre/post-cleanup expressions from `cleanup:` directives (one per line) */
+  cleanup: string[]
+  /** Setup expressions from `setup:` directives — run after pre-cleanup, before scene */
+  setup: string[]
   blocks: ActorBlock[]
 }
 
@@ -136,7 +138,7 @@ export function parseMarkdownScenes(
       // # = group, ## = scene
       if (/^## /.test(trimmed)) {
         const name = trimmed.slice(3).trim()
-        currentScene = { name, group: currentGroup, blocks: [] }
+        currentScene = { name, group: currentGroup, cleanup: [], setup: [], blocks: [] }
         scenes.push(currentScene)
         currentBlock = null
         continue
@@ -149,19 +151,26 @@ export function parseMarkdownScenes(
       // No ## headings — # = scene
       if (/^# /.test(trimmed)) {
         const name = trimmed.slice(2).trim()
-        currentScene = { name, group: undefined, blocks: [] }
+        currentScene = { name, group: undefined, cleanup: [], setup: [], blocks: [] }
         scenes.push(currentScene)
         currentBlock = null
         continue
       }
     }
 
-    // ── Cleanup directive ─────────────────────────────────────────────
-    // `cleanup: <expression>` — one per scene, before actor cues
+    // ── Cleanup / setup directives ────────────────────────────────────
+    // `cleanup: <expression>` — multiple allowed, run before AND after scene
+    // `setup: <expression>`   — multiple allowed, run after pre-cleanup, before scene
 
     const cleanupMatch = trimmed.match(/^cleanup:\s+(.+)$/)
     if (cleanupMatch && currentScene && !currentBlock) {
-      currentScene.cleanup = cleanupMatch[1]
+      currentScene.cleanup.push(cleanupMatch[1])
+      continue
+    }
+
+    const setupMatch = trimmed.match(/^setup:\s+(.+)$/)
+    if (setupMatch && currentScene && !currentBlock) {
+      currentScene.setup.push(setupMatch[1])
       continue
     }
 
@@ -173,6 +182,8 @@ export function parseMarkdownScenes(
       currentScene = {
         name: path.basename(filePath, '.spec.md'),
         group: undefined,
+        cleanup: [],
+        setup: [],
         blocks: [],
       }
       scenes.push(currentScene)
@@ -286,7 +297,7 @@ function stripListPrefix(line: string): string {
 const KNOWN_ACTIONS = [
   'openTo', 'see', 'seeInView', 'notSee', 'seeText', 'seeToast', 'click',
   'typeInto', 'check', 'select', 'wait', 'emit', 'waitFor',
-  'warnIf', 'up', 'prev', 'scrollToBottom', 'if',
+  'warnIf', 'up', 'prev', 'scrollToBottom', 'if', 'pressKey',
 ]
 
 /** Check if a line looks like a DSL action or macro invocation */
@@ -565,9 +576,11 @@ export function registerMarkdownScenes(
       }
     })
 
-    // Propagate cleanup expression to the registered scene
-    if (mdScene.cleanup && sceneRegistry.length > 0) {
-      sceneRegistry[sceneRegistry.length - 1].cleanup = mdScene.cleanup
+    // Propagate cleanup/setup expressions to the registered scene
+    if (sceneRegistry.length > 0) {
+      const registered = sceneRegistry[sceneRegistry.length - 1]
+      if (mdScene.cleanup.length > 0) registered.cleanup = mdScene.cleanup
+      if (mdScene.setup.length > 0) registered.setup = mdScene.setup
     }
   }
 }

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -647,6 +647,12 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     })
   }
 
+  pressKey(key: string): this {
+    return this.push('pressKey', key, async () => {
+      await this.page.keyboard.press(key)
+    })
+  }
+
   // -----------------------------------------------------------------------
   // Escape hatch
   // -----------------------------------------------------------------------
@@ -904,6 +910,25 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     if (!hasWarnings && !hasMonitors) {
       await action.execute()
       return
+    }
+
+    // Pre-check: fire any conditional monitors whose selector is already visible
+    // before the action starts. This handles elements that were present when
+    // `if()` was registered, not just elements that appear during an action.
+    for (const monitor of this.conditionalMonitors) {
+      if (monitor.triggered) continue
+      try {
+        const locator = resolveSelector(this.page, monitor.selector)
+        const isVisible = await locator.isVisible()
+        if (isVisible) {
+          monitor.triggered = true
+          for (const subAction of monitor.actions) {
+            await subAction.execute()
+          }
+        }
+      } catch {
+        // Ignore errors from isVisible check
+      }
     }
 
     let actionComplete = false

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -1,7 +1,7 @@
 import { chromium, firefox, webkit, type Browser } from 'playwright'
 import { glob } from 'glob'
 import path from 'path'
-import type { ScenetestConfig, ResolvedTeam, TeamConfig, RunReport, SceneReport, RegisteredScene } from './types.js'
+import type { ScenetestConfig, ResolvedTeam, TeamConfig, TeamMeta, RunReport, SceneReport, RegisteredScene } from './types.js'
 import { TeamManager } from './team-manager.js'
 import { DeviceRotation } from './devices.js'
 import { NavigationModeRotation } from './keyboard.js'
@@ -158,12 +158,15 @@ export class SceneRunner {
           const relativeFile = path.relative(path.join(process.cwd(), 'scenetest', 'scenes'), registered.file)
           console.log(`▶ ${registered.name} (${relativeFile})`)
 
+          const resolvedTeam = this.teamManager.getTeam(teamIndex)
+          const server = this.config.server as Record<string, unknown> | undefined
+          const testStart = new Date().toISOString()
+
           // Run pre-cleanup if configured
-          await runCleanup(
-            registered,
-            this.teamManager.getTeam(teamIndex).actors,
-            this.config.server as Record<string, unknown> | undefined
-          )
+          await runCleanup(registered, resolvedTeam.actors, resolvedTeam.meta, server, testStart)
+
+          // Run setup if configured (after pre-cleanup, before scene)
+          await runSetup(registered, resolvedTeam.actors, resolvedTeam.meta, server, testStart)
 
           // Run the scene
           const report = await runScene(registered, session, timeout)
@@ -363,26 +366,51 @@ export class SceneRunner {
 // ---------------------------------------------------------------------------
 
 /**
- * Interpolate `[role.field]` tokens in a cleanup expression with team data.
+ * Interpolate `[role.field]`, `[team.field]`, and `[testStart]` tokens in a
+ * cleanup/setup expression.
  *
- * Replaces tokens like `[learner.key]` with the corresponding value from the
- * team config, yielding a string literal in the expression.
+ * Supported tokens:
+ * - `[role.field]`  — actor field from the team config (e.g. `[learner.key]`)
+ * - `[team.field]`  — team metadata tag (e.g. `[team.lang]`)
+ * - `[testStart]`   — ISO 8601 timestamp of when the scene started
  */
-function interpolateCleanup(expression: string, team: TeamConfig): string {
+function interpolateExpression(
+  expression: string,
+  team: TeamConfig,
+  teamMeta: TeamMeta,
+  testStart: string
+): string {
   return expression.replace(
-    /\[([\w][\w-]*)\.([\w]+)\]/g,
-    (_match, role: string, field: string) => {
-      const actor = team[role]
+    /\[([\w][\w-]*)\.([\w]+)\]|\[testStart\]/g,
+    (match, role?: string, field?: string) => {
+      // [testStart] — ISO timestamp of scene start
+      if (match === '[testStart]') return testStart
+
+      // [team.field] — team metadata tags
+      if (role === 'team') {
+        const tags = teamMeta.tags ?? {}
+        const value = tags[field!] ?? (field === 'name' ? teamMeta.name : undefined)
+        if (value === undefined) {
+          const available = Object.keys(tags).join(', ')
+          throw new Error(
+            `cleanup/setup: [team.${field}] — team has no tag "${field}" (available: ${available || 'none'})`
+          )
+        }
+        return String(value)
+      }
+
+      // [role.field] — actor field
+      const actor = team[role!]
       if (!actor) {
         const available = Object.keys(team).join(', ')
         throw new Error(
-          `cleanup: unknown role "${role}" in [${role}.${field}] — available: ${available}`
+          `cleanup/setup: unknown role "${role}" in [${role}.${field}] — available: ${available}`
         )
       }
-      const value = actor[field]
+      const value = actor[field!]
       if (value === undefined) {
         throw new Error(
-          `cleanup: role "${role}" has no field "${field}"`
+          `cleanup/setup: role "${role}" has no field "${field}"`
         )
       }
       return String(value)
@@ -404,36 +432,73 @@ function evaluateCleanup(expression: string, server: Record<string, unknown>): u
 }
 
 /**
- * Run pre-cleanup for a scene if it has a cleanup expression.
- * Interpolates team data, evaluates with server context, and logs errors.
- * Never throws — cleanup failures are logged but don't prevent the scene.
+ * Run pre-cleanup for a scene if it has cleanup expressions.
+ * Each expression is interpolated, evaluated with server context, and awaited.
+ * Never throws — failures are logged but don't prevent the scene.
  */
 export async function runCleanup(
   registered: RegisteredScene,
   team: TeamConfig,
-  server: Record<string, unknown> | undefined
+  teamMeta: TeamMeta,
+  server: Record<string, unknown> | undefined,
+  testStart: string
 ): Promise<void> {
-  if (!registered.cleanup) return
+  if (!registered.cleanup || registered.cleanup.length === 0) return
 
-  try {
-    const interpolated = interpolateCleanup(registered.cleanup, team)
-
-    if (!server || Object.keys(server).length === 0) {
-      console.warn(`  ⚠ cleanup: expression references server resources but no server config provided`)
-      return
-    }
-
-    const result = evaluateCleanup(interpolated, server)
-    // Await if promise
-    if (result && typeof (result as Promise<unknown>).then === 'function') {
-      await result
-    }
-    console.log(`  ♻ cleanup ran`)
-  } catch (err) {
-    console.warn(
-      `  ⚠ cleanup failed: ${err instanceof Error ? err.message : String(err)}`
-    )
+  if (!server || Object.keys(server).length === 0) {
+    console.warn(`  ⚠ cleanup: expressions present but no server config provided`)
+    return
   }
+
+  for (const expr of registered.cleanup) {
+    try {
+      const interpolated = interpolateExpression(expr, team, teamMeta, testStart)
+      const result = evaluateCleanup(interpolated, server)
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        await result
+      }
+    } catch (err) {
+      console.warn(
+        `  ⚠ cleanup failed: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+  }
+  console.log(`  ♻ cleanup ran`)
+}
+
+/**
+ * Run setup expressions for a scene (after pre-cleanup, before scene steps).
+ * Each expression is interpolated, evaluated with server context, and awaited.
+ * Never throws — failures are logged but don't prevent the scene.
+ */
+export async function runSetup(
+  registered: RegisteredScene,
+  team: TeamConfig,
+  teamMeta: TeamMeta,
+  server: Record<string, unknown> | undefined,
+  testStart: string
+): Promise<void> {
+  if (!registered.setup || registered.setup.length === 0) return
+
+  if (!server || Object.keys(server).length === 0) {
+    console.warn(`  ⚠ setup: expressions present but no server config provided`)
+    return
+  }
+
+  for (const expr of registered.setup) {
+    try {
+      const interpolated = interpolateExpression(expr, team, teamMeta, testStart)
+      const result = evaluateCleanup(interpolated, server)
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        await result
+      }
+    } catch (err) {
+      console.warn(
+        `  ⚠ setup failed: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+  }
+  console.log(`  ♻ setup ran`)
 }
 
 /**

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -423,6 +423,26 @@ function interpolateExpression(
  *
  * The expression is evaluated via `new Function()` with server properties
  * destructured as local variables. The result is awaited if it's a promise.
+ *
+ * ### Security note
+ *
+ * This is intentional eval. The threat model is: cleanup/setup expressions
+ * come from `.spec.md` files that the developer wrote and committed to version
+ * control, alongside `config.server` they defined in `scenetest.config.ts`.
+ * Both inputs are trusted developer-authored code, not user-supplied strings.
+ * This is no more dangerous than running `node -e "<expression>"` directly.
+ *
+ * ### Known limitations
+ *
+ * - TypeScript cannot type-check the expression — typos surface at runtime.
+ * - Stack traces don't point to the spec file line.
+ * - There is no sandbox; the expression can call anything on the server objects.
+ *
+ * ### Future direction
+ *
+ * A registry approach (`config.cleanups: { 'name': (ctx) => ... }`) would give
+ * full type safety and proper stack traces at the cost of moving cleanup logic
+ * out of the spec file. Tracked as a potential 0.x API change.
  */
 function evaluateCleanup(expression: string, server: Record<string, unknown>): unknown {
   const keys = Object.keys(server)

--- a/packages/scenes/src/swarm.ts
+++ b/packages/scenes/src/swarm.ts
@@ -10,7 +10,7 @@ import type {
 } from './types.js'
 import type { TeamManager } from './team-manager.js'
 import { runScene } from './scene.js'
-import { runCleanup } from './runner.js'
+import { runCleanup, runSetup } from './runner.js'
 
 /**
  * Default swarm configuration values
@@ -217,8 +217,11 @@ export async function runSwarm(
           )
 
           try {
-            // Run pre-cleanup if configured
-            await runCleanup(scene, teamManager.getTeam(task.teamIndex).actors, server)
+            // Run pre-cleanup and setup if configured
+            const swarmTeam = teamManager.getTeam(task.teamIndex)
+            const swarmTestStart = new Date().toISOString()
+            await runCleanup(scene, swarmTeam.actors, swarmTeam.meta, server, swarmTestStart)
+            await runSetup(scene, swarmTeam.actors, swarmTeam.meta, server, swarmTestStart)
 
             const report = await runScene(scene, session, timeout)
 

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -641,6 +641,9 @@ export interface SequentialActorHandle extends ActorConfig {
    */
   dsl(text: string): ActionChain
 
+  /** Press a keyboard key (e.g. 'Escape', 'Enter', 'Tab') */
+  pressKey(key: string): ActionChain
+
   /**
    * Register a conditional watcher. If the selector becomes visible during
    * the next awaited action, the callback will be executed.
@@ -763,6 +766,9 @@ export interface ActionChain extends PromiseLike<void> {
    * ```
    */
   dsl(text: string): ActionChain
+
+  /** Press a keyboard key (e.g. 'Escape', 'Enter', 'Tab') */
+  pressKey(key: string): ActionChain
 }
 
 /**
@@ -785,8 +791,16 @@ export interface RegisteredScene {
   name: string
   fn: SceneFn
   file: string
-  /** Pre-cleanup expression from `cleanup:` directive in .spec.md files */
-  cleanup?: string
+  /**
+   * Pre/post-cleanup expressions from `cleanup:` directives in .spec.md files.
+   * Each entry is evaluated independently. Multiple `cleanup:` lines are supported.
+   */
+  cleanup?: string[]
+  /**
+   * Setup expressions from `setup:` directives in .spec.md files.
+   * Run after pre-cleanup but before scene steps. Multiple `setup:` lines supported.
+   */
+  setup?: string[]
   /** Roles required by this scene — used for team matching */
   roles?: string[]
 }
@@ -828,6 +842,8 @@ export interface DslTarget {
   scrollToBottom(): unknown
   /** Block until message arrives on the bus */
   waitFor(message: string): unknown
+  /** Press a keyboard key (e.g. 'Escape', 'Enter', 'Tab') */
+  pressKey(key: string): unknown
 }
 
 // ---------------------------------------------------------------------------
@@ -935,6 +951,9 @@ export interface ConcurrentActorHandle {
    * ```
    */
   dsl(text: string): ConcurrentActorHandle
+
+  /** Press a keyboard key (e.g. 'Escape', 'Enter', 'Tab') */
+  pressKey(key: string): ConcurrentActorHandle
 }
 
 /**

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",

--- a/packages/vscode-scenetest/package.json
+++ b/packages/vscode-scenetest/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-scenetest",
   "displayName": "Scenetest",
   "description": "Syntax highlighting for Scenetest scene specs (.spec.md)",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "scenetest",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

This release adds scene setup expressions, support for multiple cleanup directives per scene, and enhanced token interpolation. It also introduces the `pressKey` DSL action and fixes a bug where conditional monitors could miss already-visible elements.

## Key Changes

### New Features

- **`setup:` directive**: Scenes can now declare setup expressions that run after pre-cleanup but before scene steps. Useful for seeding scene-specific database state that differs from baseline seed data.

- **Multiple `cleanup:` and `setup:` lines**: Both directives now support multiple lines per scene. All expressions are collected as arrays and executed in order.

- **Enhanced token interpolation**: 
  - `[team.field]` tokens now resolve to team metadata tags (e.g., `[team.lang]`)
  - `[testStart]` token resolves to the ISO 8601 timestamp captured when the scene started
  - Improved error messages for missing roles or team tags

- **`pressKey` DSL action**: New action to send raw keyboard events via `page.keyboard.press()`. Supports any Playwright key name (Escape, Enter, Tab, ArrowDown, etc.).

### Bug Fixes

- **Conditional monitor pre-check**: `if` conditionals now fire immediately for already-visible elements at action start, not just elements that appear during polling. This prevents monitors from missing overlays or dialogs that were present when the `if` line was registered.

### Breaking Changes

- **`RegisteredScene.cleanup` type change**: Changed from `string | undefined` to `string[] | undefined`. Code reading `registered.cleanup` must now iterate the array instead of treating it as a single string.

## Implementation Details

- Refactored `interpolateCleanup` to `interpolateExpression` to handle all three token types uniformly
- Split cleanup/setup execution into separate loops to handle multiple expressions
- Added pre-check phase in `executeWithMonitors` that synchronously tests conditional selectors before the main action polling loop
- Updated markdown parser to collect multiple `cleanup:` and `setup:` lines into arrays
- Added `pressKey` method to both `ConcurrentActorHandleImpl` and `ActionChainImpl`

https://claude.ai/code/session_014dNNJ1mQUTpQtpR7miFof8