### PR TITLE
Fix race condition in selector resolution with timeout-based waiting

### DIFF
--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -242,10 +242,9 @@ class ActionChainImpl implements ActionChain {
   see(selector: Selector): ActionChain {
     const target = formatSelector(selector)
     return this.addAction('see', target, async () => {
-      const locator = await resolveSelectorWithFallback(
-        this.getScope(), this.page, selector, `see(${selector})`
+      await resolveSelectorWithFallback(
+        this.getScope(), this.page, selector, `see(${selector})`, this.actionTimeout
       )
-      await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
     })
   }
 
@@ -287,9 +286,8 @@ class ActionChainImpl implements ActionChain {
     const target = formatSelector(selector)
     return this.addAction('scope', target, async () => {
       const locator = await resolveSelectorWithFallback(
-        this.getScope(), this.page, selector, `scope(${selector})`
+        this.getScope(), this.page, selector, `scope(${selector})`, this.actionTimeout
       )
-      await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
       this.pushScope(locator)
     })
   }
@@ -335,10 +333,9 @@ class ActionChainImpl implements ActionChain {
     return this.addAction('click', target, async () => {
       const urlBefore = this.page.url()
       const locator = await resolveSelectorWithFallback(
-        this.getScope(), this.page, selector, `click(${selector})`
+        this.getScope(), this.page, selector, `click(${selector})`, this.actionTimeout
       )
       if (this.isKeyboard) {
-        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
         await tabToElement(this.page, locator, { timeout: this.actionTimeout })
         await pressEnter(this.page)
       } else if (this.useFuzzyFingers) {

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -477,10 +477,9 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
 
   see(selector: Selector): this {
     return this.push('see', selector, async () => {
-      const locator = await resolveSelectorWithFallback(
-        this.activeScope, this.page, selector, `see(${selector})`
+      await resolveSelectorWithFallback(
+        this.activeScope, this.page, selector, `see(${selector})`, this.actionTimeout
       )
-      await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
     })
   }
 
@@ -526,9 +525,8 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   scope(selector: Selector): this {
     return this.push('scope', selector, async () => {
       const locator = await resolveSelectorWithFallback(
-        this.activeScope, this.page, selector, `scope(${selector})`
+        this.activeScope, this.page, selector, `scope(${selector})`, this.actionTimeout
       )
-      await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
       this.scopeStack.push(this.activeScope)
       this.scopeStackUrls.push(this.scopeSetUrl)
       this.currentScope = locator
@@ -578,10 +576,9 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     return this.push('click', selector, async () => {
       const urlBefore = this.page.url()
       const locator = await resolveSelectorWithFallback(
-        this.activeScope, this.page, selector, `click(${selector})`
+        this.activeScope, this.page, selector, `click(${selector})`, this.actionTimeout
       )
       if (this.isKeyboard) {
-        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
         await tabToElement(this.page, locator, { timeout: this.actionTimeout })
         await pressEnter(this.page)
       } else if (this.useFuzzyFingers) {

--- a/packages/scenes/src/selectors.ts
+++ b/packages/scenes/src/selectors.ts
@@ -168,27 +168,51 @@ export function resolveSelector(base: Page | Locator, selector: string): Locator
  * @param page    The Page root (used as fallback)
  * @param selector  Selector string
  * @param context   Human-readable action description for the warning (e.g. "click(submit)")
+ * @param timeout   When provided, waits for the element to become visible in
+ *                  either scope or page root (using locator.or()) instead of a
+ *                  point-in-time count() check.  This prevents race conditions
+ *                  where the element hasn't appeared yet when resolution runs.
  */
 export async function resolveSelectorWithFallback(
   scope: Page | Locator,
   page: Page,
   selector: string,
-  context?: string
+  context?: string,
+  timeout?: number
 ): Promise<Locator> {
   // If scope is already the page, no fallback needed
   if (scope === page) {
     return resolveSelector(page, selector)
   }
 
-  // Try within current scope first
   const scopedLocator = resolveSelector(scope, selector)
+  const rootLocator = resolveSelector(page, selector)
+
+  if (timeout != null) {
+    // Wait for the element to appear in either scope or page root.
+    // This avoids the race where a point-in-time count() returns 0 for both,
+    // causing the wrong locator to be returned and a subsequent waitFor to
+    // look in the wrong subtree.
+    const combined = scopedLocator.or(rootLocator)
+    await combined.waitFor({ state: 'visible', timeout })
+
+    // Prefer the scoped locator when the element is within scope
+    if (await scopedLocator.isVisible()) {
+      return scopedLocator
+    }
+
+    if (context) {
+      console.warn(`⚠ ${context} — not found in current scope, resolved from page root`)
+    }
+    return rootLocator
+  }
+
+  // Point-in-time fallback (for callers that don't need to wait, e.g. ifClick)
   const count = await scopedLocator.count()
   if (count > 0) {
     return scopedLocator
   }
 
-  // Fall back to page root
-  const rootLocator = resolveSelector(page, selector)
   const rootCount = await rootLocator.count()
   if (rootCount > 0) {
     if (context) {


### PR DESCRIPTION
## Summary
This PR refactors `resolveSelectorWithFallback` to prevent race conditions when resolving selectors with fallback to page root. Instead of performing point-in-time `count()` checks that can miss elements not yet rendered, the function now optionally waits for visibility using Playwright's `waitFor()` API when a timeout is provided.

## Key Changes
- **Enhanced `resolveSelectorWithFallback` function**: Added optional `timeout` parameter that enables visibility-based waiting instead of point-in-time counting
  - Uses `locator.or()` to wait for element visibility in either scope or page root
  - Prevents race conditions where elements haven't appeared yet when resolution runs
  - Falls back to page root locator if element is not visible in current scope
  - Maintains backward compatibility with point-in-time fallback for callers that don't provide timeout

- **Simplified action implementations**: Updated `see()`, `scope()`, and `click()` methods across `actor.ts` and `reactive.ts`
  - Pass `this.actionTimeout` to `resolveSelectorWithFallback` instead of calling separate `waitFor()`
  - Removes redundant `waitFor()` calls since visibility waiting is now handled by the resolver
  - Reduces code duplication and centralizes timeout handling logic

## Implementation Details
- The timeout-based path uses `combined.waitFor({ state: 'visible', timeout })` to wait for the element to appear in either location
- After waiting, it checks `scopedLocator.isVisible()` to prefer the scoped locator when available
- Falls back to root locator if element is only visible at page root level
- Point-in-time fallback path (without timeout) is preserved for backward compatibility with callers like `ifClick()`

https://claude.ai/code/session_01UrQMPn9z1hpHuZrzsvS9mL