### PR TITLE
Replace selector fallback with strict resolution and diagnostic errors

### DIFF
--- a/packages/scenes/src/__tests__/selectors.test.ts
+++ b/packages/scenes/src/__tests__/selectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { resolveSelector, resolveSelectorWithFallback, buildScopeMissError, setAliases, clearAliases } from '../selectors.js'
+import { resolveSelector, buildSelectorMissError, setAliases, clearAliases } from '../selectors.js'
 
 // ---------------------------------------------------------------------------
 // Helpers — chainable Playwright locator mock
@@ -278,228 +278,63 @@ describe('resolveSelector', () => {
 })
 
 // ---------------------------------------------------------------------------
-// resolveSelectorWithFallback tests
+// buildSelectorMissError tests
 // ---------------------------------------------------------------------------
 
 /**
- * Create a mock locator with waitFor / count support.
- * `visible` controls whether the locator resolves or rejects.
+ * Create a mock locator that supports the `count()` calls used by
+ * buildSelectorMissError's diagnostic check.
  */
-function createAsyncMockLocator(visible: boolean) {
+function createCountingLocator(count: number) {
   return {
-    waitFor: vi.fn(async () => {
-      if (!visible) throw new Error('Timeout waiting for element')
-    }),
-    count: vi.fn(async () => (visible ? 1 : 0)),
+    count: vi.fn(async () => count),
     // resolveSelector chains through these for multi-token selectors
-    locator: vi.fn(() => createAsyncMockLocator(visible)),
-    or: vi.fn(() => createAsyncMockLocator(visible)),
-    nth: vi.fn(() => createAsyncMockLocator(visible)),
+    locator: vi.fn(() => createCountingLocator(count)),
+    or: vi.fn(() => createCountingLocator(count)),
+    nth: vi.fn(() => createCountingLocator(count)),
   }
 }
 
-/**
- * Build a mock page + scope pair.  The page always resolves selectors into
- * the provided mock locators so we can control visibility per-test.
- */
-function createFallbackMocks(scopedVisible: boolean, rootVisible: boolean) {
-  const scopedLocator = createAsyncMockLocator(scopedVisible)
-  const rootLocator = createAsyncMockLocator(rootVisible)
-
-  // We can't easily intercept resolveSelector inside the module, so we
-  // construct a scope and page whose .locator() returns our mocks directly.
-  // resolveSelectorWithFallback calls resolveSelector(scope, sel) and
-  // resolveSelector(page, sel) — for a single-token selector that's just
-  // scope.locator(css) and page.locator(css).
-  const scope: any = {
-    locator: vi.fn(() => scopedLocator),
-  }
-  const page: any = {
-    locator: vi.fn(() => rootLocator),
-  }
-
-  return { scope, page, scopedLocator, rootLocator }
-}
-
-describe('resolveSelectorWithFallback', () => {
-  describe('with timeout (progressive polling)', () => {
-    it('returns scoped locator when element is visible in scope', async () => {
-      const { scope, page, scopedLocator } = createFallbackMocks(true, true)
-
-      const result = await resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 5000)
-
-      // Scope is preferred — count is checked, then waitFor
-      expect(scopedLocator.count).toHaveBeenCalled()
-      expect(scopedLocator.waitFor).toHaveBeenCalled()
-      expect(result).toBe(scopedLocator)
-    })
-
-    it('falls back to root WITHOUT burning the full scoped timeout', async () => {
-      const { scope, page, scopedLocator, rootLocator } = createFallbackMocks(false, true)
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-      const start = Date.now()
-      const result = await resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 5000)
-      const elapsed = Date.now() - start
-
-      // Critical: should NOT have waited the full 5s on the scoped locator.
-      // Old sequential behavior would have done scopedLocator.waitFor(5000).
-      // Progressive polling sees count=0 instantly and falls back immediately.
-      expect(elapsed).toBeLessThan(500)
-      expect(scopedLocator.waitFor).not.toHaveBeenCalled()
-      expect(rootLocator.waitFor).toHaveBeenCalled()
-      expect(result).toBe(rootLocator)
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('not found in current scope')
-      )
-      warnSpy.mockRestore()
-    })
-
-    it('does not call root waitFor when scoped succeeds', async () => {
-      const { scope, page, rootLocator } = createFallbackMocks(true, true)
-
-      await resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 5000)
-
-      // Root locator's waitFor should NOT be called when scope has it
-      expect(rootLocator.waitFor).not.toHaveBeenCalled()
-    })
-
-    it('throws when element is not found in either scope', async () => {
-      const { scope, page } = createFallbackMocks(false, false)
-      vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-      // Use a tiny timeout so the polling loop exits quickly
-      await expect(
-        resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 50)
-      ).rejects.toThrow()
-
-      vi.mocked(console.warn).mockRestore()
-    })
-
-    it('suppresses warning when context is undefined', async () => {
-      const { scope, page } = createFallbackMocks(false, true)
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-      await resolveSelectorWithFallback(scope, page, 'btn', undefined, 5000)
-
-      expect(warnSpy).not.toHaveBeenCalled()
-      warnSpy.mockRestore()
-    })
-
-    it('respects single timeout budget (no doubling)', async () => {
-      // Both invisible — polling should run until ~timeout, then throw.
-      // This must NOT take 2x timeout (the old sequential fallback bug).
-      const { scope, page } = createFallbackMocks(false, false)
-      vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-      const start = Date.now()
-      await expect(
-        resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 200)
-      ).rejects.toThrow()
-      const elapsed = Date.now() - start
-
-      // Must complete within ~1.5x the budget (allow some slack for poll cycle).
-      // Old sequential code took 400ms (2x); progressive must stay under 300ms.
-      expect(elapsed).toBeLessThan(300)
-      vi.mocked(console.warn).mockRestore()
-    })
-  })
-
-  describe('without timeout (point-in-time fallback)', () => {
-    it('returns scoped locator when count > 0', async () => {
-      const { scope, page, scopedLocator } = createFallbackMocks(true, true)
-
-      const result = await resolveSelectorWithFallback(scope, page, 'btn')
-
-      expect(scopedLocator.count).toHaveBeenCalled()
-      expect(result).toBe(scopedLocator)
-    })
-
-    it('falls back to root when scoped count is 0', async () => {
-      const { scope, page, rootLocator } = createFallbackMocks(false, true)
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
-      const result = await resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)')
-
-      expect(result).toBe(rootLocator)
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('not found in current scope')
-      )
-      warnSpy.mockRestore()
-    })
-
-    it('returns scoped locator when neither has matches (for Playwright error)', async () => {
-      const { scope, page, scopedLocator } = createFallbackMocks(false, false)
-
-      const result = await resolveSelectorWithFallback(scope, page, 'btn')
-
-      // Returns scoped so Playwright gives the error with scope context
-      expect(result).toBe(scopedLocator)
-    })
-  })
-
-  describe('scope === page (no fallback needed)', () => {
-    it('still calls waitFor when timeout is provided', async () => {
-      // Regression: previously this path skipped waitFor entirely, so
-      // scope() would set the active scope to a phantom locator before
-      // the element actually existed in the DOM.
-      const pageLocator = createAsyncMockLocator(true)
-      const page: any = { locator: vi.fn(() => pageLocator) }
-
-      const result = await resolveSelectorWithFallback(page, page, 'btn', 'click(btn)', 5000)
-
-      expect(page.locator).toHaveBeenCalledTimes(1)
-      expect(pageLocator.waitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 5000 })
-      expect(result).toBe(pageLocator)
-    })
-
-    it('does not call waitFor when timeout is null (point-in-time)', async () => {
-      const pageLocator = createAsyncMockLocator(true)
-      const page: any = { locator: vi.fn(() => pageLocator) }
-
-      const result = await resolveSelectorWithFallback(page, page, 'btn')
-
-      expect(pageLocator.waitFor).not.toHaveBeenCalled()
-      expect(result).toBe(pageLocator)
-    })
-  })
-})
-
-// ---------------------------------------------------------------------------
-// buildScopeMissError tests
-// ---------------------------------------------------------------------------
-
-describe('buildScopeMissError', () => {
-  it('says "scope too narrow" when element exists at document root', async () => {
-    const rootLocator = createAsyncMockLocator(true)
-    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
-    const page: any = { locator: vi.fn(() => rootLocator) }
+describe('buildSelectorMissError', () => {
+  it('says "scope may be too narrow" when element exists at document root', async () => {
+    const scope: any = { locator: vi.fn(() => createCountingLocator(0)) }
+    const page: any = { locator: vi.fn(() => createCountingLocator(1)) }
     const cause = new Error('Timeout 5000ms exceeded')
 
-    const err = await buildScopeMissError(scope, page, 'deck-link', cause)
+    const err = await buildSelectorMissError(scope, page, 'click', 'deck-link', cause)
 
-    expect(err.message).toContain('scope(deck-link) timed out')
+    expect(err.message).toContain('click(deck-link) timed out')
     expect(err.message).toContain('not visible in current scope')
     expect(err.message).toContain('Found 1 match at document root')
-    expect(err.message).toContain('scope is too narrow')
+    expect(err.message).toContain('scope may be too narrow')
     expect((err as Error & { cause?: unknown }).cause).toBe(cause)
   })
 
-  it('pluralizes when multiple matches exist at root', async () => {
-    const rootLocator = { ...createAsyncMockLocator(true), count: vi.fn(async () => 3) }
-    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
-    const page: any = { locator: vi.fn(() => rootLocator) }
+  it('uses the action name in the message', async () => {
+    const scope: any = { locator: vi.fn(() => createCountingLocator(0)) }
+    const page: any = { locator: vi.fn(() => createCountingLocator(0)) }
 
-    const err = await buildScopeMissError(scope, page, 'deck-link', new Error('timeout'))
+    const seeErr = await buildSelectorMissError(scope, page, 'see', 'btn', new Error())
+    const scopeErr = await buildSelectorMissError(scope, page, 'scope', 'btn', new Error())
+
+    expect(seeErr.message).toContain('see(btn) timed out')
+    expect(scopeErr.message).toContain('scope(btn) timed out')
+  })
+
+  it('pluralizes when multiple matches exist at root', async () => {
+    const scope: any = { locator: vi.fn(() => createCountingLocator(0)) }
+    const page: any = { locator: vi.fn(() => createCountingLocator(3)) }
+
+    const err = await buildSelectorMissError(scope, page, 'click', 'deck-link', new Error('timeout'))
 
     expect(err.message).toContain('Found 3 matches at document root')
   })
 
   it('says "check spelling" when element exists nowhere', async () => {
-    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
-    const page: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+    const scope: any = { locator: vi.fn(() => createCountingLocator(0)) }
+    const page: any = { locator: vi.fn(() => createCountingLocator(0)) }
 
-    const err = await buildScopeMissError(scope, page, 'typoed-name', new Error('timeout'))
+    const err = await buildSelectorMissError(scope, page, 'see', 'typoed-name', new Error('timeout'))
 
     expect(err.message).toContain('Not found anywhere on the page')
     expect(err.message).toContain('Check the selector spelling')
@@ -507,32 +342,31 @@ describe('buildScopeMissError', () => {
 
   it('omits hint when scope was already page root', async () => {
     // If scope === page, there's no narrowing to blame
-    const page: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+    const page: any = { locator: vi.fn(() => createCountingLocator(0)) }
 
-    const err = await buildScopeMissError(page, page, 'btn', new Error('timeout'))
+    const err = await buildSelectorMissError(page, page, 'see', 'btn', new Error('timeout'))
 
-    expect(err.message).toContain('scope(btn) timed out')
+    expect(err.message).toContain('see(btn) timed out')
     // Should NOT include either hint — there's no scope narrowing to be wrong about
     expect(err.message).not.toContain('document root')
     expect(err.message).not.toContain('Check the selector spelling')
   })
 
   it('does not mask the original error if diagnostic count() throws', async () => {
-    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+    const scope: any = { locator: vi.fn(() => createCountingLocator(0)) }
     const page: any = {
       locator: vi.fn(() => ({
         count: vi.fn(async () => {
           throw new Error('diagnostic blew up')
         }),
-        // resolveSelector chains through these for multi-token selectors
-        locator: vi.fn(() => createAsyncMockLocator(false)),
-        or: vi.fn(() => createAsyncMockLocator(false)),
-        nth: vi.fn(() => createAsyncMockLocator(false)),
+        locator: vi.fn(() => createCountingLocator(0)),
+        or: vi.fn(() => createCountingLocator(0)),
+        nth: vi.fn(() => createCountingLocator(0)),
       })),
     }
     const cause = new Error('original timeout')
 
-    const err = await buildScopeMissError(scope, page, 'btn', cause)
+    const err = await buildSelectorMissError(scope, page, 'scope', 'btn', cause)
 
     // Should still produce an error with the original cause attached
     expect(err.message).toContain('scope(btn) timed out')

--- a/packages/scenes/src/__tests__/selectors.test.ts
+++ b/packages/scenes/src/__tests__/selectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { resolveSelector, resolveSelectorWithFallback, setAliases, clearAliases } from '../selectors.js'
+import { resolveSelector, resolveSelectorWithFallback, buildScopeMissError, setAliases, clearAliases } from '../selectors.js'
 
 // ---------------------------------------------------------------------------
 // Helpers — chainable Playwright locator mock
@@ -322,30 +322,33 @@ function createFallbackMocks(scopedVisible: boolean, rootVisible: boolean) {
 }
 
 describe('resolveSelectorWithFallback', () => {
-  describe('with timeout (sequential fallback)', () => {
+  describe('with timeout (progressive polling)', () => {
     it('returns scoped locator when element is visible in scope', async () => {
       const { scope, page, scopedLocator } = createFallbackMocks(true, true)
 
       const result = await resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 5000)
 
-      // Scoped waitFor should be called with the timeout
-      expect(scopedLocator.waitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 5000 })
-      // Should return the scoped locator (identity check)
+      // Scope is preferred — count is checked, then waitFor
+      expect(scopedLocator.count).toHaveBeenCalled()
+      expect(scopedLocator.waitFor).toHaveBeenCalled()
       expect(result).toBe(scopedLocator)
     })
 
-    it('falls back to root when scoped locator times out', async () => {
+    it('falls back to root WITHOUT burning the full scoped timeout', async () => {
       const { scope, page, scopedLocator, rootLocator } = createFallbackMocks(false, true)
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
+      const start = Date.now()
       const result = await resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 5000)
+      const elapsed = Date.now() - start
 
-      // Scoped waitFor should have been attempted and failed
-      expect(scopedLocator.waitFor).toHaveBeenCalled()
-      // Root waitFor should be called as fallback
-      expect(rootLocator.waitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 5000 })
+      // Critical: should NOT have waited the full 5s on the scoped locator.
+      // Old sequential behavior would have done scopedLocator.waitFor(5000).
+      // Progressive polling sees count=0 instantly and falls back immediately.
+      expect(elapsed).toBeLessThan(500)
+      expect(scopedLocator.waitFor).not.toHaveBeenCalled()
+      expect(rootLocator.waitFor).toHaveBeenCalled()
       expect(result).toBe(rootLocator)
-      // Warning should fire
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('not found in current scope')
       )
@@ -357,7 +360,7 @@ describe('resolveSelectorWithFallback', () => {
 
       await resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 5000)
 
-      // Root locator's waitFor should NOT be called
+      // Root locator's waitFor should NOT be called when scope has it
       expect(rootLocator.waitFor).not.toHaveBeenCalled()
     })
 
@@ -365,8 +368,9 @@ describe('resolveSelectorWithFallback', () => {
       const { scope, page } = createFallbackMocks(false, false)
       vi.spyOn(console, 'warn').mockImplementation(() => {})
 
+      // Use a tiny timeout so the polling loop exits quickly
       await expect(
-        resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 5000)
+        resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 50)
       ).rejects.toThrow()
 
       vi.mocked(console.warn).mockRestore()
@@ -380,6 +384,24 @@ describe('resolveSelectorWithFallback', () => {
 
       expect(warnSpy).not.toHaveBeenCalled()
       warnSpy.mockRestore()
+    })
+
+    it('respects single timeout budget (no doubling)', async () => {
+      // Both invisible — polling should run until ~timeout, then throw.
+      // This must NOT take 2x timeout (the old sequential fallback bug).
+      const { scope, page } = createFallbackMocks(false, false)
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const start = Date.now()
+      await expect(
+        resolveSelectorWithFallback(scope, page, 'btn', 'click(btn)', 200)
+      ).rejects.toThrow()
+      const elapsed = Date.now() - start
+
+      // Must complete within ~1.5x the budget (allow some slack for poll cycle).
+      // Old sequential code took 400ms (2x); progressive must stay under 300ms.
+      expect(elapsed).toBeLessThan(300)
+      vi.mocked(console.warn).mockRestore()
     })
   })
 
@@ -417,16 +439,103 @@ describe('resolveSelectorWithFallback', () => {
   })
 
   describe('scope === page (no fallback needed)', () => {
-    it('resolves directly from page without fallback logic', async () => {
-      const page: any = {
-        locator: vi.fn(() => createAsyncMockLocator(true)),
-      }
+    it('still calls waitFor when timeout is provided', async () => {
+      // Regression: previously this path skipped waitFor entirely, so
+      // scope() would set the active scope to a phantom locator before
+      // the element actually existed in the DOM.
+      const pageLocator = createAsyncMockLocator(true)
+      const page: any = { locator: vi.fn(() => pageLocator) }
 
       const result = await resolveSelectorWithFallback(page, page, 'btn', 'click(btn)', 5000)
 
-      // Should have called page.locator once (not twice for scope + root)
       expect(page.locator).toHaveBeenCalledTimes(1)
-      expect(result).toBeDefined()
+      expect(pageLocator.waitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 5000 })
+      expect(result).toBe(pageLocator)
     })
+
+    it('does not call waitFor when timeout is null (point-in-time)', async () => {
+      const pageLocator = createAsyncMockLocator(true)
+      const page: any = { locator: vi.fn(() => pageLocator) }
+
+      const result = await resolveSelectorWithFallback(page, page, 'btn')
+
+      expect(pageLocator.waitFor).not.toHaveBeenCalled()
+      expect(result).toBe(pageLocator)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildScopeMissError tests
+// ---------------------------------------------------------------------------
+
+describe('buildScopeMissError', () => {
+  it('says "scope too narrow" when element exists at document root', async () => {
+    const rootLocator = createAsyncMockLocator(true)
+    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+    const page: any = { locator: vi.fn(() => rootLocator) }
+    const cause = new Error('Timeout 5000ms exceeded')
+
+    const err = await buildScopeMissError(scope, page, 'deck-link', cause)
+
+    expect(err.message).toContain('scope(deck-link) timed out')
+    expect(err.message).toContain('not visible in current scope')
+    expect(err.message).toContain('Found 1 match at document root')
+    expect(err.message).toContain('scope is too narrow')
+    expect((err as Error & { cause?: unknown }).cause).toBe(cause)
+  })
+
+  it('pluralizes when multiple matches exist at root', async () => {
+    const rootLocator = { ...createAsyncMockLocator(true), count: vi.fn(async () => 3) }
+    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+    const page: any = { locator: vi.fn(() => rootLocator) }
+
+    const err = await buildScopeMissError(scope, page, 'deck-link', new Error('timeout'))
+
+    expect(err.message).toContain('Found 3 matches at document root')
+  })
+
+  it('says "check spelling" when element exists nowhere', async () => {
+    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+    const page: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+
+    const err = await buildScopeMissError(scope, page, 'typoed-name', new Error('timeout'))
+
+    expect(err.message).toContain('Not found anywhere on the page')
+    expect(err.message).toContain('Check the selector spelling')
+  })
+
+  it('omits hint when scope was already page root', async () => {
+    // If scope === page, there's no narrowing to blame
+    const page: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+
+    const err = await buildScopeMissError(page, page, 'btn', new Error('timeout'))
+
+    expect(err.message).toContain('scope(btn) timed out')
+    // Should NOT include either hint — there's no scope narrowing to be wrong about
+    expect(err.message).not.toContain('document root')
+    expect(err.message).not.toContain('Check the selector spelling')
+  })
+
+  it('does not mask the original error if diagnostic count() throws', async () => {
+    const scope: any = { locator: vi.fn(() => createAsyncMockLocator(false)) }
+    const page: any = {
+      locator: vi.fn(() => ({
+        count: vi.fn(async () => {
+          throw new Error('diagnostic blew up')
+        }),
+        // resolveSelector chains through these for multi-token selectors
+        locator: vi.fn(() => createAsyncMockLocator(false)),
+        or: vi.fn(() => createAsyncMockLocator(false)),
+        nth: vi.fn(() => createAsyncMockLocator(false)),
+      })),
+    }
+    const cause = new Error('original timeout')
+
+    const err = await buildScopeMissError(scope, page, 'btn', cause)
+
+    // Should still produce an error with the original cause attached
+    expect(err.message).toContain('scope(btn) timed out')
+    expect((err as Error & { cause?: unknown }).cause).toBe(cause)
   })
 })

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -3,7 +3,7 @@ import type { ActorConfig, SequentialActorHandle, ActionChain, AssertionResult, 
 import type { NavigationMode } from './keyboard.js'
 import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOption, fuzzyFingerClick, fuzzyFingerFill, fuzzyFingerCheck } from './keyboard.js'
 import { MessageBus } from './message-bus.js'
-import { resolveSelector, resolveSelectorWithFallback, buildScopeMissError } from './selectors.js'
+import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
@@ -242,9 +242,12 @@ class ActionChainImpl implements ActionChain {
   see(selector: Selector): ActionChain {
     const target = formatSelector(selector)
     return this.addAction('see', target, async () => {
-      await resolveSelectorWithFallback(
-        this.getScope(), this.page, selector, `see(${selector})`, this.actionTimeout
-      )
+      const locator = resolveSelector(this.getScope(), selector)
+      try {
+        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
+      } catch (err) {
+        throw await buildSelectorMissError(this.getScope(), this.page, 'see', selector, err)
+      }
     })
   }
 
@@ -285,15 +288,11 @@ class ActionChainImpl implements ActionChain {
   scope(selector: Selector): ActionChain {
     const target = formatSelector(selector)
     return this.addAction('scope', target, async () => {
-      // Strict resolution — scope() commits to "I am operating inside X".
-      // Silently widening to root would lie about where we are, so on miss
-      // we throw a diagnostic error that tells the developer whether their
-      // selector is wrong or their scope is wrong.
       const locator = resolveSelector(this.getScope(), selector)
       try {
         await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
       } catch (err) {
-        throw await buildScopeMissError(this.getScope(), this.page, selector, err)
+        throw await buildSelectorMissError(this.getScope(), this.page, 'scope', selector, err)
       }
       this.pushScope(locator)
     })
@@ -339,9 +338,12 @@ class ActionChainImpl implements ActionChain {
     const target = formatSelector(selector)
     return this.addAction('click', target, async () => {
       const urlBefore = this.page.url()
-      const locator = await resolveSelectorWithFallback(
-        this.getScope(), this.page, selector, `click(${selector})`, this.actionTimeout
-      )
+      const locator = resolveSelector(this.getScope(), selector)
+      try {
+        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
+      } catch (err) {
+        throw await buildSelectorMissError(this.getScope(), this.page, 'click', selector, err)
+      }
       if (this.isKeyboard) {
         await tabToElement(this.page, locator, { timeout: this.actionTimeout })
         await pressEnter(this.page)
@@ -363,9 +365,9 @@ class ActionChainImpl implements ActionChain {
   ifClick(selector: Selector): ActionChain {
     const target = formatSelector(selector)
     return this.addAction('ifClick', target, async () => {
-      const locator = await resolveSelectorWithFallback(
-        this.getScope(), this.page, selector, `ifClick(${selector})`
-      )
+      // Strict: only check current scope.  Conditional by design — if the
+      // element isn't here, silently skip.  No fallback to page root.
+      const locator = resolveSelector(this.getScope(), selector)
       const visible = await locator.isVisible()
       if (visible) {
         const urlBefore = this.page.url()

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -3,7 +3,7 @@ import type { ActorConfig, SequentialActorHandle, ActionChain, AssertionResult, 
 import type { NavigationMode } from './keyboard.js'
 import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOption, fuzzyFingerClick, fuzzyFingerFill, fuzzyFingerCheck } from './keyboard.js'
 import { MessageBus } from './message-bus.js'
-import { resolveSelector, resolveSelectorWithFallback } from './selectors.js'
+import { resolveSelector, resolveSelectorWithFallback, buildScopeMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
@@ -285,9 +285,16 @@ class ActionChainImpl implements ActionChain {
   scope(selector: Selector): ActionChain {
     const target = formatSelector(selector)
     return this.addAction('scope', target, async () => {
-      const locator = await resolveSelectorWithFallback(
-        this.getScope(), this.page, selector, `scope(${selector})`, this.actionTimeout
-      )
+      // Strict resolution — scope() commits to "I am operating inside X".
+      // Silently widening to root would lie about where we are, so on miss
+      // we throw a diagnostic error that tells the developer whether their
+      // selector is wrong or their scope is wrong.
+      const locator = resolveSelector(this.getScope(), selector)
+      try {
+        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
+      } catch (err) {
+        throw await buildScopeMissError(this.getScope(), this.page, selector, err)
+      }
       this.pushScope(locator)
     })
   }

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -65,7 +65,7 @@ import type {
 import type { NavigationMode } from './keyboard.js'
 import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOption, fuzzyFingerClick, fuzzyFingerFill, fuzzyFingerCheck } from './keyboard.js'
 import { MessageBus } from './message-bus.js'
-import { resolveSelector, resolveSelectorWithFallback, buildScopeMissError } from './selectors.js'
+import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { scene, getCurrentSession } from './scene.js'
 import { findDevice } from './devices.js'
@@ -477,9 +477,12 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
 
   see(selector: Selector): this {
     return this.push('see', selector, async () => {
-      await resolveSelectorWithFallback(
-        this.activeScope, this.page, selector, `see(${selector})`, this.actionTimeout
-      )
+      const locator = resolveSelector(this.activeScope, selector)
+      try {
+        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
+      } catch (err) {
+        throw await buildSelectorMissError(this.activeScope, this.page, 'see', selector, err)
+      }
     })
   }
 
@@ -518,19 +521,13 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     })
   }
 
-  /**
-   * Wait for element to be visible in the current scope and set it as the
-   * new scope.  Strict — does NOT fall back to page root.  On miss, throws
-   * a diagnostic error that tells the developer whether the element exists
-   * elsewhere on the page (= scope is wrong) or nowhere (= selector is wrong).
-   */
   scope(selector: Selector): this {
     return this.push('scope', selector, async () => {
       const locator = resolveSelector(this.activeScope, selector)
       try {
         await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
       } catch (err) {
-        throw await buildScopeMissError(this.activeScope, this.page, selector, err)
+        throw await buildSelectorMissError(this.activeScope, this.page, 'scope', selector, err)
       }
       this.scopeStack.push(this.activeScope)
       this.scopeStackUrls.push(this.scopeSetUrl)
@@ -580,9 +577,12 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
     }
     return this.push('click', selector, async () => {
       const urlBefore = this.page.url()
-      const locator = await resolveSelectorWithFallback(
-        this.activeScope, this.page, selector, `click(${selector})`, this.actionTimeout
-      )
+      const locator = resolveSelector(this.activeScope, selector)
+      try {
+        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
+      } catch (err) {
+        throw await buildSelectorMissError(this.activeScope, this.page, 'click', selector, err)
+      }
       if (this.isKeyboard) {
         await tabToElement(this.page, locator, { timeout: this.actionTimeout })
         await pressEnter(this.page)
@@ -603,9 +603,9 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
 
   ifClick(selector: Selector): this {
     return this.push('ifClick', selector, async () => {
-      const locator = await resolveSelectorWithFallback(
-        this.activeScope, this.page, selector, `ifClick(${selector})`
-      )
+      // Strict: only check current scope.  Conditional by design — if the
+      // element isn't here, silently skip.  No fallback to page root.
+      const locator = resolveSelector(this.activeScope, selector)
       const visible = await locator.isVisible()
       if (visible) {
         const urlBefore = this.page.url()

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -65,7 +65,7 @@ import type {
 import type { NavigationMode } from './keyboard.js'
 import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOption, fuzzyFingerClick, fuzzyFingerFill, fuzzyFingerCheck } from './keyboard.js'
 import { MessageBus } from './message-bus.js'
-import { resolveSelector, resolveSelectorWithFallback } from './selectors.js'
+import { resolveSelector, resolveSelectorWithFallback, buildScopeMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { scene, getCurrentSession } from './scene.js'
 import { findDevice } from './devices.js'
@@ -519,14 +519,19 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   }
 
   /**
-   * Wait for element to be visible and set it as the current scope.
-   * Tries current scope first; falls back to page root with a warning.
+   * Wait for element to be visible in the current scope and set it as the
+   * new scope.  Strict — does NOT fall back to page root.  On miss, throws
+   * a diagnostic error that tells the developer whether the element exists
+   * elsewhere on the page (= scope is wrong) or nowhere (= selector is wrong).
    */
   scope(selector: Selector): this {
     return this.push('scope', selector, async () => {
-      const locator = await resolveSelectorWithFallback(
-        this.activeScope, this.page, selector, `scope(${selector})`, this.actionTimeout
-      )
+      const locator = resolveSelector(this.activeScope, selector)
+      try {
+        await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
+      } catch (err) {
+        throw await buildScopeMissError(this.activeScope, this.page, selector, err)
+      }
       this.scopeStack.push(this.activeScope)
       this.scopeStackUrls.push(this.scopeSetUrl)
       this.currentScope = locator

--- a/packages/scenes/src/selectors.ts
+++ b/packages/scenes/src/selectors.ts
@@ -157,22 +157,30 @@ export function resolveSelector(base: Page | Locator, selector: string): Locator
 }
 
 /**
- * Resolve a selector with scope fallback.
+ * Resolve a selector with scope fallback (forgiving — for see/click).
  *
- * Tries to resolve within the given scope first.  If the scope is not the
- * page root and no matches are found, retries from the page root.  When the
- * fallback succeeds a warning is logged so spec authors know the element
- * was found outside the expected scope.
+ * Polls within a single timeout budget: each cycle checks the current scope
+ * first, then falls back to the page root.  Returns as soon as the element
+ * appears in either location.  Prefers scope, but widens to root quickly
+ * (POLL_MS, default 200ms) without burning the full timeout on a doomed
+ * scoped wait.  When the page-root fallback fires, a warning is logged so
+ * spec authors know the element was found outside the expected scope.
  *
- * @param scope   Current scope (Page or Locator)
- * @param page    The Page root (used as fallback)
+ * Why polling instead of `.or()`?  The old `.or()` race broke Playwright's
+ * strict mode when the root selector matched multiple elements — the union
+ * saw every match on the page.  Polling checks each locator's `.count()`
+ * independently, never combining them, so strict mode is unaffected.
+ *
+ * Why polling instead of sequential waitFor?  Sequential committed the full
+ * timeout to scope, then another full timeout to root — worst case 2x.  A
+ * single budget keeps the worst case at 1x.
+ *
+ * @param scope     Current scope (Page or Locator)
+ * @param page      The Page root (used as fallback)
  * @param selector  Selector string
  * @param context   Human-readable action description for the warning (e.g. "click(submit)")
- * @param timeout   When provided, waits for the element to become visible in
- *                  scope first (full timeout).  If the scoped wait times out,
- *                  falls back to the page root with the same timeout.  This
- *                  sequential approach avoids the strict-mode violation that
- *                  racing with .or() caused.
+ * @param timeout   When provided, polls within this budget.  When null,
+ *                  performs a point-in-time check (used by `ifClick`).
  */
 export async function resolveSelectorWithFallback(
   scope: Page | Locator,
@@ -181,50 +189,95 @@ export async function resolveSelectorWithFallback(
   context?: string,
   timeout?: number
 ): Promise<Locator> {
-  // If scope is already the page, no fallback needed
+  // No scope narrowing — resolve from page directly
   if (scope === page) {
-    return resolveSelector(page, selector)
+    const locator = resolveSelector(page, selector)
+    if (timeout != null) {
+      await locator.waitFor({ state: 'visible', timeout })
+    }
+    return locator
   }
 
   const scopedLocator = resolveSelector(scope, selector)
   const rootLocator = resolveSelector(page, selector)
 
-  if (timeout != null) {
-    // Try scoped first with full timeout commitment.  Only fall back to page
-    // root if the scoped wait fully times out.  This avoids the strict-mode
-    // violation that .or() caused — racing both locators meant Playwright saw
-    // every match on the page, not just the scoped one.
-    try {
-      await scopedLocator.waitFor({ state: 'visible', timeout })
-      return scopedLocator
-    } catch {
-      // Scoped element never appeared — fall through to page root
-    }
-
-    if (context) {
-      console.warn(`⚠ ${context} — not found in current scope, resolved from page root`)
-    }
-    await rootLocator.waitFor({ state: 'visible', timeout })
-    return rootLocator
-  }
-
   // Point-in-time fallback (for callers that don't need to wait, e.g. ifClick)
-  const count = await scopedLocator.count()
-  if (count > 0) {
+  if (timeout == null) {
+    if ((await scopedLocator.count()) > 0) return scopedLocator
+    if ((await rootLocator.count()) > 0) {
+      if (context) {
+        console.warn(`⚠ ${context} — not found in current scope, resolved from page root`)
+      }
+      return rootLocator
+    }
+    // Not found anywhere — return scoped locator for the normal Playwright
+    // error with the original scope context
     return scopedLocator
   }
 
-  const rootCount = await rootLocator.count()
-  if (rootCount > 0) {
-    if (context) {
-      console.warn(`⚠ ${context} — not found in current scope, resolved from page root`)
+  // Progressive resolution: single timeout budget, prefer scope each cycle
+  const POLL_MS = 200
+  const deadline = Date.now() + timeout
+
+  while (Date.now() < deadline) {
+    if ((await scopedLocator.count()) > 0) {
+      await scopedLocator.waitFor({
+        state: 'visible',
+        timeout: Math.max(deadline - Date.now(), 1),
+      })
+      return scopedLocator
     }
-    return rootLocator
+    if ((await rootLocator.count()) > 0) {
+      if (context) {
+        console.warn(`⚠ ${context} — not found in current scope, resolved from page root`)
+      }
+      await rootLocator.waitFor({
+        state: 'visible',
+        timeout: Math.max(deadline - Date.now(), 1),
+      })
+      return rootLocator
+    }
+    const sleep = Math.min(POLL_MS, deadline - Date.now())
+    if (sleep > 0) {
+      await new Promise((r) => setTimeout(r, sleep))
+    }
   }
 
-  // Not found anywhere — return the scoped locator so the caller gets
-  // the normal Playwright timeout error with the original scope context
-  return scopedLocator
+  // Timeout expired — throw with scoped context for a useful error message
+  await scopedLocator.waitFor({ state: 'visible', timeout: 1 })
+  return scopedLocator // unreachable; waitFor above throws
+}
+
+/**
+ * Build a diagnostic error for a `scope()` that timed out.
+ *
+ * Quickly checks the page root to tell the developer whether the element
+ * exists somewhere else on the page (= scope is wrong) or nowhere (= selector
+ * is wrong).  Either way the message is immediately actionable, replacing
+ * Playwright's generic "Timeout exceeded" with concrete next steps.
+ */
+export async function buildScopeMissError(
+  scope: Page | Locator,
+  page: Page,
+  selector: string,
+  cause: unknown
+): Promise<Error> {
+  let rootCount = 0
+  try {
+    rootCount = await resolveSelector(page, selector).count()
+  } catch {
+    // diagnostic best-effort — don't mask the original timeout
+  }
+  const base = `scope(${selector}) timed out — not visible in current scope.`
+  const hint =
+    scope === page
+      ? '' // scope was already page — no narrowing to blame
+      : rootCount > 0
+        ? `\n  Found ${rootCount} match${rootCount === 1 ? '' : 'es'} at document root. Your scope is too narrow — call up() first, or scope from page root.`
+        : `\n  Not found anywhere on the page. Check the selector spelling.`
+  const err = new Error(base + hint)
+  ;(err as Error & { cause?: unknown }).cause = cause
+  return err
 }
 
 /**

--- a/packages/scenes/src/selectors.ts
+++ b/packages/scenes/src/selectors.ts
@@ -157,108 +157,20 @@ export function resolveSelector(base: Page | Locator, selector: string): Locator
 }
 
 /**
- * Resolve a selector with scope fallback (forgiving — for see/click).
+ * Build a diagnostic error for a strict-resolution miss.
  *
- * Polls within a single timeout budget: each cycle checks the current scope
- * first, then falls back to the page root.  Returns as soon as the element
- * appears in either location.  Prefers scope, but widens to root quickly
- * (POLL_MS, default 200ms) without burning the full timeout on a doomed
- * scoped wait.  When the page-root fallback fires, a warning is logged so
- * spec authors know the element was found outside the expected scope.
+ * Selector resolution is strict: an action like `see("X")` or `scope("X")`
+ * must find X in the current scope.  When it doesn't, this helper runs a
+ * quick page-root check and crafts an immediately actionable error message
+ * — telling the developer whether their *scope* is wrong (X exists somewhere
+ * else on the page) or their *selector* is wrong (X exists nowhere).
  *
- * Why polling instead of `.or()`?  The old `.or()` race broke Playwright's
- * strict mode when the root selector matched multiple elements — the union
- * saw every match on the page.  Polling checks each locator's `.count()`
- * independently, never combining them, so strict mode is unaffected.
- *
- * Why polling instead of sequential waitFor?  Sequential committed the full
- * timeout to scope, then another full timeout to root — worst case 2x.  A
- * single budget keeps the worst case at 1x.
- *
- * @param scope     Current scope (Page or Locator)
- * @param page      The Page root (used as fallback)
- * @param selector  Selector string
- * @param context   Human-readable action description for the warning (e.g. "click(submit)")
- * @param timeout   When provided, polls within this budget.  When null,
- *                  performs a point-in-time check (used by `ifClick`).
+ * Replaces Playwright's generic "Timeout exceeded" with concrete next steps.
  */
-export async function resolveSelectorWithFallback(
+export async function buildSelectorMissError(
   scope: Page | Locator,
   page: Page,
-  selector: string,
-  context?: string,
-  timeout?: number
-): Promise<Locator> {
-  // No scope narrowing — resolve from page directly
-  if (scope === page) {
-    const locator = resolveSelector(page, selector)
-    if (timeout != null) {
-      await locator.waitFor({ state: 'visible', timeout })
-    }
-    return locator
-  }
-
-  const scopedLocator = resolveSelector(scope, selector)
-  const rootLocator = resolveSelector(page, selector)
-
-  // Point-in-time fallback (for callers that don't need to wait, e.g. ifClick)
-  if (timeout == null) {
-    if ((await scopedLocator.count()) > 0) return scopedLocator
-    if ((await rootLocator.count()) > 0) {
-      if (context) {
-        console.warn(`⚠ ${context} — not found in current scope, resolved from page root`)
-      }
-      return rootLocator
-    }
-    // Not found anywhere — return scoped locator for the normal Playwright
-    // error with the original scope context
-    return scopedLocator
-  }
-
-  // Progressive resolution: single timeout budget, prefer scope each cycle
-  const POLL_MS = 200
-  const deadline = Date.now() + timeout
-
-  while (Date.now() < deadline) {
-    if ((await scopedLocator.count()) > 0) {
-      await scopedLocator.waitFor({
-        state: 'visible',
-        timeout: Math.max(deadline - Date.now(), 1),
-      })
-      return scopedLocator
-    }
-    if ((await rootLocator.count()) > 0) {
-      if (context) {
-        console.warn(`⚠ ${context} — not found in current scope, resolved from page root`)
-      }
-      await rootLocator.waitFor({
-        state: 'visible',
-        timeout: Math.max(deadline - Date.now(), 1),
-      })
-      return rootLocator
-    }
-    const sleep = Math.min(POLL_MS, deadline - Date.now())
-    if (sleep > 0) {
-      await new Promise((r) => setTimeout(r, sleep))
-    }
-  }
-
-  // Timeout expired — throw with scoped context for a useful error message
-  await scopedLocator.waitFor({ state: 'visible', timeout: 1 })
-  return scopedLocator // unreachable; waitFor above throws
-}
-
-/**
- * Build a diagnostic error for a `scope()` that timed out.
- *
- * Quickly checks the page root to tell the developer whether the element
- * exists somewhere else on the page (= scope is wrong) or nowhere (= selector
- * is wrong).  Either way the message is immediately actionable, replacing
- * Playwright's generic "Timeout exceeded" with concrete next steps.
- */
-export async function buildScopeMissError(
-  scope: Page | Locator,
-  page: Page,
+  action: string,
   selector: string,
   cause: unknown
 ): Promise<Error> {
@@ -268,12 +180,12 @@ export async function buildScopeMissError(
   } catch {
     // diagnostic best-effort — don't mask the original timeout
   }
-  const base = `scope(${selector}) timed out — not visible in current scope.`
+  const base = `${action}(${selector}) timed out — not visible in current scope.`
   const hint =
     scope === page
       ? '' // scope was already page — no narrowing to blame
       : rootCount > 0
-        ? `\n  Found ${rootCount} match${rootCount === 1 ? '' : 'es'} at document root. Your scope is too narrow — call up() first, or scope from page root.`
+        ? `\n  Found ${rootCount} match${rootCount === 1 ? '' : 'es'} at document root. Your scope may be too narrow — adjust scope or use the full selector path.`
         : `\n  Not found anywhere on the page. Check the selector spelling.`
   const err = new Error(base + hint)
   ;(err as Error & { cause?: unknown }).cause = cause


### PR DESCRIPTION
## Summary

This PR replaces the automatic scope-to-root fallback behavior in selector resolution with a strict scope-only approach, paired with intelligent diagnostic error messages that help developers understand why a selector failed.

## Key Changes

- **Removed `resolveSelectorWithFallback()`**: This function automatically fell back to page-root resolution when a selector wasn't found in the current scope, with a warning logged. This behavior masked scope configuration errors.

- **Added `buildSelectorMissError()`**: A new diagnostic helper that:
  - Runs a quick page-root check when strict scope resolution fails
  - Generates actionable error messages that distinguish between two failure modes:
    - **Scope too narrow**: Element exists at page root but not in current scope → suggests adjusting scope or using full selector path
    - **Selector wrong**: Element doesn't exist anywhere → suggests checking spelling
  - Preserves the original timeout error as the `cause` property
  - Gracefully handles diagnostic failures without masking the original error

- **Updated action methods** (`see()`, `scope()`, `click()` in both `actor.ts` and `reactive.ts`):
  - Now use strict `resolveSelector()` + `waitFor()` directly
  - Catch timeout errors and wrap them with `buildSelectorMissError()` for better diagnostics
  - `ifClick()` remains conditional-only (no fallback, no error wrapping)

- **Updated tests**: Replaced 155 lines of fallback-behavior tests with 98 lines of diagnostic-message tests, covering:
  - Scope narrowing detection
  - Selector spelling validation
  - Action name inclusion in messages
  - Pluralization of match counts
  - Edge cases (scope === page, diagnostic failures)

## Implementation Details

The new approach is stricter but more transparent: developers now get immediate, specific feedback about what went wrong rather than silent fallback behavior that could hide configuration issues. The diagnostic check is best-effort (failures don't mask the original error) and only runs when resolution fails, avoiding performance overhead in the happy path.

https://claude.ai/code/session_01LXMLTmv9Wpfb7ut25P4yM9