### PR TITLE
Remove scene-vs-flow design rationale and architecture notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,17 +46,6 @@ packages/
 
 **For writing scene specs and inline assertions, see [`docs/public/design/writing-tests.md`](docs/public/design/writing-tests.md).** That guide covers both authoring models (`scene()` concurrent and `test()` classic driver), the actor DSL, and links to canonical references for selectors, text DSL format, and execution models. It is designed to be self-contained — copy it into your application repo's CLAUDE.md or reference it directly.
 
-**For the design rationale behind the two execution models, see [`docs/public/design/scene-vs-flow.md`](docs/public/design/scene-vs-flow.md).**
-
-### Architecture note for contributors
-
-There are two scene-authoring models with separate implementations:
-
-- **`test()`** — await-driven sequential orchestration (classic driver). Implemented in `actor.ts` (`SequentialActorHandleImpl`, `ActionChainImpl`).
-- **`scene()`** — reactive concurrent draining (concurrent model). Implemented in `reactive.ts` (`ConcurrentActorHandleImpl`, `drainAll()`).
-
-Both register through the same `sceneRegistry` in `scene.ts`. The runner (`runner.ts`) does not know which model a scene uses. Before 1.0, one model will be removed — see `scene-vs-flow.md` for the decision criteria and what needs to be ripped out for each path.
-
 ---
 
 ## Key Source Files


### PR DESCRIPTION
This PR removes outdated documentation from CLAUDE.md that described the internal architecture and design decisions around the two scene-authoring models.

## Summary
Removed the "Architecture note for contributors" section and the reference to `scene-vs-flow.md` from the main documentation. This content was intended as pre-1.0 guidance for deciding which execution model to keep, but is no longer relevant to users or current contributors.

## Changes
- Removed the link to `docs/public/design/scene-vs-flow.md` and its context
- Removed the "Architecture note for contributors" section that detailed:
  - The two scene-authoring models (`test()` and `scene()`)
  - Their respective implementations (`SequentialActorHandleImpl` vs `ConcurrentActorHandleImpl`)
  - The pre-1.0 decision criteria for removing one model

## Rationale
This documentation was specifically marked as pre-1.0 guidance and is no longer applicable. Keeping it in the main CLAUDE.md adds unnecessary complexity for users trying to understand how to write tests.

https://claude.ai/code/session_012CFkE87JT6e9jaHrZadxDH