### PR TITLE
Add replay controls and progress tracking to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## [0.7.0] — 2026-04-11
+
+### Dashboard improvements
+
+#### Replay buttons — restart tests from the dashboard
+
+The dashboard now has a **Replay All** button in the header and a per-scene **Replay** button on each scene card. Clicking either triggers a new `scenetest` run via the Vite plugin middleware (`POST /__scenetest/replay`). Single-scene replay passes the scene's file path so only that test re-runs. Buttons are disabled while a run is in progress to prevent concurrent runs.
+
+#### Stop & Pause/Resume controls
+
+While tests are running, **Pause** and **Stop** buttons appear in the header:
+
+- **Pause** suspends the runner process (`SIGSTOP`) and toggles to **Resume** (`SIGCONT`)
+- **Stop** kills the runner process and resets the dashboard to idle
+
+#### Progress bar
+
+A thin 3px progress bar sits at the bottom edge of the sticky header, filling left-to-right as scenes complete. Blue while running, green on all-pass, red if any scene fails. Encodes the same information as the "Scenes: 2/5" counter but provides peripheral awareness without reading numbers.
+
+#### Auto-scroll to running scene
+
+When a new scene starts, the dashboard smoothly scrolls it into view so the active timeline stays visible without manual scrolling.
+
+#### Inline error messages
+
+Failed scenes now show a persistent error summary below the swim lanes — the action name and error message are always visible without hovering. The error block shares the bottom border-radius with the swim lanes so the card shape stays clean.
+
+#### Sticky header
+
+The dashboard header is now `position: sticky` so stats, replay controls, and the progress bar remain visible while scrolling through scenes.
+
+### Bug fixes
+
+#### Tooltip z-index on dashboard
+
+Action bar tooltips were clipped behind the time-ruler header row because both `.swim-lanes` and `.lane-track` had `overflow: hidden`. Removed the overflow clipping and bumped tooltip z-index so they render above sibling rows.
+
+---
+
 ## [0.6.0] — 2026-04-10
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Failed scenes now show a persistent error summary below the swim lanes — the a
 
 The dashboard header is now `position: sticky` so stats, replay controls, and the progress bar remain visible while scrolling through scenes.
 
+### Improvements
+
+#### `[role.field]` interpolation works for any team member
+
+Previously, referencing `[learner2.key]` in a `.spec.md` step required declaring an empty `learner2:` block in the scene just to bring the credentials into scope. Now interpolation falls back to the full team config, so any team member's fields are available without declaring them as actors. This applies to both `.spec.md` scenes and the TypeScript `flow()` API.
+
 ### Bug fixes
 
 #### Tooltip z-index on dashboard

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/docs",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/packages/checks-panel/package.json
+++ b/packages/checks-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-panel",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Observer panel for scenetest - displays assertions in real-time",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-react/package.json
+++ b/packages/checks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-react",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "React bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-solid/package.json
+++ b/packages/checks-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-solid",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Solid bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-svelte/package.json
+++ b/packages/checks-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-svelte",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Svelte bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-vue/package.json
+++ b/packages/checks-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-vue",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Vue bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/eslint-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "ESLint plugin for scenetest - accessibility and testing best practices",
   "type": "module",
   "license": "MIT",

--- a/packages/playwright-scenetest/package.json
+++ b/packages/playwright-scenetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/playwright",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Playwright fixtures for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes-panel/package.json
+++ b/packages/scenes-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes-panel",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Scene recorder for scenetest - records user interactions as DSL",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -19,7 +19,7 @@ const program = new Command()
 program
   .name('scenetest')
   .description('Run scenetest scene specs')
-  .version('0.1.0')
+  .version('0.7.0')
   .argument('[scenes...]', 'Scene files or directories to run')
   .option('--ui', 'Run in interactive UI mode')
   .option('--headed', 'Run with visible browser')

