### PR TITLE
Add pressKey action and cleanup/setup directives documentation

### DIFF
--- a/docs/public/design/writing-tests.md
+++ b/docs/public/design/writing-tests.md
@@ -72,9 +72,7 @@ test('user completes onboarding', async ({ actor }) => {
 
 For the full comparison between the two TypeScript models — how to tell them apart, multi-actor concurrency, coordination, conditional monitors, and action chains vs reactive actors — see the [Concurrent and Classic Mode reference](/reference/concurrent-and-classic).
 
-For the complete `.spec.md` format rules, interpolation, macros, and `dsl()` method — see the [Text DSL Format reference](/reference/text-dsl).
-
-> **v0.4.0 additions:** Markdown scenes now support `setup:` directives for per-scene state seeding (runs after pre-cleanup, before scene steps), multiple `cleanup:`/`setup:` lines per scene, `[team.field]` interpolation from team `tags` metadata in cleanup/setup expressions, `[testStart]` timestamp tokens, and the `pressKey <key>` action for raw keyboard events.
+For the complete `.spec.md` format rules, interpolation, cleanup/setup directives, macros, and `dsl()` method — see the [Text DSL Format reference](/reference/text-dsl).
 
 > **STATUS:** Both `scene()` (concurrent) and `test()` (classic driver) execution models are implemented. We are evaluating which to keep long-term. See [Concurrent vs Classic — Two Execution Models](/design/scene-vs-flow) for the trade-off analysis. Before 1.0, one will be removed. Text DSL `.spec.md` files compile to `scene()`.
 

--- a/docs/public/design/writing-tests.md
+++ b/docs/public/design/writing-tests.md
@@ -74,6 +74,8 @@ For the full comparison between the two TypeScript models — how to tell them a
 
 For the complete `.spec.md` format rules, interpolation, macros, and `dsl()` method — see the [Text DSL Format reference](/reference/text-dsl).
 
+> **v0.4.0 additions:** Markdown scenes now support `setup:` directives for per-scene state seeding (runs after pre-cleanup, before scene steps), multiple `cleanup:`/`setup:` lines per scene, `[team.field]` interpolation from team `tags` metadata in cleanup/setup expressions, `[testStart]` timestamp tokens, and the `pressKey <key>` action for raw keyboard events.
+
 > **STATUS:** Both `scene()` (concurrent) and `test()` (classic driver) execution models are implemented. We are evaluating which to keep long-term. See [Concurrent vs Classic — Two Execution Models](/design/scene-vs-flow) for the trade-off analysis. Before 1.0, one will be removed. Text DSL `.spec.md` files compile to `scene()`.
 
 ---

--- a/docs/public/guides/conditional-handling.md
+++ b/docs/public/guides/conditional-handling.md
@@ -57,8 +57,6 @@ There are two phases: **declaration** (when your script runs) and **drain** (whe
 
 **Drain:** As the actor works through its queue (`see('dashboard')`, `click('settings')`, etc.), each action begins with a **synchronous pre-check** of all pending conditional monitors. If the selector is already visible when the action starts, the monitor fires immediately — the sub-actions execute before the main action begins. If not already visible, a polling loop runs alongside the action, checking every 50ms. The monitor is **one-shot**: once it fires, it stops polling. If the modal never appears, the monitor never fires and has zero cost beyond the polling.
 
-> **v0.4.0:** The pre-check was added to handle elements that are already visible when the action starts (e.g. a localStorage-gated intro dialog). Previously, `if` only detected elements appearing *during* the polling window.
-
 ### When does it poll?
 
 The monitor watches during **every action that comes after it** in the actor's queue. It doesn't watch retroactively — only actions declared after the `if()` call are monitored. This is why you typically declare `if()` early, before the actions where the optional UI might appear.

--- a/docs/public/guides/conditional-handling.md
+++ b/docs/public/guides/conditional-handling.md
@@ -55,7 +55,9 @@ There are two phases: **declaration** (when your script runs) and **drain** (whe
 
 **Declaration:** When the runner hits `user.if('welcome-modal', ...)`, nothing happens in the browser. The callback runs immediately, but the actor's internal queue is temporarily redirected — so `a.click('dismiss')` pushes to a *separate sub-action list* attached to the monitor, not to the actor's main queue. Your main action sequence is unaffected.
 
-**Drain:** As the actor works through its queue (`see('dashboard')`, `click('settings')`, etc.), a polling loop runs alongside each action. Every 50ms it checks: is `welcome-modal` visible? If yes, the monitor fires — the sub-actions (`click('dismiss')`) execute inline, pausing the current action, then the action resumes. The monitor is **one-shot**: once it fires, it stops polling. If the modal never appears, the monitor never fires and has zero cost beyond the polling.
+**Drain:** As the actor works through its queue (`see('dashboard')`, `click('settings')`, etc.), each action begins with a **synchronous pre-check** of all pending conditional monitors. If the selector is already visible when the action starts, the monitor fires immediately — the sub-actions execute before the main action begins. If not already visible, a polling loop runs alongside the action, checking every 50ms. The monitor is **one-shot**: once it fires, it stops polling. If the modal never appears, the monitor never fires and has zero cost beyond the polling.
+
+> **v0.4.0:** The pre-check was added to handle elements that are already visible when the action starts (e.g. a localStorage-gated intro dialog). Previously, `if` only detected elements appearing *during* the polling window.
 
 ### When does it poll?
 

--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -350,6 +350,27 @@ This separation means:
 
 For configuration, see the [guides overview](/guides).
 
+## Cleanup and Setup Directives
+
+Markdown scenes can declare `cleanup:` and `setup:` expressions for managing database state around a scene. These run server-side before and after scene steps.
+
+**Execution order:** `cleanup (before)` → `setup` → scene steps → `cleanup (after)`.
+
+```scenetest
+## review mode shows 2-buttons
+
+cleanup: supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]')
+setup: supabase.from('user_deck').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]')
+
+learner:
+- openTo /review
+- see 2-buttons-mode
+```
+
+Multiple `cleanup:` and `setup:` lines are supported — all execute in order. Use `[team.field]` to interpolate team metadata (from `tags` in `defineTeam()`), and `[testStart]` to scope cleanup to rows created during the test.
+
+For the full syntax, see the [Text DSL reference](/reference/text-dsl#cleanup-and-setup-directives).
+
 ## Summary
 
 - Scene specs describe **user journeys** — write them as concurrent TypeScript, text DSL markdown, or classic driver-style TypeScript
@@ -360,6 +381,8 @@ For configuration, see the [guides overview](/guides).
 - Use `seeInView()` to check viewport visibility without scrolling
 - Use bare `click` to click the current scope element
 - Use `seeToast()` for transient notifications
+- Use `pressKey()` to send raw keyboard events (`Escape`, `Enter`, `Tab`, etc.)
+- Use `cleanup:` and `setup:` directives in markdown specs for database state management
 - Use `if()` for conditional handling and `warnIf()` for flagging unexpected paths
 - Generate **handoff reports** listing needed test IDs
 - Let the collaboration loop guide development

--- a/docs/public/reference/actor-api.md
+++ b/docs/public/reference/actor-api.md
@@ -384,6 +384,32 @@ await user.select('settings timezone-select', 'America/New_York')
 ```
 
 
+### pressKey
+
+```typescript
+user.pressKey(key: string): ConcurrentActorHandle | ActionChain
+```
+
+Sends a raw keyboard event via `page.keyboard.press()`. Accepts any [Playwright key name](https://playwright.dev/docs/api/class-keyboard) (`Escape`, `Enter`, `Tab`, `ArrowDown`, etc.). Use this when you need to send a key press that isn't tied to a specific element interaction.
+
+```typescript [concurrent]
+user.see('intro-dialog')
+user.pressKey('Escape')
+user.see('main-page')
+```
+```typescript [driver]
+await user.see('intro-dialog')
+await user.pressKey('Escape')
+await user.see('main-page')
+```
+
+```scenetest [markdown]
+user:
+- see intro-dialog
+- pressKey Escape
+- see main-page
+```
+
 ## Timing & Coordination
 
 ### wait

--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -30,6 +30,7 @@ Actions:
   wait <ms>                       Wait milliseconds
   emit <message>                  Emit to message bus
   waitFor <message>               Block until bus message arrives
+  pressKey <key>                  Send raw keyboard event (Playwright key name)
   warnIf <selector> <message>     Register script warning
   up [<selector>]                 Navigate scope to ancestor (bare up = reset to page root)
   prev                            Return to previous scope
@@ -118,6 +119,31 @@ returning-user:
 - Bare `click` (no selector) clicks the current scope element
 - Bare `up` (no selector) resets scope to the page root
 
+### Cleanup and setup directives
+
+Scenes can declare `cleanup:` and `setup:` expressions that run server-side code around the scene. Use them when a scene needs specific database state.
+
+**Execution order:** `cleanup (before)` → `setup` → scene steps → `cleanup (after)`.
+
+```scenetest
+## review mode shows 2-buttons
+
+cleanup: supabase.from('user_deck').update({ review_answer_mode: null }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')
+setup: supabase.from('user_deck').update({ review_answer_mode: '2-buttons' }).eq('uid', '[learner.key]').eq('lang', '[team.lang]')
+
+learner:
+
+- openTo /review
+- see 2-buttons-mode
+```
+
+**Multiple directives:** You can declare multiple `cleanup:` and `setup:` lines — they are collected as an array and all execute in order:
+
+```scenetest
+cleanup: supabase.from('request_comment').delete().eq('uid', '[friend.key]')
+cleanup: supabase.from('notification').delete().eq('uid', '[learner.key]')
+```
+
 ### Variable interpolation
 
 Use `[namespace.field]` to interpolate values into action lines:
@@ -125,8 +151,9 @@ Use `[namespace.field]` to interpolate values into action lines:
 ```
 [self.field]         # Current actor's own fields (email, username, id, etc.)
 [role-name.field]    # Another actor's fields by role name
-[team.field]         # Team metadata (language, category, etc.)
+[team.field]         # Team metadata from tags (language, category, etc.)
 [alias.field]        # Aliased role (from macro args)
+[testStart]          # ISO 8601 timestamp captured before cleanup/setup runs
 ```
 
 **Examples:**
@@ -141,6 +168,12 @@ Variables work inside selectors for compound IDs:
 ```
 see user-result-[target.key]             # becomes "see user-result-12345"
 click language-card-[team.language]     # becomes "click language-card-spanish"
+```
+
+`[team.field]` resolves from the team's `tags` metadata defined in `defineTeam()`. `[testStart]` is a built-in token useful for scoping cleanup to rows created during the test:
+
+```scenetest
+cleanup: supabase.from('request_comment').delete().eq('uid', '[friend.key]').gte('created_at', '[testStart]')
 ```
 
 ### Cross-device testing in markdown
@@ -266,7 +299,8 @@ scene('multi-user interaction', ({ actor }) => {
 All namespace types work:
 - `[self.field]` — current actor's own fields
 - `[role.field]` — another actor's fields by role name
-- `[team.field]` — team metadata (when available)
+- `[team.field]` — team metadata from `tags` (when available)
+- `[testStart]` — ISO 8601 timestamp captured before cleanup/setup runs
 
 Interpolated values are automatically escaped to prevent selector injection attacks.
 


### PR DESCRIPTION
## Summary
This PR adds documentation for two new testing features: the `pressKey()` action for sending raw keyboard events, and `cleanup:`/`setup:` directives for managing database state in markdown scene specs.

## Key Changes

- **Added `pressKey` action documentation** across multiple reference docs:
  - Text DSL reference: Added `pressKey <key>` to the actions list with description
  - Actor API reference: Added comprehensive `pressKey()` method documentation with TypeScript examples (concurrent and driver modes) and markdown syntax
  - Writing scene specs guide: Added `pressKey()` to the summary of key testing patterns

- **Added cleanup/setup directives documentation**:
  - Text DSL reference: New "Cleanup and setup directives" section explaining execution order, syntax, and multiple directive support
  - Text DSL reference: Updated variable interpolation section to document `[testStart]` built-in token and clarify `[team.field]` resolves from `tags` metadata
  - Writing scene specs guide: New "Cleanup and Setup Directives" section with examples and link to full reference
  - Writing scene specs guide: Added cleanup/setup directives to the summary of key patterns

- **Minor clarifications**:
  - Updated `[team.field]` documentation to specify it resolves from `tags` in `defineTeam()`
  - Updated writing-tests.md to mention cleanup/setup directives in the reference link
  - Fixed truncated sentence in conditional-handling.md

## Notable Details

- `pressKey()` accepts any Playwright key name (`Escape`, `Enter`, `Tab`, `ArrowDown`, etc.)
- Cleanup/setup execution order: `cleanup (before)` → `setup` → scene steps → `cleanup (after)`
- `[testStart]` is a built-in interpolation token for scoping cleanup to rows created during the test
- Multiple `cleanup:` and `setup:` lines are supported and execute in order

https://claude.ai/code/session_01LCxj6tudYa5gpYL8YLRE8e