### PR TITLE
Update Scenetest documentation site URL to msnook.xyz domain

### DIFF
--- a/docs/public/design/dashboard.md
+++ b/docs/public/design/dashboard.md
@@ -125,7 +125,7 @@ PR comment:
 > | Regression | checkout.validates | was 8ms/pass, now 92ms/fail |
 > | New | checkout.applyCoupon | 5ms pass |
 >
-> [View full comparison →](https://scenetest.dev/compare/...)
+> [View full comparison →](https://scenetest.msnook.xyz/compare/...)
 
 ## Live DSL Playground (Future)
 

--- a/docs/vite-plugin-llms-txt.ts
+++ b/docs/vite-plugin-llms-txt.ts
@@ -10,7 +10,8 @@ const SECTIONS = [
 
 const PUBLIC_DIR = 'public'
 
-const SITE = 'https://scenetest.dev'
+/** Production site URL — the canonical home for Scenetest docs. */
+const SITE = 'https://scenetest.msnook.xyz'
 
 /** Read the first `# Heading` from a markdown file. */
 function getTitle(filePath: string): string {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"license": "MIT",
 	"private": true,
 	"type": "module",
+	"homepage": "https://scenetest.msnook.xyz",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/scenetest/scenetest-js.git"


### PR DESCRIPTION
## Summary
Updates the canonical documentation site URL from `scenetest.dev` to `scenetest.msnook.xyz` across the project configuration and documentation.

## Changes
- Updated the `SITE` constant in the Vite plugin configuration with a clarifying comment about its purpose as the production documentation URL
- Updated the example dashboard documentation to reference the new domain in a sample PR comment link
- Added `homepage` field to `package.json` pointing to the new documentation URL

## Details
This change reflects a domain migration for the Scenetest documentation. All references to the old `scenetest.dev` domain have been replaced with the new `scenetest.msnook.xyz` domain to ensure consistency across configuration files, documentation examples, and package metadata.

https://claude.ai/code/session_01MLWzz8g4kvitWB8AcrUdGp