--- a/packages/scenes/src/markdown-scene.ts
+++ b/packages/scenes/src/markdown-scene.ts
@@ -60,7 +60,7 @@ import path from 'path'
 import type { ConcurrentActorHandle } from './types.js'
 import { parseAction, applyDslAction, getMacro } from './dsl.js'
 import { flow } from './reactive.js'
-import { sceneRegistry, setCurrentFile } from './scene.js'
+import { sceneRegistry, setCurrentFile, getCurrentSession } from './scene.js'
 
 // ---------------------------------------------------------------------------
 // Intermediate representation
@@ -386,6 +386,8 @@ interface InterpolationContext {
   team?: Record<string, string>
   /** Alias mappings from macros (alias -> role name) */
   aliases?: Map<string, string>
+  /** Full team actor configs — fallback for [role.field] when role isn't declared in scene */
+  teamActors?: Record<string, import('./types.js').ActorConfig>
 }
 
 /**
@@ -433,10 +435,11 @@ function interpolate(line: string, ctx: InterpolationContext): string {
       // Check for alias mapping first
       const resolvedRole = ctx.aliases?.get(namespace) ?? namespace
 
-      // Look up the actor
+      // Look up the actor — first from scene actors, then from full team
       const actor = ctx.actors.get(resolvedRole)
-      if (!actor) {
-        const available = [...ctx.actors.keys()].join(', ')
+      const config = actor ?? ctx.teamActors?.[resolvedRole]
+      if (!config) {
+        const available = [...new Set([...ctx.actors.keys(), ...Object.keys(ctx.teamActors ?? {})])].join(', ')
         const aliasNote = ctx.aliases?.has(namespace)
           ? ` (alias "${namespace}" -> "${resolvedRole}")`
           : ''
@@ -445,7 +448,7 @@ function interpolate(line: string, ctx: InterpolationContext): string {
         )
       }
 
-      const value = (actor as Record<string, unknown>)[field]
+      const value = (config as Record<string, unknown>)[field]
       if (value === undefined) {
         throw new Error(
           `Actor "${resolvedRole}" has no field "${field}" (available: id, username, email, password, ...)`
@@ -489,6 +492,11 @@ export function registerMarkdownScenes(
         }
       }
 
+      // Get full team config so [role.field] works for any team member,
+      // even actors not declared as blocks in this scene
+      const session = getCurrentSession()
+      const teamActors = session?.getTeamConfig()
+
       // ── Phase 2: apply actions to each actor block ──────────────────
       for (const block of mdScene.blocks) {
         const a = actors.get(block.alias || block.role)!
@@ -503,6 +511,7 @@ export function registerMarkdownScenes(
           actors,
           self: a,
           team: Object.keys(teamInterpolation).length > 0 ? teamInterpolation : undefined,
+          teamActors,
         }
 
         for (const action of block.actions) {

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -58,6 +58,7 @@ import type {
   FlowFn,
   SceneOptions,
   ConcurrentActorHandle,
+  TeamConfig,
   TeamMeta,
   PageFactory,
 } from './types.js'
@@ -187,6 +188,8 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   private _actorRegistry: Map<string, ConcurrentActorHandle> | null = null
   /** Team metadata for [team.field] interpolation */
   private _teamMetadata: Record<string, string> | null = null
