### PR TITLE
Add #N nth-element selector syntax for robust element selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## [0.6.0] — 2026-04-10
+
+### New features
+
+#### `#N` nth-element selector syntax
+
+Selectors can now include a `#N` token (1-based) to pick the Nth matching element instead of relying on brittle identifiers like UUIDs from seed data:
+
+```markdown
+user:
+- click feed-phrase-link #1
+```
+
+Works mid-chain too — narrow first, then descend:
+
+```markdown
+user:
+- see table-row #2
+- click delete-button
+```
+
+Or inline: `click table-row #2 delete-button`.
+
+Available everywhere selectors are used: `.spec.md`, text DSL, and TypeScript API.
+
+#### Browser console error detection
+
+`console.error` messages (and optionally `console.warn`) from the browser are now captured during scene execution and surfaced in the CLI output per-scene and in the run summary. Controlled via the `consoleErrors` config option:
+
+```ts
+export default defineConfig({
+  consoleErrors: true,       // capture console.error (default)
+  consoleErrors: 'warn',    // also capture console.warn
+  consoleErrors: false,      // disable entirely
+})
+```
+
+#### Uncaught JS exception capture
+
+Uncaught exceptions and unhandled promise rejections (`page.on('pageerror')`) are now captured alongside console errors. A `source` field (`'console'` | `'pageerror'`) distinguishes them in reports so the CLI can label them distinctly (e.g. `"uncaught: TypeError: ..."`).
+
+### Types
+
+- New `ConsoleError` type with `message`, `actor`, `timestamp`, `type` (`'error'` | `'warning'`), `source` (`'console'` | `'pageerror'`), and `url` fields
+- `SceneReport` and `RunReport` now include `consoleErrors` arrays and summary counts
+
+---
+
 ## [0.5.0] — 2026-04-09
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,10 +60,21 @@ export default defineConfig({
 
 CLI output labels these as `error-selector(...)` alongside `console.error`, `console.warn`, and `uncaught` entries.
 
+#### Live dashboard at `/__scenetest/dashboard`
+
+The CLI runner now streams real-time events to the Vite dev server, which fans them out to browser clients via SSE. Open `/__scenetest/dashboard` while scenes are running to see a swim-lane timeline with per-actor action bars, assertion markers, and durations — all updating live.
+
+- **DashboardReporter** in the runner posts events (scene start/end, action start/end, assertions, warnings) to Vite via fire-and-forget HTTP
+- **EventHub** in the Vite plugin manages SSE connections with a ring buffer so late-joining clients catch up
+- **Dashboard page** is self-contained HTML served by the plugin middleware
+- **Dev panel** now includes a "dashboard" link next to the fullscreen button
+- Graceful degradation: silently no-ops if the Vite server is unavailable
+
 ### Types
 
 - New `ConsoleError` type with `message`, `actor`, `timestamp`, `type` (`'error'` | `'warning'`), `source` (`'console'` | `'pageerror'` | `'selector'`), `url`, and optional `selector` fields
 - New `ErrorSelector` type (`{ selector, message }`)
+- New `DashboardEvent` union type for runner-to-dashboard event streaming
 - `SceneReport` and `RunReport` now include `consoleErrors` arrays and summary counts
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,25 @@ export default defineConfig({
 
 Uncaught exceptions and unhandled promise rejections (`page.on('pageerror')`) are now captured alongside console errors. A `source` field (`'console'` | `'pageerror'`) distinguishes them in reports so the CLI can label them distinctly (e.g. `"uncaught: TypeError: ..."`).
 
+#### `errorSelectors` config — detect error toasts via selectors
+
+New config option watches for visible error elements (toasts, alert banners) across all scenes and actors. When a matching element appears during action execution, a `ConsoleError` with `source: 'selector'` is recorded through the same reporting pipeline as console errors and uncaught exceptions:
+
+```ts
+export default defineConfig({
+  errorSelectors: [
+    { selector: '[role="alert"]', message: 'Unexpected error toast' },
+    { selector: '.toast-error',   message: 'Error toast appeared' },
+  ],
+})
+```
+
+CLI output labels these as `error-selector(...)` alongside `console.error`, `console.warn`, and `uncaught` entries.
+
 ### Types
 
-- New `ConsoleError` type with `message`, `actor`, `timestamp`, `type` (`'error'` | `'warning'`), `source` (`'console'` | `'pageerror'`), and `url` fields
+- New `ConsoleError` type with `message`, `actor`, `timestamp`, `type` (`'error'` | `'warning'`), `source` (`'console'` | `'pageerror'` | `'selector'`), `url`, and optional `selector` fields
+- New `ErrorSelector` type (`{ selector, message }`)
 - `SceneReport` and `RunReport` now include `consoleErrors` arrays and summary counts
 
 ---

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/docs",
-  "version": "0.3.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/packages/checks-panel/package.json
+++ b/packages/checks-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-panel",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Observer panel for scenetest - displays assertions in real-time",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-react/package.json
+++ b/packages/checks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-react",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "React bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-solid/package.json
+++ b/packages/checks-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-solid",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Solid bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-svelte/package.json
+++ b/packages/checks-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-svelte",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Svelte bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-vue/package.json
+++ b/packages/checks-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-vue",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Vue bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/eslint-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "ESLint plugin for scenetest - accessibility and testing best practices",
   "type": "module",
   "license": "MIT",

--- a/packages/playwright-scenetest/package.json
+++ b/packages/playwright-scenetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/playwright",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Playwright fixtures for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes-panel/package.json
+++ b/packages/scenes-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes-panel",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scene recorder for scenetest - records user interactions as DSL",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/src/__tests__/selectors.test.ts
+++ b/packages/scenes/src/__tests__/selectors.test.ts
@@ -213,4 +213,66 @@ describe('resolveSelector', () => {
       expect(firstCalls).toHaveLength(0)
     })
   })
+
+  describe('#N nth-element narrowing', () => {
+    it('#1 calls .nth(0) on the current locator', () => {
+      const { page, calls } = createMockPage()
+
+      resolveSelector(page, 'feed-phrase-link #1')
+
+      // Step 1: page.locator(token1CSS)
+      expect(calls[0]).toMatchObject({ method: 'locator', on: 'page' })
+      expect(calls[0].args[0]).toContain('[aria-label="feed-phrase-link"]')
+
+      // Step 2: .nth(0) — 1-based #1 maps to 0-based nth(0)
+      const nthCalls = calls.filter((c) => c.method === 'nth')
+      expect(nthCalls).toHaveLength(1)
+      expect(nthCalls[0].args[0]).toBe(0)
+
+      // No .first() or .or() calls
+      expect(calls.filter((c) => c.method === 'first')).toHaveLength(0)
+      expect(calls.filter((c) => c.method === 'or')).toHaveLength(0)
+    })
+
+    it('#3 calls .nth(2)', () => {
+      const { page, calls } = createMockPage()
+
+      resolveSelector(page, 'list-item #3')
+
+      const nthCalls = calls.filter((c) => c.method === 'nth')
+      expect(nthCalls).toHaveLength(1)
+      expect(nthCalls[0].args[0]).toBe(2)
+    })
+
+    it('#N in the middle narrows then continues descending', () => {
+      const { page, calls } = createMockPage()
+
+      resolveSelector(page, 'table-row #2 delete-button')
+
+      // Step 1: page.locator(table-row CSS)
+      expect(calls[0]).toMatchObject({ method: 'locator', on: 'page' })
+
+      // Step 2: .nth(1) for #2
+      const nthCalls = calls.filter((c) => c.method === 'nth')
+      expect(nthCalls).toHaveLength(1)
+      expect(nthCalls[0].args[0]).toBe(1)
+
+      // Step 3: descendant lookup for delete-button (xpath + CSS + .or())
+      const orCalls = calls.filter((c) => c.method === 'or')
+      expect(orCalls).toHaveLength(1)
+    })
+
+    it('#N does not trigger data-key or descendant matching', () => {
+      const { page, calls } = createMockPage()
+
+      resolveSelector(page, 'item #1')
+
+      // Should only have: locator (token1), nth — no xpath self-match, no descendant locator
+      const locatorCalls = calls.filter((c) => c.method === 'locator')
+      expect(locatorCalls).toHaveLength(1) // just the initial token
+
+      const nthCalls = calls.filter((c) => c.method === 'nth')
+      expect(nthCalls).toHaveLength(1)
+    })
+  })
 })

