### PR TITLE
v0.7.2: Fix scope resolution race condition and add llms.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Scenetest are documented here.
 
 ---
 
-## [0.7.1] — 2026-04-11
+## [0.7.2] — 2026-04-11
 
 ### New features
 
@@ -22,7 +22,17 @@ user:
 
 `scope()`, `see()`, and `click()` use a fallback resolver — they try the current scope first, then fall back to page root with a warning, so existing tests continue to pass even if they relied on `see()` setting scope. Form interactions (`typeInto`, `check`, `select`) remain strict and only resolve within the current scope to avoid ambiguity across multiple forms on the same page.
 
+#### `llms.txt` / `llms-full.txt` for docs site
+
+The docs site Vite config now includes a plugin that generates `/llms.txt` (structured index with descriptions) and `/llms-full.txt` (all page content concatenated) following the [llmstxt.org](https://llmstxt.org) convention. Since the docs site is a React SPA, LLMs fetching pages would only get the JavaScript shell — these static text files give them the actual content.
+
 ### Bug fixes
+
+#### `scope()` waits for visibility before resolving
+
+`scope()`, `see()`, and `click()` used a point-in-time `count()` check to decide whether to resolve within the current scope or fall back to page root. If the target element hadn't appeared yet, `count()` returned 0 for both locators, causing the fallback to pick the wrong subtree and subsequent `waitFor` to time out.
+
+Now `resolveSelectorWithFallback` uses Playwright's `locator.or()` to race both candidates with a proper timeout, returning whichever locator matches first. `ifClick()` retains the instant `count()` path since it needs non-blocking behavior.
 
 #### Scope reset after click-induced navigation
 

--- a/packages/checks-panel/package.json
+++ b/packages/checks-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-panel",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Observer panel for scenetest - displays assertions in real-time",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-react/package.json
+++ b/packages/checks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-react",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "React bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-solid/package.json
+++ b/packages/checks-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-solid",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Solid bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-svelte/package.json
+++ b/packages/checks-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-svelte",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Svelte bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-vue/package.json
+++ b/packages/checks-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-vue",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Vue bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/eslint-plugin",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "ESLint plugin for scenetest - accessibility and testing best practices",
   "type": "module",
   "license": "MIT",

--- a/packages/playwright-scenetest/package.json
+++ b/packages/playwright-scenetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/playwright",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Playwright fixtures for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes-panel/package.json
+++ b/packages/scenes-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes-panel",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Scene recorder for scenetest - records user interactions as DSL",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",

--- a/packages/vscode-scenetest/package.json
+++ b/packages/vscode-scenetest/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-scenetest",
   "displayName": "Scenetest",
   "description": "Syntax highlighting for Scenetest scene specs (.spec.md)",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publisher": "scenetest",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

This release fixes a critical bug in scope resolution where elements that haven't appeared yet cause fallback to the wrong subtree, and adds LLM-friendly documentation files to the docs site.

## Key Changes

- **Fixed `scope()` visibility race condition**: `resolveSelectorWithFallback` now uses Playwright's `locator.or()` to race both scope candidates with a proper timeout, returning whichever matches first. This prevents the point-in-time `count()` check from picking the wrong subtree when target elements haven't appeared yet, which was causing subsequent `waitFor` calls to time out.

- **Added `llms.txt` / `llms-full.txt` generation**: The docs site Vite config now includes a plugin that generates `/llms.txt` (structured index with descriptions) and `/llms-full.txt` (all page content concatenated) following the [llmstxt.org](https://llmstxt.org) convention. This provides LLMs with actual content instead of just the JavaScript shell of the React SPA.

- **Preserved `ifClick()` behavior**: `ifClick()` retains the instant `count()` path since it requires non-blocking behavior.

## Implementation Details

The scope resolution fix addresses a timing issue where `count()` would return 0 for both the current scope and page root locators if the target element hadn't rendered yet. This caused the fallback logic to incorrectly select the page root, leading to subsequent visibility waits timing out. Using `locator.or()` with a timeout ensures we wait for either candidate to become available rather than making an instant decision based on incomplete DOM state.

## Version Bumps

All packages bumped to v0.7.2:
- @scenetest/checks-panel
- @scenetest/checks-react
- @scenetest/checks-solid
- @scenetest/checks-svelte
- @scenetest/checks-vue
- @scenetest/checks
- @scenetest/eslint-plugin
- @scenetest/playwright
- @scenetest/scenes-panel
- @scenetest/scenes
- @scenetest/vite-plugin
- vscode-scenetest

https://claude.ai/code/session_01DZ2bX269LP5HWJfWwbJNP7