+  /** Full team config — fallback for [role.field] when role isn't a scene actor */
+  private _teamConfig: TeamConfig | null = null
 
   constructor(
     role: string,
@@ -263,6 +266,13 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
    */
   _setTeamMetadata(metadata: Record<string, string>): void {
     this._teamMetadata = metadata
+  }
+
+  /**
+   * Set full team config for [role.field] fallback interpolation.
+   */
+  _setTeamConfig(config: TeamConfig): void {
+    this._teamConfig = config
   }
 
   /**
@@ -772,15 +782,15 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
           return escapeForSelector(String(value))
         }
 
-        // [role.field] — another actor's fields
+        // [role.field] — another actor's fields (scene actors first, then full team)
         if (!this._actorRegistry) {
           throw new Error(
             `[${namespace}.${field}] — cannot reference other actors outside a scene context`
           )
         }
-        const actor = this._actorRegistry.get(namespace)
+        const actor = this._actorRegistry.get(namespace) ?? this._teamConfig?.[namespace]
         if (!actor) {
-          const available = [...this._actorRegistry.keys()].join(', ')
+          const available = [...new Set([...this._actorRegistry.keys(), ...Object.keys(this._teamConfig ?? {})])].join(', ')
           throw new Error(
             `[${namespace}.${field}] — unknown actor "${namespace}" (available: ${available})`
           )
@@ -1268,9 +1278,11 @@ export function flow(name: string, fnOrOptions: FlowFn | SceneOptions, maybeFn?:
       await result
     }
 
-    // Set actor registry and team metadata on all actors for interpolation
+    // Set actor registry, team metadata, and full team config on all actors for interpolation
+    const teamConfig = session.getTeamConfig()
     for (const actor of reactiveActors) {
       actor._setActorRegistry(actorRegistry)
+      actor._setTeamConfig(teamConfig)
       if (Object.keys(teamMetadataForInterpolation).length > 0) {
         actor._setTeamMetadata(teamMetadataForInterpolation)
       }

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -359,6 +359,15 @@ export class TeamSession {
   }
 
   /**
+   * Get the full team config (all actor roles and their configs).
+   * Used for interpolation so `[role.field]` can reference any team
+   * member, not just actors declared in the scene.
+   */
+  getTeamConfig(): TeamConfig {
+    return this.team
+  }
+
+  /**
    * Get the navigation mode assigned to an actor role.
    * If rotation is enabled, assigns and caches a mode for this role.
    * If rotation is not enabled, returns 'pointer'.

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",

--- a/packages/vite-plugin/src/dashboard.ts
+++ b/packages/vite-plugin/src/dashboard.ts
@@ -174,6 +174,36 @@ export function generateDashboardHtml(): string {
       display: inline-flex;
     }
 
+    /* ─── Progress bar ───────────────────────────────── */
+    .progress-bar {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+      background: var(--border);
+      display: none;
+    }
+
+    .progress-bar.visible {
+      display: block;
+    }
+
+    .progress-bar .progress-fill {
+      height: 100%;
+      background: var(--blue);
+      transition: width 0.3s ease;
+      width: 0%;
+    }
+
+    .progress-bar.done .progress-fill {
+      background: var(--green);
+    }
+
+    .progress-bar.has-failures .progress-fill {
+      background: var(--red);
+    }
+
     main {
       padding: 24px;
     }
@@ -229,11 +259,44 @@ export function generateDashboardHtml(): string {
       font-size: 12px;
     }
 
+    /* ─── Scene errors ────────────────────────────────── */
+    .scene-errors {
+      border: 1px solid var(--border);
+      border-top: none;
+      background: rgba(239, 68, 68, 0.05);
+      padding: 8px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .scene-error-line {
+      font-size: 12px;
+      color: var(--red);
+      display: flex;
+      align-items: baseline;
+      gap: 8px;
+      line-height: 1.4;
+    }
+
+    .scene-error-line .error-icon {
+      flex-shrink: 0;
+      font-size: 10px;
+    }
+
+    .scene-error-line .error-action {
+      color: var(--text2);
+      flex-shrink: 0;
+    }
+
+    .scene-error-line .error-msg {
+      word-break: break-word;
+    }
+
     /* ─── Swim lanes ──────────────────────────────────── */
     .swim-lanes {
       border: 1px solid var(--border);
       border-top: none;
-      border-radius: 0 0 8px 8px;
     }
 
     .lane {
@@ -454,6 +517,7 @@ export function generateDashboardHtml(): string {
       </div>
       <div class="connection" id="connection" title="SSE connection"></div>
     </div>
+    <div class="progress-bar" id="progress-bar"><div class="progress-fill" id="progress-fill"></div></div>
   </header>
 
   <main id="main">
@@ -533,6 +597,9 @@ export function generateDashboardHtml(): string {
           state.scenes.push(scene)
           state.currentScene = scene
           renderScene(scene)
+          // Auto-scroll to keep the running scene visible
+          var sceneEl = document.getElementById('scene-' + (state.scenes.length - 1))
+          if (sceneEl) sceneEl.scrollIntoView({ behavior: 'smooth', block: 'start' })
           break
         }
 
@@ -628,6 +695,17 @@ export function generateDashboardHtml(): string {
       if (state.runStartTime && state.scenes.some(s => s.status === 'running')) {
         document.getElementById('elapsed').textContent =
           (Date.now() - state.runStartTime) + 'ms'
+      }
+
+      // Progress bar
+      var bar = document.getElementById('progress-bar')
+      var fill = document.getElementById('progress-fill')
+      if (state.sceneCount > 0) {
+        bar.classList.add('visible')
+        var pct = Math.round((completed / state.sceneCount) * 100)
+        fill.style.width = pct + '%'
+        bar.classList.toggle('done', completed === state.sceneCount && state.failCount === 0)
+        bar.classList.toggle('has-failures', state.failCount > 0)
       }
     }
 
@@ -726,6 +804,37 @@ export function generateDashboardHtml(): string {
       const replayDisabled = state.scenes.some(s => s.status === 'running') ? ' disabled' : ''
       const replayFileAttr = scene.file ? ' data-file="' + escapeHtml(scene.file) + '"' : ''
 
+      // Collect errors from failed actions and scene-level error
+      var errors = []
+      for (var _a of scene.actions.values()) {
+        for (var _act of _a) {
+          if (_act.error) {
+            errors.push({ action: _act.action, target: _act.target, msg: _act.error })
+          }
+        }
+      }
+      if (scene.error && !errors.some(function(e) { return e.msg === scene.error })) {
+        errors.push({ action: null, target: null, msg: scene.error })
+      }
+
+      var errorsHtml = ''
+      if (errors.length > 0) {
+        var lines = ''
+        for (var _e of errors) {
+          var actionLabel = _e.action
+            ? '<span class="error-action">' + escapeHtml(_e.action + (_e.target ? '(' + _e.target + ')' : '')) + '</span> '
+            : ''
+          lines += '<div class="scene-error-line">' +
+            '<span class="error-icon">\\u2717</span> ' +
+            actionLabel +
+            '<span class="error-msg">' + escapeHtml(_e.msg) + '</span>' +
+            '</div>'
+        }
+        errorsHtml = '<div class="scene-errors" style="border-radius: 0 0 8px 8px;">' + lines + '</div>'
+      }
+
+      var lanesRadius = errors.length > 0 ? '' : ' style="border-radius: 0 0 8px 8px;"'
+
       el.innerHTML =
         '<div class="scene-header">' +
           '<span class="icon" style="color:' + statusColor + '">' + statusIcon + '</span>' +
@@ -737,13 +846,14 @@ export function generateDashboardHtml(): string {
             '<span class="play-icon">&#9654;</span> Replay' +
           '</button>' +
         '</div>' +
-        '<div class="swim-lanes">' +
+        '<div class="swim-lanes"' + lanesRadius + '>' +
           '<div class="time-ruler">' +
             '<div class="lane-label" style="font-size:10px;color:var(--text2)">time</div>' +
             '<div class="ruler-track">' + rulerHtml + '</div>' +
           '</div>' +
           lanesHtml +
-        '</div>'
+        '</div>' +
+        errorsHtml
     }
 
     function formatMs(ms) {

--- a/packages/vite-plugin/src/dashboard.ts
+++ b/packages/vite-plugin/src/dashboard.ts
@@ -94,6 +94,51 @@ export function generateDashboardHtml(): string {
     .connection.connected { background: var(--green); }
     .connection.disconnected { background: var(--red); }
 
+    /* ─── Replay buttons ─────────────────────────────── */
+    .replay-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 4px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: transparent;
+      color: var(--text2);
+      font-family: inherit;
+      font-size: 12px;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    .replay-btn:hover {
+      background: rgba(59, 130, 246, 0.15);
+      border-color: var(--blue);
+      color: var(--blue);
+    }
+
+    .replay-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .replay-btn:disabled:hover {
+      background: transparent;
+      border-color: var(--border);
+      color: var(--text2);
+    }
+
+    .replay-btn .play-icon {
+      font-size: 10px;
+    }
+
+    .replay-all-btn {
+      margin-left: 12px;
+    }
+
+    .scene-replay-btn {
+      margin-left: auto;
+    }
+
     main {
       padding: 24px;
     }
@@ -346,6 +391,9 @@ export function generateDashboardHtml(): string {
 <body>
   <header>
     <h1><span class="logo">S</span> Scenetest Dashboard</h1>
+    <button class="replay-btn replay-all-btn" id="replay-all" onclick="replayAll()">
+      <span class="play-icon">&#9654;</span> Replay All
+    </button>
     <div class="status-bar">
       <div class="stat scenes">
         <span class="label">Scenes:</span>
@@ -422,6 +470,7 @@ export function generateDashboardHtml(): string {
           state.sceneCount = event.sceneCount
           document.getElementById('waiting').style.display = 'none'
           document.getElementById('scenes').innerHTML = ''
+          setReplayButtonsDisabled(true)
           updateStats()
           break
 
@@ -521,6 +570,7 @@ export function generateDashboardHtml(): string {
           state.passCount = event.summary?.assertions?.passed || state.passCount
           state.failCount = event.summary?.assertions?.failed || state.failCount
           document.getElementById('elapsed').textContent = event.duration + 'ms'
+          setReplayButtonsDisabled(false)
           updateStats()
           break
       }
@@ -632,12 +682,19 @@ export function generateDashboardHtml(): string {
           '</div>'
       }
 
+      const replayDisabled = state.scenes.some(s => s.status === 'running') ? ' disabled' : ''
+      const replayFileAttr = scene.file ? ' data-file="' + escapeHtml(scene.file) + '"' : ''
+
       el.innerHTML =
         '<div class="scene-header">' +
           '<span class="icon" style="color:' + statusColor + '">' + statusIcon + '</span>' +
           '<span class="name">' + escapeHtml(scene.name) + '</span>' +
           '<span class="file">' + escapeHtml(scene.file || '') + '</span>' +
           '<span class="duration">' + durationStr + '</span>' +
+          '<button class="replay-btn scene-replay-btn"' + replayFileAttr + replayDisabled +
+            ' onclick="replayScene(this)">' +
+            '<span class="play-icon">&#9654;</span> Replay' +
+          '</button>' +
         '</div>' +
         '<div class="swim-lanes">' +
           '<div class="time-ruler">' +
@@ -656,6 +713,37 @@ export function generateDashboardHtml(): string {
     function escapeHtml(str) {
       if (!str) return ''
       return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+    }
+
+    // ─── Replay controls ─────────────────────────────
+    function setReplayButtonsDisabled(disabled) {
+      document.querySelectorAll('.replay-btn').forEach(function(btn) {
+        btn.disabled = disabled
+      })
+    }
+
+    function replayAll() {
+      setReplayButtonsDisabled(true)
+      fetch('/__scenetest/replay', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      }).catch(function() {
+        setReplayButtonsDisabled(false)
+      })
+    }
+
+    function replayScene(btn) {
+      var file = btn.getAttribute('data-file')
+      if (!file) return
+      setReplayButtonsDisabled(true)
+      fetch('/__scenetest/replay', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file: file }),
+      }).catch(function() {
+        setReplayButtonsDisabled(false)
+      })
     }
   </script>
 </body>

--- a/packages/vite-plugin/src/dashboard.ts
+++ b/packages/vite-plugin/src/dashboard.ts
@@ -139,6 +139,41 @@ export function generateDashboardHtml(): string {
       margin-left: auto;
     }
 
+    .stop-btn, .pause-btn {
+      display: none;
+      align-items: center;
+      gap: 5px;
+      padding: 4px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: transparent;
+      color: var(--text2);
+      font-family: inherit;
+      font-size: 12px;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    .stop-btn:hover {
+      background: rgba(239, 68, 68, 0.15);
+      border-color: var(--red);
+      color: var(--red);
+    }
+
+    .pause-btn:hover {
+      background: rgba(245, 158, 11, 0.15);
+      border-color: var(--amber);
+      color: var(--amber);
+    }
+
+    .stop-btn .btn-icon, .pause-btn .btn-icon {
+      font-size: 10px;
+    }
+
+    .running .stop-btn, .running .pause-btn {
+      display: inline-flex;
+    }
+
     main {
       padding: 24px;
     }
@@ -394,6 +429,12 @@ export function generateDashboardHtml(): string {
     <button class="replay-btn replay-all-btn" id="replay-all" onclick="replayAll()">
       <span class="play-icon">&#9654;</span> Replay All
     </button>
+    <button class="pause-btn" id="pause-btn" onclick="togglePause()">
+      <span class="btn-icon" id="pause-icon">&#9646;&#9646;</span> <span id="pause-label">Pause</span>
+    </button>
+    <button class="stop-btn" id="stop-btn" onclick="stopRun()">
+      <span class="btn-icon">&#9632;</span> Stop
+    </button>
     <div class="status-bar">
       <div class="stat scenes">
         <span class="label">Scenes:</span>
@@ -470,7 +511,7 @@ export function generateDashboardHtml(): string {
           state.sceneCount = event.sceneCount
           document.getElementById('waiting').style.display = 'none'
           document.getElementById('scenes').innerHTML = ''
-          setReplayButtonsDisabled(true)
+          setRunning(true)
           updateStats()
           break
 
@@ -570,7 +611,7 @@ export function generateDashboardHtml(): string {
           state.passCount = event.summary?.assertions?.passed || state.passCount
           state.failCount = event.summary?.assertions?.failed || state.failCount
           document.getElementById('elapsed').textContent = event.duration + 'ms'
-          setReplayButtonsDisabled(false)
+          setRunning(false)
           updateStats()
           break
       }
@@ -715,35 +756,65 @@ export function generateDashboardHtml(): string {
       return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
     }
 
-    // ─── Replay controls ─────────────────────────────
-    function setReplayButtonsDisabled(disabled) {
+    // ─── Run controls ─────────────────────────────────
+    var isPaused = false
+
+    function setRunning(running) {
       document.querySelectorAll('.replay-btn').forEach(function(btn) {
-        btn.disabled = disabled
+        btn.disabled = running
       })
+      if (running) {
+        document.querySelector('header').classList.add('running')
+      } else {
+        document.querySelector('header').classList.remove('running')
+        isPaused = false
+        updatePauseButton()
+      }
+    }
+
+    function updatePauseButton() {
+      document.getElementById('pause-icon').innerHTML = isPaused ? '&#9654;' : '&#9646;&#9646;'
+      document.getElementById('pause-label').textContent = isPaused ? 'Resume' : 'Pause'
     }
 
     function replayAll() {
-      setReplayButtonsDisabled(true)
+      setRunning(true)
       fetch('/__scenetest/replay', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: '{}',
       }).catch(function() {
-        setReplayButtonsDisabled(false)
+        setRunning(false)
       })
     }
 
     function replayScene(btn) {
       var file = btn.getAttribute('data-file')
       if (!file) return
-      setReplayButtonsDisabled(true)
+      setRunning(true)
       fetch('/__scenetest/replay', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ file: file }),
       }).catch(function() {
-        setReplayButtonsDisabled(false)
+        setRunning(false)
       })
+    }
+
+    function stopRun() {
+      fetch('/__scenetest/stop', { method: 'POST' })
+        .then(function() { setRunning(false) })
+        .catch(function() { setRunning(false) })
+    }
+
+    function togglePause() {
+      fetch('/__scenetest/pause', { method: 'POST' })
+        .then(function(r) { return r.json() })
+        .then(function(data) {
+          isPaused = data.paused
+          updatePauseButton()
+        })
+        .catch(function() {})
     }
   </script>
 </body>

--- a/packages/vite-plugin/src/dashboard.ts
+++ b/packages/vite-plugin/src/dashboard.ts
@@ -35,12 +35,15 @@ export function generateDashboardHtml(): string {
     }
 
     header {
+      position: sticky;
+      top: 0;
       padding: 16px 24px;
       border-bottom: 1px solid var(--border);
       display: flex;
       align-items: center;
       gap: 16px;
       background: var(--bg2);
+      z-index: 100;
     }
 
     header h1 {
@@ -151,7 +154,6 @@ export function generateDashboardHtml(): string {
       border: 1px solid var(--border);
       border-top: none;
       border-radius: 0 0 8px 8px;
-      overflow: hidden;
     }
 
     .lane {
@@ -183,7 +185,6 @@ export function generateDashboardHtml(): string {
       position: relative;
       padding: 6px 8px;
       min-height: 48px;
-      overflow: hidden;
     }
 
     .action-bar {
@@ -242,8 +243,9 @@ export function generateDashboardHtml(): string {
       padding: 4px 8px;
       font-size: 11px;
       white-space: nowrap;
-      z-index: 10;
+      z-index: 50;
       color: var(--text);
+      pointer-events: none;
     }
 
     /* ─── Assertion markers ───────────────────────────── */

--- a/packages/vite-plugin/src/middleware.ts
+++ b/packages/vite-plugin/src/middleware.ts
@@ -60,6 +60,7 @@ export function failed(description: string, context?: Record<string, unknown>): 
 export function createScenetestMiddleware(server: ViteDevServer, root: string): Connect.NextHandleFunction {
   const eventHub = new EventHub()
   let activeReplay: ChildProcess | null = null
+  let paused = false
 
   return async (req, res, next) => {
     // ── Dashboard page ──────────────────────────────────────
@@ -138,9 +139,40 @@ export function createScenetestMiddleware(server: ViteDevServer, root: string): 
         // Silently ignore spawn errors
       })
 
+      paused = false
       res.statusCode = 200
       res.setHeader('Content-Type', 'application/json')
       res.end(JSON.stringify({ ok: true }))
+      return
+    }
+
+    // ── Stop running tests ──────────────────────────────────
+    if (req.method === 'POST' && req.url === '/__scenetest/stop') {
+      if (activeReplay && activeReplay.exitCode === null) {
+        activeReplay.kill()
+        activeReplay = null
+      }
+      paused = false
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ ok: true }))
+      return
+    }
+
+    // ── Pause / resume running tests ────────────────────────
+    if (req.method === 'POST' && req.url === '/__scenetest/pause') {
+      if (activeReplay && activeReplay.exitCode === null && activeReplay.pid) {
+        if (paused) {
+          process.kill(activeReplay.pid, 'SIGCONT')
+          paused = false
+        } else {
+          process.kill(activeReplay.pid, 'SIGSTOP')
+          paused = true
+        }
+      }
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ ok: true, paused }))
       return
     }
 

--- a/packages/vite-plugin/src/middleware.ts
+++ b/packages/vite-plugin/src/middleware.ts
@@ -1,6 +1,8 @@
 import type { Connect, ViteDevServer } from 'vite'
 import type { AssertionRpcPayload, AssertionRpcResponse, AssertionResult, ServerContext } from '@scenetest/checks'
 import { AsyncLocalStorage } from 'async_hooks'
+import { spawn, type ChildProcess } from 'child_process'
+import path from 'path'
 import { RESOLVED_VIRTUAL_MODULE_ID } from './virtual-module.js'
 import { loadConfig } from './config.js'
 import { EventHub } from './event-hub.js'
@@ -57,6 +59,7 @@ export function failed(description: string, context?: Record<string, unknown>): 
  */
 export function createScenetestMiddleware(server: ViteDevServer, root: string): Connect.NextHandleFunction {
   const eventHub = new EventHub()
+  let activeReplay: ChildProcess | null = null
 
   return async (req, res, next) => {
     // ── Dashboard page ──────────────────────────────────────
@@ -94,6 +97,50 @@ export function createScenetestMiddleware(server: ViteDevServer, root: string): 
       res.statusCode = 200
       res.setHeader('Content-Type', 'application/json')
       res.end('{"ok":true}')
+      return
+    }
+
+    // ── Replay endpoint ──────────────────────────────────────
+    if (req.method === 'POST' && req.url === '/__scenetest/replay') {
+      let body = ''
+      for await (const chunk of req) {
+        body += chunk
+      }
+
+      let file: string | undefined
+      try {
+        const parsed = JSON.parse(body)
+        file = parsed.file
+      } catch {
+        // No body or invalid JSON — replay all
+      }
+
+      // If a replay is already running, kill it first
+      if (activeReplay && activeReplay.exitCode === null) {
+        activeReplay.kill()
+      }
+
+      // Build the CLI args
+      const args: string[] = []
+      if (file) {
+        // file is relative to scenetest/scenes/, resolve to full path
+        args.push(path.resolve(root, 'scenetest', 'scenes', file))
+      }
+
+      // Spawn the scenetest CLI as a child process
+      activeReplay = spawn('npx', ['scenetest', ...args], {
+        cwd: root,
+        stdio: 'ignore',
+        shell: true,
+      })
+
+      activeReplay.on('error', () => {
+        // Silently ignore spawn errors
+      })
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ ok: true }))
       return
     }
 