--- a/packages/scenes/src/selectors.ts
+++ b/packages/scenes/src/selectors.ts
@@ -79,6 +79,12 @@ function resolveToken(base: Page | Locator, token: string): Locator {
 }
 
 /**
+ * Match a `#N` nth-element token (1-based index).
+ * Returns the parsed index (1-based) or null if the token doesn't match.
+ */
+const NTH_RE = /^#(\d+)$/
+
+/**
  * Resolve a space-separated selector string.
  *
  * Algorithm:
@@ -87,6 +93,10 @@ function resolveToken(base: Page | Locator, token: string): Locator {
  * 3. After matching, check if SAME element has data-key matching NEXT token
  *    - If yes: consume that token (it's a key match), continue with token after
  *    - If no: descend into children for next token
+ *
+ * Special token `#N` (e.g. `#1`, `#3`) narrows the current locator to the
+ * Nth match (1-based).  This avoids brittle selectors that hardcode dynamic
+ * values like UUIDs from seed data.
  *
  * @example
  * ```ts
@@ -100,6 +110,12 @@ function resolveToken(base: Page | Locator, token: string): Locator {
  * resolveSelector(page, 'playlist-row 12345 like-button')
  * // Finds playlist-row, checks if it has data-key="12345",
  * // if yes stays on same element, then finds like-button child
+ *
+ * // Nth element — click the first feed-phrase-link
+ * resolveSelector(page, 'feed-phrase-link #1')
+ *
+ * // Nth element with nesting — click delete in the 2nd row
+ * resolveSelector(page, 'table-row #2 delete-button')
  * ```
  */
 export function resolveSelector(base: Page | Locator, selector: string): Locator {
@@ -114,6 +130,18 @@ export function resolveSelector(base: Page | Locator, selector: string): Locator
 
   while (i < tokens.length) {
     const nextToken = tokens[i]
+
+    // Nth-element narrowing: #1, #2, etc. (1-based)
+    const nthMatch = NTH_RE.exec(nextToken)
+    if (nthMatch) {
+      const n = parseInt(nthMatch[1], 10)
+      if (n < 1) {
+        throw new Error(`#N index must be >= 1, got #${n}`)
+      }
+      locator = locator.nth(n - 1)
+      i++
+      continue
+    }
 
     // Same-element match: current element has data-key=nextToken (stay on it)
     const sameElement = locator.locator(`xpath=self::*[@data-key="${nextToken}"]`)

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -24,10 +24,15 @@ export type PageFactory = (device: DeviceProfile | null) => Promise<{ page: Page
  * Special behavior: after matching a token, if the SAME element has a data-key
  * matching the NEXT token, that token is consumed without descending.
  *
+ * A `#N` token (1-based) narrows the current matches to the Nth element.
+ * This avoids brittle selectors that hardcode dynamic values like UUIDs.
+ *
  * @example
- * 'button'                        // Simple selector
- * 'modal form submit-button'      // Nested: modal > form > submit-button
+ * 'button'                         // Simple selector
+ * 'modal form submit-button'       // Nested: modal > form > submit-button
  * 'playlist-row 12345 like-button' // If playlist-row has data-key="12345", stays on same element
+ * 'feed-phrase-link #1'            // Click the first feed-phrase-link
+ * 'table-row #2 delete-button'     // Delete button inside the 2nd table-row
  */
 export type Selector = string
 

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",

--- a/packages/vscode-scenetest/package.json
+++ b/packages/vscode-scenetest/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-scenetest",
   "displayName": "Scenetest",
   "description": "Syntax highlighting for Scenetest scene specs (.spec.md)",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "scenetest",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

This PR introduces the `#N` nth-element selector syntax to Scenetest, allowing users to select the Nth matching element (1-based) without relying on brittle identifiers like UUIDs from seed data.

## Key Changes

- **Nth-element selector syntax (`#N`)**: Added support for `#1`, `#2`, etc. tokens in selector strings to narrow the current locator to the Nth match using Playwright's `.nth()` method
  - Works standalone: `click feed-phrase-link #1`
  - Works mid-chain: `click table-row #2 delete-button`
  - Converts 1-based user input to 0-based `.nth()` calls internally
  - Validates that indices are >= 1

- **Selector resolution logic**: Updated `resolveSelector()` in `packages/scenes/src/selectors.ts` to:
  - Detect `#N` tokens via regex pattern `/^#(\d+)$/`
  - Apply `.nth(n - 1)` to the current locator before continuing with remaining tokens
  - Maintain proper token consumption order (nth narrowing doesn't trigger data-key or descendant matching)

- **Type documentation**: Enhanced `Selector` type documentation in `packages/scenes/src/types.ts` to explain the new syntax and provide usage examples

- **Test coverage**: Added comprehensive test suite in `packages/scenes/src/__tests__/selectors.test.ts` covering:
  - Basic nth narrowing (`#1`, `#3`)
  - Mid-chain narrowing with descendant continuation
  - Validation that nth tokens don't interfere with data-key or descendant matching

- **Version bump**: Updated all package versions from 0.5.0 to 0.6.0

## Implementation Details

The nth-element feature integrates seamlessly into the existing selector resolution pipeline:
1. Tokens are parsed left-to-right
2. When a `#N` token is encountered, it immediately applies `.nth(n - 1)` to the current locator
3. Resolution continues with subsequent tokens, allowing chaining like `table-row #2 delete-button`
4. The feature is available everywhere selectors are used (`.spec.md`, text DSL, TypeScript API)

https://claude.ai/code/session_012FgpSQ2oyMxMUKM7hirGmt