### PR TITLE
Add error selector monitoring to detect UI errors during actions

### DIFF
--- a/packages/scenes/src/__tests__/dsl.test.ts
+++ b/packages/scenes/src/__tests__/dsl.test.ts
@@ -50,6 +50,7 @@ function createTestActor(role = 'user') {
     bus,
     timeline,
     warnings,
+    [],
     5000,
     60000
   )
@@ -425,6 +426,7 @@ describe('ConcurrentActorHandleImpl.dsl()', () => {
       bus,
       timeline,
       warnings,
+      [],
       5000,
       60000
     )
@@ -438,6 +440,7 @@ describe('ConcurrentActorHandleImpl.dsl()', () => {
       bus,
       timeline,
       warnings,
+      [],
       5000,
       60000
     )
@@ -477,6 +480,7 @@ describe('ConcurrentActorHandleImpl.dsl()', () => {
       bus,
       timeline,
       warnings,
+      [],
       5000,
       60000
     )
@@ -520,6 +524,7 @@ describe('ConcurrentActorHandleImpl.dsl()', () => {
       bus,
       timeline,
       warnings,
+      [],
       5000,
       60000
     )
@@ -547,6 +552,7 @@ describe('ConcurrentActorHandleImpl.dsl()', () => {
       bus,
       timeline,
       warnings,
+      [],
       5000,
       60000
     )

--- a/packages/scenes/src/__tests__/reactive.test.ts
+++ b/packages/scenes/src/__tests__/reactive.test.ts
@@ -57,6 +57,7 @@ function createTestActor(
     bus,
     timeline,
     warnings,
+    /* consoleErrors */ [],
     /* actionTimeout */ 5000,
     /* warnAfter */ 60000 // high so warnings don't fire during tests
   )
@@ -81,6 +82,7 @@ function createDeferredActor(role = 'user') {
     bus,
     timeline,
     warnings,
+    [],
     5000,
     60000
   )

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -1,5 +1,5 @@
 import type { Page, BrowserContext, Locator } from 'playwright'
-import type { ActorConfig, SequentialActorHandle, ActionChain, AssertionResult, TimelineEntry, ScriptWarning, Selector, PageFactory } from './types.js'
+import type { ActorConfig, SequentialActorHandle, ActionChain, AssertionResult, TimelineEntry, ScriptWarning, ConsoleError, ErrorSelector, Selector, PageFactory } from './types.js'
 import type { NavigationMode } from './keyboard.js'
 import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOption, fuzzyFingerClick, fuzzyFingerFill, fuzzyFingerCheck } from './keyboard.js'
 import { MessageBus } from './message-bus.js'
@@ -29,6 +29,16 @@ interface Watcher {
  * Registered warning trigger - fires when selector becomes visible
  */
 interface WarningTrigger {
+  selector: Selector
+  message: string
+  triggered: boolean
+}
+
+/**
+ * Error selector trigger - fires when selector becomes visible,
+ * records a ConsoleError with source: 'selector'
+ */
+interface ErrorSelectorTrigger {
   selector: Selector
   message: string
   triggered: boolean
@@ -501,8 +511,9 @@ class ActionChainImpl implements ActionChain {
 
     const watchers = this.actor.getWatchers()
     const warningTriggers = this.actor.getWarningTriggers()
+    const errorSelectorTriggers = this.actor.getErrorSelectorTriggers()
 
-    if (watchers.length === 0 && warningTriggers.length === 0) {
+    if (watchers.length === 0 && warningTriggers.length === 0 && errorSelectorTriggers.length === 0) {
       await action.execute()
       return
     }
@@ -572,6 +583,29 @@ class ActionChainImpl implements ActionChain {
                 timestamp: Date.now(),
                 actor: this.actor.role,
                 duringAction: `${action.name}(${action.target ?? ''})`,
+              })
+            }
+          } catch {
+            // Ignore errors from isVisible check
+          }
+        }
+
+        // Check error selector triggers (from config.errorSelectors)
+        for (const trigger of errorSelectorTriggers) {
+          if (trigger.triggered) continue
+          try {
+            const locator = resolveSelector(this.page, trigger.selector)
+            const isVisible = await locator.isVisible()
+            if (isVisible) {
+              trigger.triggered = true
+              this.actor.pushConsoleError({
+                message: trigger.message,
+                actor: this.actor.role,
+                timestamp: Date.now(),
+                type: 'error',
+                source: 'selector',
+                selector: formatSelector(trigger.selector),
+                url: this.page.url(),
               })
             }
           } catch {
@@ -674,6 +708,9 @@ export class SequentialActorHandleImpl implements SequentialActorHandle {
   // Registered warning triggers
   private warningTriggers: WarningTrigger[] = []
 
+  // Error selector triggers (from config.errorSelectors)
+  private errorSelectorTriggers: ErrorSelectorTrigger[] = []
+
   // Page factory for switchDevice support
   private _pageFactory: PageFactory | null
 
@@ -692,11 +729,13 @@ export class SequentialActorHandleImpl implements SequentialActorHandle {
     private bus: MessageBus,
     private timeline: TimelineEntry[],
     private warnings: ScriptWarning[],
+    private consoleErrors: ConsoleError[],
     private actionTimeout: number,
     private warnAfter: number,
     navigationMode: NavigationMode = 'pointer',
     fuzzyFingers: boolean = false,
-    pageFactory?: PageFactory | null
+    pageFactory?: PageFactory | null,
+    errorSelectors?: ErrorSelector[]
   ) {
     this.role = role
     this._page = page
@@ -705,6 +744,17 @@ export class SequentialActorHandleImpl implements SequentialActorHandle {
     this.key = config.key
     this.navigationMode = navigationMode
     this.fuzzyFingers = fuzzyFingers
+
+    // Seed error selector triggers from config
+    if (errorSelectors) {
+      for (const es of errorSelectors) {
+        this.errorSelectorTriggers.push({
+          selector: es.selector,
+          message: es.message,
+          triggered: false,
+        })
+      }
+    }
 
     // Copy all config properties to this instance
     for (const [k, value] of Object.entries(config)) {
@@ -749,6 +799,20 @@ export class SequentialActorHandleImpl implements SequentialActorHandle {
    */
   getWarningTriggers(): WarningTrigger[] {
     return this.warningTriggers
+  }
+
+  /**
+   * Get registered error selector triggers (used by ActionChainImpl)
+   */
+  getErrorSelectorTriggers(): ErrorSelectorTrigger[] {
+    return this.errorSelectorTriggers
+  }
+
+  /**
+   * Push a console error (used by ActionChainImpl for error selector matches)
+   */
+  pushConsoleError(error: ConsoleError): void {
+    this.consoleErrors.push(error)
   }
 
   /**

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -59,5 +59,6 @@ export type {
   SwarmSceneResult,
   SwarmRunDetail,
   SwarmClassification,
+  ErrorSelector,
   PageFactory,
 } from './types.js'

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -52,6 +52,8 @@ import type {
   Selector,
   TimelineEntry,
   ScriptWarning,
+  ConsoleError,
+  ErrorSelector,
   FlowContext,
   FlowFn,
   SceneOptions,
@@ -108,6 +110,16 @@ interface WarningTrigger {
 }
 
 // ---------------------------------------------------------------------------
+// Error selector trigger (from config.errorSelectors, pushes to consoleErrors)
+// ---------------------------------------------------------------------------
+
+interface ErrorSelectorTrigger {
+  selector: Selector
+  message: string
+  triggered: boolean
+}
+
+// ---------------------------------------------------------------------------
 // Conditional monitor — the flow model's answer to if()
 // ---------------------------------------------------------------------------
 
@@ -156,6 +168,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   private currentScope: Page | Locator | null
   private scopeStack: Array<Page | Locator> = []
   private warningTriggers: WarningTrigger[] = []
+  private errorSelectorTriggers: ErrorSelectorTrigger[] = []
   private conditionalMonitors: ConditionalMonitor[] = []
 
   // URL when scope was last set (for detecting navigation-induced staleness)
@@ -181,10 +194,12 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     private bus: MessageBus,
     private timeline: TimelineEntry[],
     private warnings: ScriptWarning[],
+    private consoleErrors: ConsoleError[],
     private actionTimeout: number,
     private warnAfter: number,
     navigationMode: NavigationMode = 'pointer',
-    fuzzyFingers: boolean = false
+    fuzzyFingers: boolean = false,
+    errorSelectors?: ErrorSelector[]
   ) {
     this.role = role
     this._page = page
@@ -192,6 +207,17 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     this.key = config.key
     this.navigationMode = navigationMode
     this.fuzzyFingers = fuzzyFingers
+
+    // Seed error selector triggers from config
+    if (errorSelectors) {
+      for (const es of errorSelectors) {
+        this.errorSelectorTriggers.push({
+          selector: es.selector,
+          message: es.message,
+          triggered: false,
+        })
+      }
+    }
 
     // Forward all config properties
     for (const [k, value] of Object.entries(config)) {
@@ -923,9 +949,10 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     await this.validateScope()
 
     const hasWarnings = this.warningTriggers.some((t) => !t.triggered)
+    const hasErrorSelectors = this.errorSelectorTriggers.some((t) => !t.triggered)
     const hasMonitors = this.conditionalMonitors.some((m) => !m.triggered)
 
-    if (!hasWarnings && !hasMonitors) {
+    if (!hasWarnings && !hasErrorSelectors && !hasMonitors) {
       await action.execute()
       return
     }
@@ -979,6 +1006,29 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
                 timestamp: Date.now(),
                 actor: this.role,
                 duringAction: `${action.name}(${action.target ?? ''})`,
+              })
+            }
+          } catch {
+            // Ignore errors from isVisible check
+          }
+        }
+
+        // Poll error selector triggers (from config.errorSelectors)
+        for (const trigger of this.errorSelectorTriggers) {
+          if (trigger.triggered) continue
+          try {
+            const locator = resolveSelector(this.page, trigger.selector)
+            const isVisible = await locator.isVisible()
+            if (isVisible) {
+              trigger.triggered = true
+              this.consoleErrors.push({
+                message: trigger.message,
+                actor: this.role,
+                timestamp: Date.now(),
+                type: 'error',
+                source: 'selector',
+                selector: trigger.selector,
+                url: this.page.url(),
               })
             }
           } catch {
@@ -1165,10 +1215,12 @@ export function flow(name: string, fnOrOptions: FlowFn | SceneOptions, maybeFn?:
           session.getMessageBus(),
           session.timeline,
           session.warnings,
+          session.consoleErrors,
           session.actionTimeout,
           session.warnAfter,
           navMode,
-          fuzzyFingers
+          fuzzyFingers,
+          session.getErrorSelectors()
         )
 
         reactiveActors.push(reactive)

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -151,7 +151,7 @@ export class SceneRunner {
       try {
         // Create session
         const fuzzyFingers = !!this.config.fuzzyFingers
-        const session = await this.teamManager.createSession(teamIndex, actionTimeout, warnAfter, this.config.baseUrl, fuzzyFingers, this.config.noPanel, this.config.consoleErrors)
+        const session = await this.teamManager.createSession(teamIndex, actionTimeout, warnAfter, this.config.baseUrl, fuzzyFingers, this.config.noPanel, this.config.consoleErrors, this.config.errorSelectors)
 
         try {
           // Log which scene is starting
@@ -201,7 +201,7 @@ export class SceneRunner {
           if (report.consoleErrors.length > 0) {
             console.log(`    ⚠ ${report.consoleErrors.length} console error(s)`)
             for (const ce of report.consoleErrors.slice(0, 5)) {
-              const label = ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
+              const label = ce.source === 'selector' ? `error-selector(${ce.selector})` : ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
               console.log(`      └─ [${ce.actor}] ${label}: ${ce.message.slice(0, 200)}`)
             }
             if (report.consoleErrors.length > 5) {
@@ -315,7 +315,8 @@ export class SceneRunner {
       this.config.server as Record<string, unknown> | undefined,
       fuzzyFingers,
       this.config.noPanel,
-      this.config.consoleErrors
+      this.config.consoleErrors,
+      this.config.errorSelectors
     )
 
     // Build a RunReport that includes the swarm results
@@ -572,7 +573,7 @@ export function printSummary(report: RunReport): void {
       if (scene.consoleErrors.length > 0) {
         console.log(`    ${scene.name}: ${scene.consoleErrors.length} error(s)`)
         for (const ce of scene.consoleErrors.slice(0, 3)) {
-          const label = ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
+          const label = ce.source === 'selector' ? `error-selector(${ce.selector})` : ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
           console.log(`      └─ [${ce.actor}] ${label}: ${ce.message.slice(0, 150)}`)
         }
         if (scene.consoleErrors.length > 3) {

--- a/packages/scenes/src/swarm.ts
+++ b/packages/scenes/src/swarm.ts
@@ -150,7 +150,8 @@ export async function runSwarm(
   server?: Record<string, unknown>,
   fuzzyFingers: boolean = false,
   noPanel?: boolean,
-  consoleErrors?: boolean | 'error' | 'warn'
+  consoleErrors?: boolean | 'error' | 'warn',
+  errorSelectors?: import('./types.js').ErrorSelector[]
 ): Promise<SwarmReport> {
   const resolved = resolveSwarmConfig(config)
   const totalTeams = teamManager.totalCount
@@ -215,7 +216,8 @@ export async function runSwarm(
             baseUrl,
             fuzzyFingers,
             noPanel,
-            consoleErrors
+            consoleErrors,
+            errorSelectors
           )
 
           try {

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -1,5 +1,5 @@
 import type { Browser, BrowserContext, Page } from 'playwright'
-import type { TeamConfig, ActorConfig, AssertionResult, TimelineEntry, ScriptWarning, ConsoleError, ResolvedTeam, TeamMeta, PageFactory } from './types.js'
+import type { TeamConfig, ActorConfig, AssertionResult, TimelineEntry, ScriptWarning, ConsoleError, ErrorSelector, ResolvedTeam, TeamMeta, PageFactory } from './types.js'
 import type { DeviceProfile } from './devices.js'
 import type { StorageState } from './warmup.js'
 import { WarmupCache } from './warmup.js'
@@ -191,7 +191,8 @@ export class TeamManager {
     baseUrl?: string,
     fuzzyFingers: boolean = false,
     noPanel?: boolean,
-    consoleErrors?: boolean | 'error' | 'warn'
+    consoleErrors?: boolean | 'error' | 'warn',
+    errorSelectors?: ErrorSelector[]
   ): Promise<TeamSession> {
     if (!this.browser) {
       throw new Error('Browser not set. Call setBrowser() first.')
@@ -210,7 +211,8 @@ export class TeamManager {
       this.navigationModeRotation,
       fuzzyFingers,
       noPanel,
-      consoleErrors
+      consoleErrors,
+      errorSelectors
     )
   }
 }
@@ -236,6 +238,9 @@ export class TeamSession {
   /** Which console message types to capture */
   private consoleErrorMode: false | 'error' | 'warn'
 
+  /** Error selectors from config — injected into every actor */
+  private errorSelectors?: ErrorSelector[]
+
   constructor(
     private browser: Browser,
     private team: TeamConfig,
@@ -249,11 +254,13 @@ export class TeamSession {
     private navigationModeRotation?: NavigationModeRotation | null,
     private fuzzyFingers: boolean = false,
     private noPanel?: boolean,
-    consoleErrors?: boolean | 'error' | 'warn'
+    consoleErrors?: boolean | 'error' | 'warn',
+    errorSelectors?: ErrorSelector[]
   ) {
     this.meta = meta
     // Default: capture errors
     this.consoleErrorMode = consoleErrors === false ? false : consoleErrors === 'warn' ? 'warn' : 'error'
+    this.errorSelectors = errorSelectors
   }
 
   /**
@@ -372,6 +379,14 @@ export class TeamSession {
    */
   getFuzzyFingers(): boolean {
     return this.fuzzyFingers
+  }
+
+  /**
+   * Get global error selectors for this session.
+   * Used by flow() to pass to ConcurrentActorHandleImpl.
+   */
+  getErrorSelectors(): ErrorSelector[] | undefined {
+    return this.errorSelectors
   }
 
   /**
@@ -552,11 +567,13 @@ export class TeamSession {
       this.bus,
       this.timeline,
       this.warnings,
+      this.consoleErrors,
       this.actionTimeout,
       this.warnAfter,
       navMode,
       this.fuzzyFingers,
-      pageFactory
+      pageFactory,
+      this.errorSelectors
     )
 
     this.contexts.set(role, context)

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -248,6 +248,22 @@ export interface ScenetestConfig extends BaseConfig {
    */
   consoleErrors?: boolean | 'error' | 'warn'
 
+  /**
+   * Global error selectors — watched across all scenes and actors.
+   * When any selector matches a visible element during action execution,
+   * a ConsoleError with `source: 'selector'` is recorded alongside
+   * console errors and uncaught exceptions.
+   *
+   * @example
+   * ```ts
+   * errorSelectors: [
+   *   { selector: '[role="alert"]', message: 'Unexpected error toast' },
+   *   { selector: '.toast-error',   message: 'Error toast appeared' },
+   * ]
+   * ```
+   */
+  errorSelectors?: ErrorSelector[]
+
   /** Hook: before all scenes run */
   beforeAll?: () => Promise<void>
 
@@ -310,10 +326,13 @@ export interface ConsoleError {
    * Where the error originated:
    * - `'console'` — explicit `console.error()` / `console.warn()` call
    * - `'pageerror'` — uncaught exception or unhandled promise rejection
+   * - `'selector'` — a config-level error selector matched a visible element
    */
-  source?: 'console' | 'pageerror'
+  source?: 'console' | 'pageerror' | 'selector'
   /** URL of the page when the error occurred */
   url?: string
+  /** The CSS selector that matched (only present when source is 'selector') */
+  selector?: string
 }
 
 /**
@@ -386,6 +405,20 @@ export interface RunReport {
   }
   /** Present when this run was triggered by swarm mode */
   swarm?: SwarmReport
+}
+
+// ─── Error Selector Types ────────────────────────────────────────────
+
+/**
+ * A global error selector watched across all scenes.
+ * When the selector matches a visible element during action execution,
+ * a ConsoleError with `source: 'selector'` is recorded.
+ */
+export interface ErrorSelector {
+  /** CSS selector, aria-label, or alias (~name) to watch for */
+  selector: Selector
+  /** Message recorded when the selector matches */
+  message: string
 }
 
 // ─── Swarm Mode Types ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds support for global error selectors that are monitored during action execution. When a configured selector matches a visible element, a `ConsoleError` with `source: 'selector'` is recorded, allowing tests to detect and report UI-level errors (like error toasts or alerts) that occur during test execution.

## Key Changes

- **New `ErrorSelector` type** in `types.ts`: Defines a selector and message pair for error detection
- **Extended `ConsoleError` interface**: Added `source: 'selector'` option and optional `selector` field to track which error selector matched
- **New `errorSelectors` config option**: Global configuration in `ScenetestConfig` to define error selectors watched across all scenes
- **Error selector polling in action execution**: Both `SequentialActorHandleImpl` (actor.ts) and `ConcurrentActorHandleImpl` (reactive.ts) now poll error selectors during action execution, similar to warning triggers
- **Error selector trigger tracking**: Maintains state of which selectors have already triggered to avoid duplicate reporting
- **Session-level error selector propagation**: `TeamSession` and `TeamManager` pass error selectors to all actor instances via constructor parameters
- **Updated reporting**: `SceneRunner` now displays error-selector matches in console output with the matched selector name

## Implementation Details

- Error selector checking is integrated into the existing action polling loop alongside warning triggers and conditional monitors
- Triggered selectors are tracked per-actor to prevent duplicate errors from the same selector
- Errors from visibility checks are silently ignored to prevent test failures from selector evaluation
- The feature works with both sequential (actor.ts) and concurrent (reactive.ts) execution models
- Test fixtures updated to pass empty `consoleErrors` array to actor constructors

https://claude.ai/code/session_01Sg3YwMLhj9e39apDVKLWK7