--- a/packages/vscode-scenetest/package.json
+++ b/packages/vscode-scenetest/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-scenetest",
   "displayName": "Scenetest",
   "description": "Syntax highlighting for Scenetest scene specs (.spec.md)",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "scenetest",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Enhanced the Scenetest dashboard with interactive replay controls, progress visualization, and improved error display. Users can now replay all tests or individual scenes, pause/resume execution, and monitor progress with a visual indicator.

## Key Changes

**Dashboard UI Enhancements:**
- Added sticky header with z-index layering for better UX
- Implemented replay controls: "Replay All" button, per-scene replay buttons, pause/resume, and stop buttons
- Added progress bar showing test execution progress with color coding (blue for running, green for success, red for failures)
- Improved error display with dedicated error section showing failed actions and scene-level errors
- Auto-scroll to keep running scene visible during execution

**Middleware API Endpoints:**
- `POST /__scenetest/replay` - Replay all tests or a specific test file by spawning the scenetest CLI
- `POST /__scenetest/stop` - Kill the currently running test process
- `POST /__scenetest/pause` - Pause/resume test execution using SIGSTOP/SIGCONT signals

**State Management:**
- Track running state to enable/disable replay buttons during execution
- Manage pause state with visual feedback (pause icon changes to play icon when paused)
- Calculate and display progress percentage based on completed scenes

**Visual Improvements:**
- Error messages displayed with icons and proper formatting
- Conditional border-radius on swim lanes based on error presence
- Better z-index management for overlays and tooltips
- Improved button styling with hover states and disabled states

https://claude.ai/code/session_01EzdMwHBcgrheiBnivPJrVT