### PR TITLE
Add live dashboard with real-time swim-lane timeline

### DIFF
--- a/docs/app/sections.ts
+++ b/docs/app/sections.ts
@@ -64,6 +64,12 @@ export const reference: SectionItem[] = [
     description:
       'Writing scenes in TypeScript with scene(), dropping to Playwright with test(), and when to use each.',
   },
+  {
+    slug: 'live-dashboard',
+    title: 'Live Dashboard',
+    description:
+      'Real-time swim-lane timeline at /__scenetest/dashboard showing actor actions, assertions, and timing as scenes run.',
+  },
 ]
 
 export const faqs: SectionItem[] = [

--- a/docs/public/design/dashboard.md
+++ b/docs/public/design/dashboard.md
@@ -1,6 +1,6 @@
 # Scenetest Dashboard & Reports
 
-**STATUS: Design Stage**
+**STATUS: Partially Implemented** — Live dashboard with swim-lane timeline is shipped. See [Live Dashboard reference](/reference/live-dashboard). The JSONL format, comparison view, and CI integration below are still design-stage.
 
 ---
 

--- a/docs/public/guides/getting-started.md
+++ b/docs/public/guides/getting-started.md
@@ -434,6 +434,7 @@ When your test suite grows, add more actor teams to run scenes in parallel. Each
 - [Writing Scene Specs](/guides/writing-scene-specs) -- the full guide to scene orchestration
 - [Writing Inline Assertions](/guides/writing-inline-assertions) -- deep dive into `should()`, `failed()`, `serverCheck()`, and framework hooks
 - [Building Good Teams of Actors](/guides/building-teams) -- designing teams, seed data, and scaling concurrency
+- [Live Dashboard](/reference/live-dashboard) -- real-time swim-lane timeline of actor actions and assertions
 - [Selectors Reference](/reference/selectors) -- attribute matching, nesting, key selectors, aliases
 - [Markdown Spec Reference](/reference/text-dsl) -- full Markdown spec grammar, interpolation, macros
 - [TypeScript Scenes & Playwright Specs](/reference/concurrent-and-classic) -- writing scenes in TypeScript or dropping to Playwright

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -261,6 +261,14 @@ scenetest-reports/
 
 **JSON reports** include the full `RunReport` object for programmatic analysis.
 
+## Live Dashboard
+
+When running against a Vite dev server with the scenetest plugin, a live dashboard is available at `/__scenetest/dashboard`. It shows a real-time swim-lane timeline with per-actor action bars, assertion markers, and timing data as scenes execute.
+
+The URL is printed when the runner starts. You can also open it from the floating dev panel's **dashboard** button.
+
+See [Live Dashboard](/reference/live-dashboard) for full details.
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/docs/public/reference/live-dashboard.md
+++ b/docs/public/reference/live-dashboard.md
@@ -1,0 +1,133 @@
+# Live Dashboard
+
+The live dashboard streams scene execution events in real-time to a browser-based timeline at `/__scenetest/dashboard`. It shows swim lanes per actor with action bars, assertion markers, and timing data as scenes run.
+
+## Quick Start
+
+1. Start your dev server (`pnpm dev` or equivalent)
+2. Open `http://localhost:5173/__scenetest/dashboard` in your browser
+3. Run scenes: `pnpm scenetest scenetest/scenes/my-scene.spec.md`
+4. Watch the timeline populate in real-time
+
+The dashboard URL is also printed to the terminal when scenes start:
+
+```text
+Running 2 scene file(s)...
+
+Found 2 scene(s)
+
+Dashboard: http://localhost:5173/__scenetest/dashboard
+```
+
+You can also open it from the floating dev panel — click the **dashboard** button in the action bar.
+
+## How It Works
+
+The CLI runner and Vite dev server are separate processes. They communicate via HTTP:
+
+```text
+CLI Runner (Playwright)
+    │
+    POST /__scenetest/events     → pushes timeline events
+    │
+Vite Plugin (middleware)
+    │
+    GET /__scenetest/events      → SSE stream to browser
+    │
+Dashboard (browser)
+    └── renders swim-lane timeline
+```
+
+1. **Runner emits events** — as scenes execute, the runner sends fire-and-forget POSTs to the Vite dev server with timeline data (scene start/end, action start/end, assertions)
+2. **Vite plugin fans out** — the plugin's event hub broadcasts events to all connected dashboard clients via Server-Sent Events (SSE)
+3. **Dashboard renders** — the browser page updates the swim-lane timeline in real-time
+
+If the Vite dev server isn't running or doesn't have the scenetest plugin, events silently drop. There is zero impact on test execution — the reporter never blocks or slows down the runner.
+
+## Dashboard UI
+
+### Header
+
+Shows run-level stats updated in real-time:
+
+- **Scenes** — completed / total
+- **Pass** — assertion pass count
+- **Fail** — assertion fail count
+- **Time** — elapsed duration
+- **Connection indicator** — green (connected), amber (connecting), red (disconnected)
+
+### Swim Lanes
+
+Each scene gets a section with one horizontal lane per actor. Actions appear as bars positioned by timestamp:
+
+| Color | Meaning |
+|-------|---------|
+| Blue (pulsing) | Action currently running |
+| Green | Action completed successfully |
+| Amber | Action completed but was slow (>500ms) |
+| Red | Action failed with an error |
+
+Hover over any bar to see the full action name, target selector, duration, and error message (if any).
+
+### Time Ruler
+
+A ruler at the top of each scene's swim lanes shows tick marks at regular intervals relative to the scene start time.
+
+### Assertion Markers
+
+Small markers appear on the lane for the actor that triggered them:
+
+- **Green checkmark** — assertion passed
+- **Red cross** — assertion failed
+
+Hover for the assertion description.
+
+## Events
+
+The runner emits these event types:
+
+| Event | When | Data |
+|-------|------|------|
+| `run:start` | Run begins | scene count |
+| `scene:start` | Scene begins | name, file, actor roles |
+| `action:start` | Action begins executing | actor, action name, target selector |
+| `action:end` | Action finishes | actor, action, duration, error (if any) |
+| `assertion` | Inline check fires | actor, description, pass/fail |
+| `scene:end` | Scene finishes | name, status, duration, error |
+| `run:end` | Run finishes | duration, summary totals |
+
+Events flow through both the sequential (`test()`) and concurrent (`scene()`) execution models. Both `ActionChainImpl` and `ConcurrentActorHandleImpl` emit action events.
+
+## Late Joining
+
+If you open the dashboard after a run has started, you'll still see all events from the current run. The event hub keeps a ring buffer of the last 2000 events and replays them to newly connected clients.
+
+Opening a new run clears the buffer so the dashboard starts fresh.
+
+## No Configuration Required
+
+The dashboard works out of the box with the default Vite plugin setup:
+
+```typescript
+// vite.config.ts
+import scenetest from '@scenetest/vite-plugin'
+
+export default defineConfig({
+  plugins: [react(), scenetest()],
+})
+```
+
+The dashboard routes (`/__scenetest/dashboard` and `/__scenetest/events`) are registered automatically in dev mode. They are not included in production builds.
+
+## Relationship to Reports
+
+The live dashboard and static HTML reports serve different purposes:
+
+| | Live Dashboard | HTML Reports |
+|---|---|---|
+| **When** | During test execution | After run completes |
+| **Where** | `/__scenetest/dashboard` in browser | `scenetest/.reports/report-*.html` on disk |
+| **Data** | Real-time event stream | Complete run summary |
+| **Use case** | Watching test progress, debugging slow actions | Sharing results, CI artifacts, historical comparison |
+
+Both are available simultaneously — the runner writes reports to disk regardless of whether the dashboard is open.

--- a/packages/checks-panel/src/panel.ts
+++ b/packages/checks-panel/src/panel.ts
@@ -57,6 +57,7 @@ function getPanelHTML(): string {
         <button class="scenetest-btn scenetest-audio-btn" id="scenetest-play" title="Play symphony">\u25B6</button>
       </div>
       <span class="scenetest-separator"></span>
+      <a class="scenetest-btn" id="scenetest-dashboard" href="/__scenetest/dashboard" target="_blank" title="Live dashboard">dashboard</a>
       <button class="scenetest-btn" id="scenetest-fullscreen">fullscreen</button>
       <button class="scenetest-btn" id="scenetest-clear">clear</button>
     </div>

--- a/packages/checks-panel/src/styles.ts
+++ b/packages/checks-panel/src/styles.ts
@@ -167,6 +167,7 @@ export const panelStyles = `
   font-size: 11px;
   font-family: inherit;
   transition: all 0.15s;
+  text-decoration: none;
 }
 .scenetest-btn:hover {
   background: #3a3a5a;

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -6,6 +6,7 @@ import { MessageBus } from './message-bus.js'
 import { resolveSelector } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { findDevice } from './devices.js'
+import { dashboardSend } from './dashboard-reporter.js'
 
 /**
  * Action to be executed in a chain
@@ -654,9 +655,26 @@ class ActionChainImpl implements ActionChain {
         }
       }, this.warnAfter)
 
+      dashboardSend({
+        type: 'action:start',
+        timestamp: start,
+        actor: this.actor.role,
+        action: action.name,
+        target: action.target,
+      })
+
       try {
         await this.executeWithWatchers(action)
         entry.duration = Date.now() - start
+
+        dashboardSend({
+          type: 'action:end',
+          timestamp: Date.now(),
+          actor: this.actor.role,
+          action: action.name,
+          target: action.target,
+          duration: entry.duration,
+        })
 
         // Log completion if we warned
         if (warned) {
@@ -665,6 +683,17 @@ class ActionChainImpl implements ActionChain {
       } catch (err) {
         entry.duration = Date.now() - start
         entry.error = err instanceof Error ? err.message : String(err)
+
+        dashboardSend({
+          type: 'action:end',
+          timestamp: Date.now(),
+          actor: this.actor.role,
+          action: action.name,
+          target: action.target,
+          duration: entry.duration,
+          error: entry.error,
+        })
+
         this.timeline.push(entry)
         throw err
       } finally {

--- a/packages/scenes/src/dashboard-reporter.ts
+++ b/packages/scenes/src/dashboard-reporter.ts
@@ -1,0 +1,57 @@
+import type { DashboardEvent } from './types.js'
+
+/**
+ * Streams dashboard events to the Vite dev server for the live timeline.
+ *
+ * All sends are fire-and-forget — if the Vite server isn't running or
+ * doesn't have the scenetest plugin, events silently drop.
+ * Zero impact on test execution.
+ */
+export class DashboardReporter {
+  private endpoint: string
+  private connected: boolean | null = null // null = unknown
+
+  constructor(baseUrl: string) {
+    // Strip trailing slash, append event endpoint
+    this.endpoint = baseUrl.replace(/\/+$/, '') + '/__scenetest/events'
+  }
+
+  /** Post an event to the Vite dev server. Non-blocking, never throws. */
+  send(event: DashboardEvent): void {
+    // Skip if we already know the server isn't listening
+    if (this.connected === false) return
+
+    fetch(this.endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(event),
+      signal: AbortSignal.timeout(2000),
+    })
+      .then((res) => {
+        this.connected = res.ok
+      })
+      .catch(() => {
+        // First failure — mark as disconnected so we stop trying
+        this.connected = false
+      })
+  }
+
+  /** Dashboard URL for the user to open in a browser. */
+  get dashboardUrl(): string {
+    return this.endpoint.replace('/events', '/dashboard')
+  }
+}
+
+// ─── Module-level singleton ─────────────────────────────────────────
+// Set by the runner before execution; read by actor.ts and team-manager.ts
+// without needing to thread through every constructor.
+
+let _reporter: DashboardReporter | null = null
+
+export function setDashboardReporter(reporter: DashboardReporter | null): void {
+  _reporter = reporter
+}
+
+export function dashboardSend(event: DashboardEvent): void {
+  _reporter?.send(event)
+}

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -68,6 +68,7 @@ import { resolveSelector } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { scene, getCurrentSession } from './scene.js'
 import { findDevice } from './devices.js'
+import { dashboardSend } from './dashboard-reporter.js'
 
 // ---------------------------------------------------------------------------
 // Interpolation helpers
@@ -912,9 +913,26 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
           warned = true
         }, this.warnAfter)
 
+        dashboardSend({
+          type: 'action:start',
+          timestamp: start,
+          actor: this.role,
+          action: action.name,
+          target: action.target,
+        })
+
         try {
           await this.executeWithMonitors(action)
           entry.duration = Date.now() - start
+
+          dashboardSend({
+            type: 'action:end',
+            timestamp: Date.now(),
+            actor: this.role,
+            action: action.name,
+            target: action.target,
+            duration: entry.duration,
+          })
 
           if (warned) {
             console.warn(
@@ -924,6 +942,17 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
         } catch (err) {
           entry.duration = Date.now() - start
           entry.error = err instanceof Error ? err.message : String(err)
+
+          dashboardSend({
+            type: 'action:end',
+            timestamp: Date.now(),
+            actor: this.role,
+            action: action.name,
+            target: action.target,
+            duration: entry.duration,
+            error: entry.error,
+          })
+
           this.timeline.push(entry)
           throw err
         } finally {

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -12,6 +12,7 @@ import { importFile } from './loader.js'
 import { loadMarkdownScene } from './markdown-scene.js'
 import { SwarmTrigger, runSwarm } from './swarm.js'
 import { registerBuiltinMacros, registerSelectedMacros } from './builtin-macros.js'
+import { DashboardReporter, setDashboardReporter, dashboardSend } from './dashboard-reporter.js'
 
 /**
  * Main scene runner
@@ -137,6 +138,8 @@ export class SceneRunner {
       console.log('')
     }
 
+    dashboardSend({ type: 'run:start', timestamp: Date.now(), sceneCount: sceneRegistry.length })
+
     for (const registered of sceneRegistry) {
       // Run beforeEach hook
       if (this.config.beforeEach) {
@@ -161,6 +164,14 @@ export class SceneRunner {
           const resolvedTeam = this.teamManager.getTeam(teamIndex)
           const server = this.config.server as Record<string, unknown> | undefined
           const testStart = new Date().toISOString()
+
+          dashboardSend({
+            type: 'scene:start',
+            timestamp: Date.now(),
+            name: registered.name,
+            file: relativeFile,
+            actors: registered.roles || [],
+          })
 
           // Run pre-cleanup if configured
           await runCleanup(registered, resolvedTeam.actors, resolvedTeam.meta, server, testStart)
@@ -189,6 +200,15 @@ export class SceneRunner {
           if (this.config.afterEach) {
             await this.config.afterEach({ name: registered.name, file: registered.file }, report)
           }
+
+          dashboardSend({
+            type: 'scene:end',
+            timestamp: Date.now(),
+            name: registered.name,
+            status: report.status,
+            duration: report.duration,
+            error: report.error,
+          })
 
           // Log progress
           const statusIcon = report.status === 'completed' ? '✓' : report.status === 'timeout' ? '⏱' : '✗'
@@ -250,6 +270,13 @@ export class SceneRunner {
         consoleErrors: totalConsoleErrors,
       },
     }
+
+    dashboardSend({
+      type: 'run:end',
+      timestamp: Date.now(),
+      duration: report.duration,
+      summary: report.summary,
+    })
 
     // Record run for swarm trigger evaluation
     if (this.swarmTrigger) {
@@ -364,6 +391,13 @@ export class SceneRunner {
     await this.loadScenes(sceneFiles)
 
     console.log(`Found ${sceneRegistry.length} scene(s)\n`)
+
+    // Set up live dashboard reporter if we have a baseUrl
+    if (this.config.baseUrl) {
+      const reporter = new DashboardReporter(this.config.baseUrl)
+      setDashboardReporter(reporter)
+      console.log(`Dashboard: ${reporter.dashboardUrl}\n`)
+    }
 
     return this.runAll()
   }

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -8,6 +8,7 @@ import { NavigationModeRotation } from './keyboard.js'
 import { DeviceRotation } from './devices.js'
 import { SequentialActorHandleImpl } from './actor.js'
 import { MessageBus } from './message-bus.js'
+import { dashboardSend } from './dashboard-reporter.js'
 
 /**
  * Manages team assignment and lifecycle.
@@ -432,6 +433,14 @@ export class TeamSession {
         ...(navigationMode ? { navigationMode } : {}),
       }
       this.assertions.push(enriched)
+
+      dashboardSend({
+        type: 'assertion',
+        timestamp: result.timestamp || Date.now(),
+        actor: role,
+        description: result.description,
+        result: result.result,
+      })
     })
 
     // Wire console error listener
@@ -485,6 +494,14 @@ export class TeamSession {
       await page.exposeFunction('__scenetest_report', (result: AssertionResult) => {
         const enriched = { ...result, actor: role, ...(deviceName ? { device: deviceName } : {}) }
         this.assertions.push(enriched)
+
+        dashboardSend({
+          type: 'assertion',
+          timestamp: result.timestamp || Date.now(),
+          actor: role,
+          description: result.description,
+          result: result.result,
+        })
       })
 
       // Wire console error listener

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -421,6 +421,22 @@ export interface ErrorSelector {
   message: string
 }
 
+// ─── Dashboard Event Types ──────────────────────────────────────────
+
+/**
+ * Events streamed from the CLI runner to the Vite dev server
+ * for the live dashboard at /__scenetest/dashboard.
+ */
+export type DashboardEvent =
+  | { type: 'run:start'; timestamp: number; sceneCount: number }
+  | { type: 'scene:start'; timestamp: number; name: string; file: string; actors: string[] }
+  | { type: 'action:start'; timestamp: number; actor: string; action: string; target?: string }
+  | { type: 'action:end'; timestamp: number; actor: string; action: string; target?: string; duration: number; error?: string }
+  | { type: 'assertion'; timestamp: number; actor?: string; description: string; result: boolean }
+  | { type: 'warning'; timestamp: number; actor: string; selector: string; message: string }
+  | { type: 'scene:end'; timestamp: number; name: string; status: string; duration: number; error?: string }
+  | { type: 'run:end'; timestamp: number; duration: number; summary: RunReport['summary'] }
+
 // ─── Swarm Mode Types ────────────────────────────────────────────────
 
 /**

--- a/packages/vite-plugin/src/dashboard.ts
+++ b/packages/vite-plugin/src/dashboard.ts
@@ -1,0 +1,661 @@
+/**
+ * Self-contained HTML dashboard page with swim-lane timeline.
+ * Connects to /__scenetest/events via SSE for real-time updates.
+ */
+export function generateDashboardHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scenetest Dashboard</title>
+  <style>
+    :root {
+      --bg: #0f1117;
+      --bg2: #1a1d27;
+      --bg3: #252833;
+      --border: #2e3140;
+      --text: #e1e4ed;
+      --text2: #8b8fa3;
+      --green: #22c55e;
+      --red: #ef4444;
+      --amber: #f59e0b;
+      --blue: #3b82f6;
+      --purple: #8b5cf6;
+      --cyan: #06b6d4;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+    }
+
+    header {
+      padding: 16px 24px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      background: var(--bg2);
+    }
+
+    header h1 {
+      font-size: 16px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .logo {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border-radius: 6px;
+      background: rgba(80, 70, 229, 0.15);
+      box-shadow: inset 0 1px 4px rgba(80, 70, 229, 0.3);
+      font-size: 14px;
+    }
+
+    .status-bar {
+      display: flex;
+      gap: 16px;
+      margin-left: auto;
+      font-size: 13px;
+    }
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .stat .label { color: var(--text2); }
+    .stat .value { font-weight: 600; }
+    .stat.pass .value { color: var(--green); }
+    .stat.fail .value { color: var(--red); }
+
+    .connection {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--amber);
+      transition: background 0.3s;
+    }
+    .connection.connected { background: var(--green); }
+    .connection.disconnected { background: var(--red); }
+
+    main {
+      padding: 24px;
+    }
+
+    .waiting {
+      text-align: center;
+      padding: 80px 24px;
+      color: var(--text2);
+    }
+
+    .waiting h2 {
+      font-size: 18px;
+      font-weight: 500;
+      margin-bottom: 8px;
+    }
+
+    .waiting p {
+      font-size: 13px;
+    }
+
+    /* ─── Scene sections ──────────────────────────────── */
+    .scene-section {
+      margin-bottom: 32px;
+    }
+
+    .scene-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      background: var(--bg2);
+      border: 1px solid var(--border);
+      border-radius: 8px 8px 0 0;
+      font-size: 13px;
+    }
+
+    .scene-header .icon {
+      font-size: 14px;
+    }
+
+    .scene-header .name {
+      font-weight: 600;
+    }
+
+    .scene-header .file {
+      color: var(--text2);
+      margin-left: auto;
+      font-size: 12px;
+    }
+
+    .scene-header .duration {
+      color: var(--text2);
+      font-size: 12px;
+    }
+
+    /* ─── Swim lanes ──────────────────────────────────── */
+    .swim-lanes {
+      border: 1px solid var(--border);
+      border-top: none;
+      border-radius: 0 0 8px 8px;
+      overflow: hidden;
+    }
+
+    .lane {
+      display: flex;
+      align-items: stretch;
+      border-bottom: 1px solid var(--border);
+      min-height: 48px;
+    }
+
+    .lane:last-child {
+      border-bottom: none;
+    }
+
+    .lane-label {
+      width: 120px;
+      min-width: 120px;
+      padding: 8px 14px;
+      background: var(--bg2);
+      border-right: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--cyan);
+    }
+
+    .lane-track {
+      flex: 1;
+      position: relative;
+      padding: 6px 8px;
+      min-height: 48px;
+      overflow: hidden;
+    }
+
+    .action-bar {
+      display: inline-flex;
+      align-items: center;
+      height: 28px;
+      margin: 3px 2px;
+      padding: 0 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      white-space: nowrap;
+      position: relative;
+      transition: opacity 0.2s;
+      cursor: default;
+    }
+
+    .action-bar.success {
+      background: rgba(34, 197, 94, 0.15);
+      border: 1px solid rgba(34, 197, 94, 0.3);
+      color: var(--green);
+    }
+
+    .action-bar.error {
+      background: rgba(239, 68, 68, 0.15);
+      border: 1px solid rgba(239, 68, 68, 0.3);
+      color: var(--red);
+    }
+
+    .action-bar.running {
+      background: rgba(59, 130, 246, 0.15);
+      border: 1px solid rgba(59, 130, 246, 0.3);
+      color: var(--blue);
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    .action-bar.slow {
+      background: rgba(245, 158, 11, 0.15);
+      border: 1px solid rgba(245, 158, 11, 0.3);
+      color: var(--amber);
+    }
+
+    .action-bar .duration {
+      margin-left: 6px;
+      opacity: 0.7;
+      font-size: 10px;
+    }
+
+    .action-bar:hover::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: calc(100% + 4px);
+      left: 0;
+      background: var(--bg3);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 4px 8px;
+      font-size: 11px;
+      white-space: nowrap;
+      z-index: 10;
+      color: var(--text);
+    }
+
+    /* ─── Assertion markers ───────────────────────────── */
+    .assertion-marker {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      margin: 7px 1px;
+      border-radius: 3px;
+      font-size: 10px;
+      cursor: default;
+    }
+
+    .assertion-marker.pass {
+      background: rgba(34, 197, 94, 0.2);
+      color: var(--green);
+    }
+
+    .assertion-marker.fail {
+      background: rgba(239, 68, 68, 0.2);
+      color: var(--red);
+    }
+
+    /* ─── Time ruler ──────────────────────────────────── */
+    .time-ruler {
+      display: flex;
+      align-items: stretch;
+      border-bottom: 1px solid var(--border);
+      height: 24px;
+      background: var(--bg2);
+    }
+
+    .time-ruler .lane-label {
+      height: 24px;
+      min-height: 24px;
+    }
+
+    .time-ruler .ruler-track {
+      flex: 1;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .tick {
+      position: absolute;
+      top: 0;
+      height: 100%;
+      border-left: 1px solid var(--border);
+      font-size: 9px;
+      color: var(--text2);
+      padding-left: 4px;
+      line-height: 24px;
+    }
+
+    /* ─── Event log ───────────────────────────────────── */
+    .event-log {
+      margin-top: 24px;
+    }
+
+    .event-log h3 {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: var(--text2);
+    }
+
+    .log-entry {
+      font-size: 12px;
+      padding: 3px 0;
+      color: var(--text2);
+      display: flex;
+      gap: 8px;
+    }
+
+    .log-entry .ts {
+      color: var(--text2);
+      opacity: 0.6;
+      min-width: 70px;
+    }
+
+    .log-entry .actor {
+      color: var(--cyan);
+      min-width: 80px;
+    }
+
+    .log-entry .msg { color: var(--text); }
+    .log-entry.error .msg { color: var(--red); }
+    .log-entry.pass .msg { color: var(--green); }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.6; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1><span class="logo">S</span> Scenetest Dashboard</h1>
+    <div class="status-bar">
+      <div class="stat scenes">
+        <span class="label">Scenes:</span>
+        <span class="value" id="scene-count">0</span>
+      </div>
+      <div class="stat pass">
+        <span class="label">Pass:</span>
+        <span class="value" id="pass-count">0</span>
+      </div>
+      <div class="stat fail">
+        <span class="label">Fail:</span>
+        <span class="value" id="fail-count">0</span>
+      </div>
+      <div class="stat">
+        <span class="label">Time:</span>
+        <span class="value" id="elapsed">-</span>
+      </div>
+      <div class="connection" id="connection" title="SSE connection"></div>
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="waiting" id="waiting">
+      <h2>Waiting for scene run...</h2>
+      <p>Run <code>scenetest</code> to see the live timeline here.</p>
+    </div>
+    <div id="scenes"></div>
+  </main>
+
+  <script>
+    // ─── State ────────────────────────────────────────
+    const state = {
+      scenes: [],       // { name, file, actors, actions: Map<actor, []>, assertions: [], startTime, endTime, status }
+      currentScene: null,
+      runStartTime: null,
+      passCount: 0,
+      failCount: 0,
+      sceneCount: 0,
+    }
+
+    // ─── SSE Connection ───────────────────────────────
+    const evtSource = new EventSource('/__scenetest/events')
+    const connEl = document.getElementById('connection')
+
+    evtSource.onopen = () => {
+      connEl.classList.add('connected')
+      connEl.classList.remove('disconnected')
+      connEl.title = 'Connected'
+    }
+
+    evtSource.onerror = () => {
+      connEl.classList.add('disconnected')
+      connEl.classList.remove('connected')
+      connEl.title = 'Disconnected — retrying...'
+    }
+
+    evtSource.onmessage = (e) => {
+      try {
+        const event = JSON.parse(e.data)
+        handleEvent(event)
+      } catch {}
+    }
+
+    // ─── Event handling ───────────────────────────────
+    function handleEvent(event) {
+      switch (event.type) {
+        case 'run:start':
+          // Clear previous run
+          state.scenes = []
+          state.currentScene = null
+          state.runStartTime = event.timestamp
+          state.passCount = 0
+          state.failCount = 0
+          state.sceneCount = event.sceneCount
+          document.getElementById('waiting').style.display = 'none'
+          document.getElementById('scenes').innerHTML = ''
+          updateStats()
+          break
+
+        case 'scene:start': {
+          const scene = {
+            name: event.name,
+            file: event.file,
+            actors: event.actors || [],
+            actions: new Map(),
+            assertions: [],
+            startTime: event.timestamp,
+            endTime: null,
+            status: 'running',
+          }
+          // Initialize lanes for declared actors
+          for (const actor of scene.actors) {
+            scene.actions.set(actor, [])
+          }
+          state.scenes.push(scene)
+          state.currentScene = scene
+          renderScene(scene)
+          break
+        }
+
+        case 'action:start': {
+          const scene = state.currentScene
+          if (!scene) break
+          // Ensure lane exists for this actor
+          if (!scene.actions.has(event.actor)) {
+            scene.actions.set(event.actor, [])
+            scene.actors.push(event.actor)
+          }
+          const actions = scene.actions.get(event.actor)
+          actions.push({
+            action: event.action,
+            target: event.target,
+            startTime: event.timestamp,
+            endTime: null,
+            duration: null,
+            error: null,
+            status: 'running',
+          })
+          renderScene(scene)
+          break
+        }
+
+        case 'action:end': {
+          const scene = state.currentScene
+          if (!scene) break
+          const actions = scene.actions.get(event.actor)
+          if (!actions) break
+          // Find the running action (last one that matches)
+          for (let i = actions.length - 1; i >= 0; i--) {
+            if (actions[i].status === 'running' && actions[i].action === event.action) {
+              actions[i].endTime = event.timestamp
+              actions[i].duration = event.duration
+              actions[i].error = event.error || null
+              actions[i].status = event.error ? 'error' : (event.duration > 500 ? 'slow' : 'success')
+              break
+            }
+          }
+          renderScene(scene)
+          break
+        }
+
+        case 'assertion': {
+          const scene = state.currentScene
+          if (!scene) break
+          scene.assertions.push({
+            actor: event.actor,
+            description: event.description,
+            result: event.result,
+            timestamp: event.timestamp,
+          })
+          if (event.result) state.passCount++
+          else state.failCount++
+          updateStats()
+          renderScene(scene)
+          break
+        }
+
+        case 'scene:end': {
+          const scene = state.currentScene
+          if (!scene) break
+          scene.endTime = event.timestamp
+          scene.status = event.status
+          scene.duration = event.duration
+          scene.error = event.error
+          state.currentScene = null
+          renderScene(scene)
+          updateStats()
+          break
+        }
+
+        case 'run:end':
+          state.sceneCount = event.summary?.scenes || state.sceneCount
+          state.passCount = event.summary?.assertions?.passed || state.passCount
+          state.failCount = event.summary?.assertions?.failed || state.failCount
+          document.getElementById('elapsed').textContent = event.duration + 'ms'
+          updateStats()
+          break
+      }
+    }
+
+    // ─── Stats ────────────────────────────────────────
+    function updateStats() {
+      const completed = state.scenes.filter(s => s.status !== 'running').length
+      document.getElementById('scene-count').textContent =
+        completed + '/' + state.sceneCount
+      document.getElementById('pass-count').textContent = state.passCount
+      document.getElementById('fail-count').textContent = state.failCount
+
+      if (state.runStartTime && state.scenes.some(s => s.status === 'running')) {
+        document.getElementById('elapsed').textContent =
+          (Date.now() - state.runStartTime) + 'ms'
+      }
+    }
+
+    // Update elapsed timer
+    setInterval(() => {
+      if (state.runStartTime && state.scenes.some(s => s.status === 'running')) {
+        document.getElementById('elapsed').textContent =
+          (Date.now() - state.runStartTime) + 'ms'
+      }
+    }, 200)
+
+    // ─── Rendering ────────────────────────────────────
+    function renderScene(scene) {
+      const idx = state.scenes.indexOf(scene)
+      let el = document.getElementById('scene-' + idx)
+      if (!el) {
+        el = document.createElement('div')
+        el.id = 'scene-' + idx
+        el.className = 'scene-section'
+        document.getElementById('scenes').appendChild(el)
+      }
+
+      const statusIcon = scene.status === 'completed' ? '\\u2713'
+        : scene.status === 'failed' ? '\\u2717'
+        : scene.status === 'timeout' ? '\\u23F1'
+        : '\\u25B6'
+
+      const statusColor = scene.status === 'completed' ? 'var(--green)'
+        : scene.status === 'failed' || scene.status === 'timeout' ? 'var(--red)'
+        : 'var(--blue)'
+
+      const durationStr = scene.duration ? scene.duration + 'ms' : 'running...'
+
+      // Build swim lanes
+      let lanesHtml = ''
+      const actors = Array.from(scene.actions.keys())
+
+      // Calculate time range for positioning
+      let minTime = scene.startTime
+      let maxTime = scene.endTime || Date.now()
+      for (const actions of scene.actions.values()) {
+        for (const a of actions) {
+          if (a.endTime && a.endTime > maxTime) maxTime = a.endTime
+        }
+      }
+      const timeSpan = Math.max(maxTime - minTime, 1)
+
+      // Time ruler
+      const tickCount = 5
+      let rulerHtml = ''
+      for (let i = 0; i <= tickCount; i++) {
+        const pct = (i / tickCount) * 100
+        const ms = Math.round((i / tickCount) * timeSpan)
+        rulerHtml += '<div class="tick" style="left: ' + pct + '%">' + formatMs(ms) + '</div>'
+      }
+
+      for (const actor of actors) {
+        const actions = scene.actions.get(actor) || []
+        let barsHtml = ''
+
+        for (const a of actions) {
+          const offsetPct = ((a.startTime - minTime) / timeSpan) * 100
+          const durMs = a.duration || (Date.now() - a.startTime)
+          const widthPct = Math.max((durMs / timeSpan) * 100, 2)
+
+          const cls = a.status
+          const label = a.action + (a.target ? '(' + escapeHtml(a.target) + ')' : '')
+          const durLabel = a.duration ? formatMs(a.duration) : '...'
+          const tooltip = label + ' — ' + durLabel + (a.error ? ' — ' + escapeHtml(a.error) : '')
+
+          barsHtml += '<div class="action-bar ' + cls + '" ' +
+            'style="position:absolute; left:' + offsetPct + '%; width:' + widthPct + '%;" ' +
+            'data-tooltip="' + escapeHtml(tooltip) + '">' +
+            '<span class="name">' + escapeHtml(a.action) + '</span>' +
+            (a.duration ? '<span class="duration">' + formatMs(a.duration) + '</span>' : '') +
+            '</div>'
+        }
+
+        // Assertion markers for this actor
+        const actorAssertions = scene.assertions.filter(a => a.actor === actor)
+        for (const a of actorAssertions) {
+          const offsetPct = ((a.timestamp - minTime) / timeSpan) * 100
+          const cls = a.result ? 'pass' : 'fail'
+          const icon = a.result ? '\\u2713' : '\\u2717'
+          barsHtml += '<div class="assertion-marker ' + cls + '" ' +
+            'style="position:absolute; left:' + offsetPct + '%; top:50%; transform:translateY(-50%);" ' +
+            'title="' + escapeHtml(a.description) + '">' + icon + '</div>'
+        }
+
+        lanesHtml += '<div class="lane">' +
+          '<div class="lane-label">' + escapeHtml(actor) + '</div>' +
+          '<div class="lane-track" style="position:relative;">' + barsHtml + '</div>' +
+          '</div>'
+      }
+
+      el.innerHTML =
+        '<div class="scene-header">' +
+          '<span class="icon" style="color:' + statusColor + '">' + statusIcon + '</span>' +
+          '<span class="name">' + escapeHtml(scene.name) + '</span>' +
+          '<span class="file">' + escapeHtml(scene.file || '') + '</span>' +
+          '<span class="duration">' + durationStr + '</span>' +
+        '</div>' +
+        '<div class="swim-lanes">' +
+          '<div class="time-ruler">' +
+            '<div class="lane-label" style="font-size:10px;color:var(--text2)">time</div>' +
+            '<div class="ruler-track">' + rulerHtml + '</div>' +
+          '</div>' +
+          lanesHtml +
+        '</div>'
+    }
+
+    function formatMs(ms) {
+      if (ms < 1000) return ms + 'ms'
+      return (ms / 1000).toFixed(1) + 's'
+    }
+
+    function escapeHtml(str) {
+      if (!str) return ''
+      return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+    }
+  </script>
+</body>
+</html>`
+}

--- a/packages/vite-plugin/src/event-hub.ts
+++ b/packages/vite-plugin/src/event-hub.ts
@@ -1,0 +1,69 @@
+import type { ServerResponse } from 'http'
+
+/**
+ * Simple SSE fan-out hub for dashboard events.
+ *
+ * - POST handler pushes events to all connected SSE clients
+ * - GET handler registers an SSE connection
+ * - Keeps a ring buffer of recent events so late-joining clients catch up
+ */
+
+interface DashboardEvent {
+  type: string
+  timestamp: number
+  [key: string]: unknown
+}
+
+const MAX_BUFFER_SIZE = 2000
+
+export class EventHub {
+  private clients = new Set<ServerResponse>()
+  private buffer: DashboardEvent[] = []
+
+  /** Register an SSE client connection. */
+  addClient(res: ServerResponse): void {
+    // Set up SSE headers
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Access-Control-Allow-Origin': '*',
+    })
+
+    // Send buffered events so late joiners catch up
+    for (const event of this.buffer) {
+      res.write(`data: ${JSON.stringify(event)}\n\n`)
+    }
+
+    this.clients.add(res)
+
+    // Clean up on disconnect
+    res.on('close', () => {
+      this.clients.delete(res)
+    })
+  }
+
+  /** Broadcast an event to all connected clients and buffer it. */
+  push(event: DashboardEvent): void {
+    // Buffer for late joiners
+    this.buffer.push(event)
+    if (this.buffer.length > MAX_BUFFER_SIZE) {
+      this.buffer = this.buffer.slice(-MAX_BUFFER_SIZE)
+    }
+
+    // Fan out to all connected SSE clients
+    const data = `data: ${JSON.stringify(event)}\n\n`
+    for (const client of this.clients) {
+      client.write(data)
+    }
+  }
+
+  /** Clear the buffer (e.g., on new run). */
+  clear(): void {
+    this.buffer = []
+  }
+
+  get clientCount(): number {
+    return this.clients.size
+  }
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -363,6 +363,7 @@ import '${OBSERVER_MODULE}';`,
         console.log(`[vite-plugin-scenetest] ${mode} mode - scenetest assertions active`)
         if (showDevPanel) {
           console.log('[vite-plugin-scenetest] Dev panel enabled - open your app to see assertions')
+          console.log('[vite-plugin-scenetest] Live dashboard available at /__scenetest/dashboard')
         }
         if (showRecorder) {
           console.log('[vite-plugin-scenetest] Scene recorder enabled - record interactions as DSL')

--- a/packages/vite-plugin/src/middleware.ts
+++ b/packages/vite-plugin/src/middleware.ts
@@ -3,6 +3,8 @@ import type { AssertionRpcPayload, AssertionRpcResponse, AssertionResult, Server
 import { AsyncLocalStorage } from 'async_hooks'
 import { RESOLVED_VIRTUAL_MODULE_ID } from './virtual-module.js'
 import { loadConfig } from './config.js'
+import { EventHub } from './event-hub.js'
+import { generateDashboardHtml } from './dashboard.js'
 
 /**
  * AsyncLocalStorage for collecting assertion results within a serverFn execution
@@ -54,8 +56,48 @@ export function failed(description: string, context?: Record<string, unknown>): 
  * or networks. See README.md "Security Considerations" for details.
  */
 export function createScenetestMiddleware(server: ViteDevServer, root: string): Connect.NextHandleFunction {
+  const eventHub = new EventHub()
+
   return async (req, res, next) => {
-    // Only handle POST /__scenetest/run
+    // ── Dashboard page ──────────────────────────────────────
+    if (req.method === 'GET' && req.url === '/__scenetest/dashboard') {
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/html; charset=utf-8')
+      res.end(generateDashboardHtml())
+      return
+    }
+
+    // ── SSE event stream ────────────────────────────────────
+    if (req.method === 'GET' && req.url === '/__scenetest/events') {
+      eventHub.addClient(res)
+      return
+    }
+
+    // ── Receive events from CLI runner ──────────────────────
+    if (req.method === 'POST' && req.url === '/__scenetest/events') {
+      let body = ''
+      for await (const chunk of req) {
+        body += chunk
+      }
+
+      try {
+        const event = JSON.parse(body)
+        // Clear buffer on new run so the dashboard starts fresh
+        if (event.type === 'run:start') {
+          eventHub.clear()
+        }
+        eventHub.push(event)
+      } catch {
+        // Ignore malformed events
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end('{"ok":true}')
+      return
+    }
+
+    // ── Assertion RPC (existing) ────────────────────────────
     if (req.method !== 'POST' || req.url !== '/__scenetest/run') {
       return next()
     }


### PR DESCRIPTION
## Summary

Adds a live dashboard that streams scene execution events in real-time to a browser-based swim-lane timeline. The dashboard connects to the Vite dev server via Server-Sent Events (SSE) and displays actions, assertions, and timing data as scenes run.

## Key Changes

- **Dashboard UI** (`packages/vite-plugin/src/dashboard.ts`): Self-contained HTML page with dark theme, swim lanes per actor, action bars with color-coded status (running/success/slow/error), assertion markers, and a time ruler. Connects to `/__scenetest/events` via SSE for real-time updates.

- **Event Hub** (`packages/vite-plugin/src/event-hub.ts`): Simple SSE fan-out system that:
  - Registers SSE client connections on `GET /__scenetest/events`
  - Receives events from the CLI runner on `POST /__scenetest/events`
  - Maintains a ring buffer (2000 events) so late-joining clients catch up
  - Broadcasts events to all connected clients

- **Dashboard Reporter** (`packages/scenes/src/dashboard-reporter.ts`): Fire-and-forget HTTP client that posts timeline events to the Vite dev server. Non-blocking; silently drops events if the server isn't running or lacks the plugin.

- **Event Emission**: Integrated dashboard event sending throughout the execution pipeline:
  - `runner.ts`: Emits `run:start` and `scene:start/end` events
  - `actor.ts`: Emits `action:start/end` events from sequential action chains
  - `reactive.ts`: Emits `action:start/end` events from concurrent actor handles
  - `team-manager.ts`: Emits `assertion` events when checks fire

- **Middleware Integration** (`packages/vite-plugin/src/middleware.ts`): Added routes for dashboard page and SSE stream; receives and fans out events from the runner.

- **Type Definitions** (`packages/scenes/src/types.ts`): Added `DashboardEvent` union type covering all event kinds (run, scene, action, assertion).

- **Documentation** (`docs/public/reference/live-dashboard.md`): Comprehensive guide covering quick start, architecture, UI components, event types, late joining, and relationship to static reports.

## Implementation Details

- Dashboard URL is printed to terminal when scenes start and accessible via the dev panel
- Events flow through both sequential (`test()`) and concurrent (`scene()`) execution models
- Zero impact on test execution—all sends are non-blocking with 2s timeout
- Vite plugin routes are dev-mode only and excluded from production builds
- Connection indicator in header shows real-time SSE status (green/amber/red)
- Action bars positioned by timestamp with hover tooltips showing full details and errors
- Time ruler auto-scales based on scene duration

https://claude.ai/code/session_01Ndt3eGxXU89BjiB1eqasYe