### PR TITLE
Rename flow() to scene() and scene() to test() for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## [0.8.1] — 2026-04-17
+
+### API
+
+#### Authoring entry points renamed to match their semantics
+
+We had always intended for the scenetest typescript files to use the semantics of `scene()` and `test()`
+for the two different ways to author specs, with `scene` being the scenetest reactive runtime, while `test`
+would be for the async/await approach that is a very thin wrapper on the Playwright browser driver.
+
+But along the way something got confused, and we didn't figure it out until we actually started using all
+three methods in our project that uses the Scenetest library, so this change actually just brings the API
+code into alignment with the way documentation has claimed things worked all along.
+
+**Migration:** rename `flow` → `scene`, and rename any `scene(..., async ({ actor }) => await ...)` call to `test(..., async ({ actor }) => await ...)`. Markdown `.spec.md` files need no changes — they already compile through the reactive path.
+
+### Fixes
+
+#### Remove root-level `pnpm.overrides`
+
+The `devalue`, `nitro>h3`, and `srvx` overrides added in 0.8.0 were breaking the docs site build (TanStack Start + Nitro pulled in an `srvx`/`h3` combination that no longer resolved cleanly once pinned). The overrides are removed; the lockfile now resolves transitive deps naturally. If fresh dependabot alerts appear against `devalue`/`h3`/`srvx` we'll re-evaluate on a per-dep basis rather than pinning wholesale.
+
+---
+
 ## [0.8.0] — 2026-04-17
 
 Security-focused maintenance release. Resolves all open dependabot alerts (41 → 0) and adds a runtime nudge for consumers on outdated vite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ packages/
 - `fixtures.ts` — `scenePage` fixture, `waitForAssertions()`, failure logging
 
 ### Scenes (`packages/scenes/src/`)
-- `scene.ts` — `scene()` and `test()` registration, `runScene()`
-- `actor.ts` — `SequentialActorHandleImpl` with all DSL methods, `ActionChainImpl` with scope tracking (classic driver model)
-- `reactive.ts` — `ConcurrentActorHandleImpl`, `drainAll()`, `scene()` registration (declarative model)
+- `scene.ts` — `test()` registration (await-driven), shared `registerScene()` helper, `runScene()`, session accessors
+- `actor.ts` — `SequentialActorHandleImpl` with all DSL methods, `ActionChainImpl` with scope tracking (await-driven `test()` model)
+- `reactive.ts` — `ConcurrentActorHandleImpl`, `drainAll()`, `scene()` registration (reactive queue-building model)
 - `selectors.ts` — `resolveSelector()`, `explainSelector()`, alias registry
 - `dsl.ts` — `runDsl()`, `defineMacro()`, `runMacro()`, text DSL parser
 - `message-bus.ts` — `MessageBus` with sticky messages

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Choose your style — TypeScript or plain markdown:
 
 ```typescript
 // scenes/profile.spec.ts
-import { flow } from '@scenetest/scenes'
+import { scene } from '@scenetest/scenes'
 
-flow('user can update their name', ({ actor }) => {
+scene('user can update their name', ({ actor }) => {
   const user = actor('user')
 
   user.openTo('/')
@@ -108,7 +108,7 @@ pnpm scenetest
 - [Note on Security](./docs/public/faq/security.md)
 
 **Design Docs**
-- [Declarative Flow vs Classic Driver](./docs/public/design/scene-vs-flow.md) — execution model comparison and decision criteria
+- [TypeScript Scenes & Playwright Specs](./docs/public/reference/concurrent-and-classic.md) — the two TypeScript execution models side-by-side
 - [Actors API Design](./docs/public/design/actors-api.md)
 - [CLI Design](./docs/public/design/cli-v2.md) — text DSL grammar, selector resolution, warnings
 - [Server Actions Design](./docs/public/design/server-actions.md)

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/docs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/packages/checks-panel/package.json
+++ b/packages/checks-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-panel",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Observer panel for scenetest - displays assertions in real-time",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-react/package.json
+++ b/packages/checks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-react",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "React bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-solid/package.json
+++ b/packages/checks-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-solid",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Solid bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-svelte/package.json
+++ b/packages/checks-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-svelte",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Svelte bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-vue/package.json
+++ b/packages/checks-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-vue",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Vue bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/eslint-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "ESLint plugin for scenetest - accessibility and testing best practices",
   "type": "module",
   "license": "MIT",

--- a/packages/example-app-react/scenetest/scenes/basic.spec.ts
+++ b/packages/example-app-react/scenetest/scenes/basic.spec.ts
@@ -1,6 +1,6 @@
-import { scene } from '@scenetest/scenes'
+import { test } from '@scenetest/scenes'
 
-scene('user can see the welcome page', async ({ actor }) => {
+test('user can see the welcome page', async ({ actor }) => {
   const user = await actor('user')
 
   // Navigate to the app
@@ -11,7 +11,7 @@ scene('user can see the welcome page', async ({ actor }) => {
   await user.see('name-input')
 })
 
-scene('user can update their name', async ({ actor }) => {
+test('user can update their name', async ({ actor }) => {
   const user = await actor('user')
 
   await user.openTo('/')

--- a/packages/playwright-scenetest/package.json
+++ b/packages/playwright-scenetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/playwright",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Playwright fixtures for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes-panel/package.json
+++ b/packages/scenes-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes-panel",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Scene recorder for scenetest - records user interactions as DSL",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/src/__tests__/reactive.test.ts
+++ b/packages/scenes/src/__tests__/reactive.test.ts
@@ -67,7 +67,7 @@ function createTestActor(
 
 /**
  * Create a ConcurrentActorHandleImpl with deferred page (null).
- * Simulates how flow() creates actors before browser init.
+ * Simulates how the reactive scene() runner creates actors before browser init.
  */
 function createDeferredActor(role = 'user') {
   const bus = new MessageBus()
@@ -329,7 +329,7 @@ describe('ConcurrentActorHandleImpl', () => {
       actor.do(async () => { order.push('after') })
 
       // The mock locator returns isVisible=false by default, so the
-      // monitor won't fire.  This test verifies the flow completes
+      // monitor won't fire.  This test verifies the scene completes
       // without the monitor firing (selector not visible).
       await actor.drain()
 
@@ -484,7 +484,7 @@ describe('deferred page initialization', () => {
     actor.do(async () => { order.push('first') })
     actor.do(async () => { order.push('second') })
 
-    // Set page — simulates flow runner phase 2
+    // Set page — simulates scene runner phase 2
     actor._setPage(page as any)
 
     await actor.drain()

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -1,9 +1,11 @@
 // Public API for scene specs
-export { scene } from './scene.js'
+//
+// Two authoring entry points:
+//   - `scene()` — reactive queue-building (scenetest's unique approach)
+//   - `test()`  — await-driven sequential orchestration (Playwright-style)
+export { test } from './scene.js'
+export { scene } from './reactive.js'
 export { defineConfig, defineTeam } from './config.js'
-
-// Reactive flow API
-export { flow } from './reactive.js'
 
 // Text DSL for declarative scenes
 export { defineMacro, getMacro, clearMacros } from './dsl.js'
@@ -43,6 +45,9 @@ export type {
   ActorConfig,
   SceneOptions,
   SceneContext,
+  SceneFn,
+  TestContext,
+  TestFn,
   SequentialActorHandle,
   ActionChain,
   SceneReport,
@@ -52,8 +57,6 @@ export type {
   ConsoleError,
   Selector,
   ConcurrentActorHandle,
-  FlowContext,
-  FlowFn,
   SwarmConfig,
   SwarmReport,
   SwarmSceneResult,

--- a/packages/scenes/src/markdown-scene.ts
+++ b/packages/scenes/src/markdown-scene.ts
@@ -1,7 +1,7 @@
 /**
  * Markdown scene parser and loader.
  *
- * Parses `.spec.md` files into reactive flow registrations.  The format is
+ * Parses `.spec.md` files into reactive `scene()` registrations.  The format is
  * natural markdown — human-readable, GitHub-renderable, and executable:
  *
  * ```markdown
@@ -37,7 +37,7 @@
  * ## Format rules
  *
  * - `#` headings are **group names** (optional hierarchy/context)
- * - `##` headings are **scene names** (each becomes a `flow()` registration)
+ * - `##` headings are **scene names** (each becomes a reactive `scene()` registration)
  * - If no `##` headings exist, `#` headings are promoted to scene names
  * - `role-name:` switches the active actor for subsequent lines (like a screenplay cue)
  * - `role-name: action args` is inline shorthand for a one-line actor block
@@ -59,7 +59,7 @@
 import path from 'path'
 import type { ConcurrentActorHandle } from './types.js'
 import { parseAction, applyDslAction, getMacro } from './dsl.js'
-import { flow } from './reactive.js'
+import { scene as registerReactiveScene } from './reactive.js'
 import { sceneRegistry, setCurrentFile, getCurrentSession } from './scene.js'
 
 // ---------------------------------------------------------------------------
@@ -461,13 +461,13 @@ function interpolate(line: string, ctx: InterpolationContext): string {
 }
 
 // ---------------------------------------------------------------------------
-// Registration — convert parsed scenes into flow() registrations
+// Registration — convert parsed scenes into reactive scene() registrations
 // ---------------------------------------------------------------------------
 
 /**
- * Register parsed markdown scenes as reactive flows.
+ * Register parsed markdown scenes as reactive `scene()` calls.
  *
- * Each scene becomes a `flow()` call.  Actors are created upfront so
+ * Each markdown scene becomes a reactive `scene()` registration.  Actors are created upfront so
  * `[actor.field]` interpolation can reference any actor regardless of
  * declaration order.
  */
@@ -479,7 +479,7 @@ export function registerMarkdownScenes(
     // Extract unique roles from actor blocks for team matching
     const roles = [...new Set(mdScene.blocks.map(b => b.role))]
 
-    flow(mdScene.name, { roles }, ({ actor, team: teamMeta }) => {
+    registerReactiveScene(mdScene.name, { roles }, ({ actor, team: teamMeta }) => {
       // ── Phase 1: collect all unique roles and create actors ──────────
       const actors = new Map<string, ConcurrentActorHandle>()
 
@@ -579,7 +579,7 @@ export function registerMarkdownScenes(
                 aliases,
               }
 
-              // Apply macro actions inline (no await — flow model)
+              // Apply macro actions inline (no await — reactive scene model)
               // Uses unified [namespace.field] syntax — no {{var}} substitution
               for (const actionLine of macro) {
                 const interpolated = interpolate(actionLine, macroCtx)
@@ -607,7 +607,7 @@ export function registerMarkdownScenes(
 // ---------------------------------------------------------------------------
 
 /**
- * Load a `.spec.md` file: parse it and register all scenes as flows.
+ * Load a `.spec.md` file: parse it and register all scenes as reactive scenes.
  *
  * Called by the runner when it discovers `.spec.md` files alongside
  * `.spec.ts` files.

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -1,15 +1,16 @@
 /**
- * Reactive flow execution model.
+ * Reactive `scene()` execution model — scenetest's signature queue-building
+ * authoring surface.
  *
- * In the standard `scene()` model, `await` is the trigger — actions queue
+ * In the await-driven `test()` model, `await` is the trigger: actions queue
  * on a chain and execute only when awaited.  The test writer carries a
  * mental timeline: "has this happened yet?  do I need to wait?"
  *
- * In the reactive `flow()` model:
+ * In the reactive `scene()` model:
  *
  *   1. Actor DSL calls are **declarations** — they push to a persistent
  *      per-actor queue and return immediately.
- *   2. After the flow function returns, all actors **drain their queues
+ *   2. After the scene function returns, all actors **drain their queues
  *      concurrently** — each actor advances through its own queue as fast
  *      as the DOM allows.
  *   3. `see()`, `seeText()`, and friends already poll/wait for DOM state,
@@ -25,9 +26,9 @@
  *
  * @example
  * ```ts
- * import { flow } from '@scenetest/scenes'
+ * import { scene } from '@scenetest/scenes'
  *
- * flow('two users chat', ({ actor }) => {
+ * scene('two users chat', ({ actor }) => {
  *   const alice = actor('alice')
  *   const bob   = actor('bob')
  *
@@ -54,8 +55,9 @@ import type {
   ScriptWarning,
   ConsoleError,
   ErrorSelector,
-  FlowContext,
-  FlowFn,
+  SceneContext,
+  SceneFn,
+  TestContext,
   SceneOptions,
   ConcurrentActorHandle,
   TeamConfig,
@@ -67,7 +69,7 @@ import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOptio
 import { MessageBus } from './message-bus.js'
 import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
-import { scene, getCurrentSession } from './scene.js'
+import { registerScene, getCurrentSession } from './scene.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
 
@@ -122,7 +124,7 @@ interface ErrorSelectorTrigger {
 }
 
 // ---------------------------------------------------------------------------
-// Conditional monitor — the flow model's answer to if()
+// Conditional monitor — the reactive model's answer to if()
 // ---------------------------------------------------------------------------
 
 /**
@@ -149,7 +151,7 @@ interface ConditionalMonitor {
 // ---------------------------------------------------------------------------
 
 /**
- * Concurrent actor handle implementation (declarative / flow model).
+ * Concurrent actor handle implementation (declarative / reactive scene model).
  *
  * Unlike `SequentialActorHandleImpl`, every DSL method pushes to a single
  * persistent queue on the actor itself and returns `this`.  Scope lives on
@@ -246,7 +248,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
 
   /**
    * Set the Playwright page for this actor.
-   * Called by the flow runner after declaration, before drain.
+   * Called by the scene runner after declaration, before drain.
    */
   _setPage(page: Page): void {
     this._page = page
@@ -255,7 +257,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
 
   /**
    * Set the actor registry for [actor.field] interpolation.
-   * Called by the flow runner after all actors are created.
+   * Called by the scene runner after all actors are created.
    */
   _setActorRegistry(registry: Map<string, ConcurrentActorHandle>): void {
     this._actorRegistry = registry
@@ -277,7 +279,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
 
   /**
    * Set the page factory for switchDevice support.
-   * Called by the flow runner after page initialization.
+   * Called by the scene runner after page initialization.
    */
   _setPageFactory(factory: PageFactory): void {
     this._pageFactory = factory
@@ -852,8 +854,8 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   /**
    * Register a persistent warning trigger.
    * If the selector becomes visible during any action, a warning is recorded.
-   * Unlike the `scene()` model, there are no watchers that clear after
-   * each await — warnings are the right primitive for reactive flows.
+   * Unlike the `test()` await-driven model, there are no watchers that clear
+   * after each await — warnings are the right primitive for reactive scenes.
    */
   warnIf(selector: Selector, message: string): void {
     this.warningTriggers.push({ selector, message, triggered: false })
@@ -921,7 +923,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
    * Drain the action queue.
    *
    * Executes all queued actions sequentially.  Called automatically by the
-   * flow runner after the declaration phase completes.
+   * scene runner after the declaration phase completes.
    *
    * Each action is executed with concurrent warning-trigger polling (same
    * approach as `ActionChainImpl.executeWithWatchers`).
@@ -1192,21 +1194,24 @@ export async function drainAll(actors: ConcurrentActorHandleImpl[]): Promise<voi
 }
 
 // ---------------------------------------------------------------------------
-// flow() — reactive scene registration
+// scene() — reactive scene registration
 // ---------------------------------------------------------------------------
 
 /**
- * Define a reactive flow.
+ * Define a reactive scene — scenetest's signature queue-building model.
  *
- * Inside the flow function, actor DSL calls just queue actions — nothing
+ * Inside the scene function, actor DSL calls just queue actions — nothing
  * executes.  After the function returns, all actors drain their queues
  * concurrently through the application.
  *
+ * For the await-driven Playwright-style authoring model, use `test()` from
+ * `./scene.js` instead.
+ *
  * @example
  * ```ts
- * import { flow } from '@scenetest/scenes'
+ * import { scene } from '@scenetest/scenes'
  *
- * flow('user updates profile', ({ actor }) => {
+ * scene('user updates profile', ({ actor }) => {
  *   const user = actor('user')
  *
  *   user.openTo('/login')
@@ -1229,7 +1234,7 @@ export async function drainAll(actors: ConcurrentActorHandleImpl[]): Promise<voi
  *
  * @example Multi-actor
  * ```ts
- * flow('two users chat', ({ actor }) => {
+ * scene('two users chat', ({ actor }) => {
  *   const alice = actor('alice')
  *   const bob   = actor('bob')
  *
@@ -1241,18 +1246,19 @@ export async function drainAll(actors: ConcurrentActorHandleImpl[]): Promise<voi
  * })
  * ```
  */
-export function flow(name: string, fn: FlowFn): void
-export function flow(name: string, options: SceneOptions, fn: FlowFn): void
-export function flow(name: string, fnOrOptions: FlowFn | SceneOptions, maybeFn?: FlowFn): void {
+export function scene(name: string, fn: SceneFn): void
+export function scene(name: string, options: SceneOptions, fn: SceneFn): void
+export function scene(name: string, fnOrOptions: SceneFn | SceneOptions, maybeFn?: SceneFn): void {
   const fn = typeof fnOrOptions === 'function' ? fnOrOptions : maybeFn!
   const options = typeof fnOrOptions === 'function' ? undefined : fnOrOptions
 
-  // Register as a normal scene — the runner doesn't need to know it's
-  // reactive.  The wrapping scene fn handles the three-phase execution.
-  const wrappedFn = async (context: import('./types.js').SceneContext) => {
+  // Register through the shared helper — the runner doesn't need to know
+  // this scene is reactive.  The wrapper handles the three-phase execution
+  // and presents a uniform TestFn shape to the registry.
+  const wrappedFn = async (context: TestContext) => {
     const session = getCurrentSession()
     if (!session) {
-      throw new Error('flow() must be run inside the scene runner')
+      throw new Error('scene() must be run inside the scene runner')
     }
 
     const reactiveActors: ConcurrentActorHandleImpl[] = []
@@ -1268,7 +1274,7 @@ export function flow(name: string, fnOrOptions: FlowFn | SceneOptions, maybeFn?:
       ...(teamMeta.name ? { name: teamMeta.name } : {}),
     }
 
-    const flowContext: FlowContext = {
+    const sceneContext: SceneContext = {
       actor: (role: string) => {
         // Check if already created (re-referencing an actor)
         const existing = actorRegistry.get(role)
@@ -1311,8 +1317,8 @@ export function flow(name: string, fnOrOptions: FlowFn | SceneOptions, maybeFn?:
     }
 
     // Phase 1: Declaration — user code queues actions, nothing executes.
-    //          actor() is synchronous so the flow body can be sync too.
-    const result = fn(flowContext)
+    //          actor() is synchronous so the scene body can be sync too.
+    const result = fn(sceneContext)
     if (result && typeof (result as Promise<void>).then === 'function') {
       await result
     }
@@ -1342,9 +1348,5 @@ export function flow(name: string, fnOrOptions: FlowFn | SceneOptions, maybeFn?:
     await drainAll(reactiveActors)
   }
 
-  if (options) {
-    scene(name, options, wrappedFn)
-  } else {
-    scene(name, wrappedFn)
-  }
+  registerScene(name, wrappedFn, options)
 }

--- a/packages/scenes/src/scene.ts
+++ b/packages/scenes/src/scene.ts
@@ -1,9 +1,16 @@
-import type { SceneFn, SceneOptions, RegisteredScene, SceneContext, SceneReport } from './types.js'
+import type { TestFn, SceneOptions, RegisteredScene, TestContext, SceneReport } from './types.js'
 import { TeamSession } from './team-manager.js'
 
 /**
  * Global registry of scenes.
  * Populated when scene files are imported.
+ *
+ * Both authoring entry points register here:
+ *   - `test()` — await-driven sequential driver (this file)
+ *   - `scene()` — reactive queue-building (see `reactive.ts`)
+ *
+ * The reactive `scene()` wraps its user fn into an async function so that
+ * the runner sees a uniform `TestFn` shape regardless of authoring model.
  */
 export const sceneRegistry: RegisteredScene[] = []
 
@@ -20,36 +27,50 @@ export function setCurrentFile(file: string): void {
 }
 
 /**
- * Define a scene spec.
+ * Internal registration helper used by both `test()` and the reactive `scene()`.
  *
- * @example
- * ```ts
- * import { scene } from '@scenetest/scenes'
- *
- * scene('user updates their profile', async ({ actor }) => {
- *   const user = await actor('primary-user')
- *   await user.openTo('/settings/profile')
- *   await user.see('profile-form')
- * })
- *
- * // With roles for team matching:
- * scene('admin promotes user', { roles: ['admin', 'user'] }, async ({ actor }) => {
- *   const admin = await actor('admin')
- *   const user = await actor('user')
- * })
- * ```
+ * Not part of the public API — authors should use `test()` or `scene()`.
  */
-export function scene(name: string, fn: SceneFn): void
-export function scene(name: string, options: SceneOptions, fn: SceneFn): void
-export function scene(name: string, fnOrOptions: SceneFn | SceneOptions, maybeFn?: SceneFn): void {
-  const fn = typeof fnOrOptions === 'function' ? fnOrOptions : maybeFn!
-  const options = typeof fnOrOptions === 'function' ? undefined : fnOrOptions
+export function registerScene(name: string, fn: TestFn, options?: SceneOptions): void {
   sceneRegistry.push({
     name,
     fn,
     file: currentFile,
     ...(options?.roles ? { roles: options.roles } : {}),
   })
+}
+
+/**
+ * Define an await-driven test (Playwright-style sequential orchestration).
+ *
+ * Each DSL call is awaited in order — the mental model is "first this, then
+ * that."  Use this when you want explicit, linear control flow.  For the
+ * reactive queue-building model (scenetest's unique approach), use `scene()`
+ * from `./reactive.ts`.
+ *
+ * @example
+ * ```ts
+ * import { test } from '@scenetest/scenes'
+ *
+ * test('user updates their profile', async ({ actor }) => {
+ *   const user = await actor('primary-user')
+ *   await user.openTo('/settings/profile')
+ *   await user.see('profile-form')
+ * })
+ *
+ * // With roles for team matching:
+ * test('admin promotes user', { roles: ['admin', 'user'] }, async ({ actor }) => {
+ *   const admin = await actor('admin')
+ *   const user = await actor('user')
+ * })
+ * ```
+ */
+export function test(name: string, fn: TestFn): void
+export function test(name: string, options: SceneOptions, fn: TestFn): void
+export function test(name: string, fnOrOptions: TestFn | SceneOptions, maybeFn?: TestFn): void {
+  const fn = typeof fnOrOptions === 'function' ? fnOrOptions : maybeFn!
+  const options = typeof fnOrOptions === 'function' ? undefined : fnOrOptions
+  registerScene(name, fn, options)
 }
 
 /**
@@ -65,8 +86,8 @@ export function setCurrentSession(session: TeamSession | null): void {
 }
 
 /**
- * Get the current session. Used by flow() to access session internals
- * during reactive scene execution.
+ * Get the current session. Used by `scene()` (reactive) to access session
+ * internals during execution.
  */
 export function getCurrentSession(): TeamSession | null {
   return currentSession
@@ -83,7 +104,7 @@ export async function runScene(
   const start = Date.now()
 
   // Create scene context
-  const context: SceneContext = {
+  const context: TestContext = {
     actor: async (role: string) => {
       return session.getActor(role)
     },
@@ -91,7 +112,7 @@ export async function runScene(
     team: session.meta,
   }
 
-  // Set current session for when() calls
+  // Set current session for reactive scene() calls
   setCurrentSession(session)
 
   let status: SceneReport['status'] = 'completed'

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -348,7 +348,7 @@ export class TeamSession {
 
   /**
    * Get the actor config for a role (sync — no browser setup).
-   * Used by flow() to create reactive handles before browser init.
+   * Used by scene() (reactive) to create reactive handles before browser init.
    */
   getActorConfig(role: string): ActorConfig {
     const config = this.team[role]
@@ -371,7 +371,7 @@ export class TeamSession {
    * Get the navigation mode assigned to an actor role.
    * If rotation is enabled, assigns and caches a mode for this role.
    * If rotation is not enabled, returns 'pointer'.
-   * Used by flow() to pass the mode to ConcurrentActorHandleImpl.
+   * Used by scene() (reactive) to pass the mode to ConcurrentActorHandleImpl.
    */
   getNavigationMode(role: string): NavigationMode {
     // Return cached mode if already assigned
@@ -385,7 +385,7 @@ export class TeamSession {
 
   /**
    * Get whether fuzzy-finger touch behavior is enabled.
-   * Used by flow() to pass to ConcurrentActorHandleImpl.
+   * Used by scene() (reactive) to pass to ConcurrentActorHandleImpl.
    */
   getFuzzyFingers(): boolean {
     return this.fuzzyFingers
@@ -393,7 +393,7 @@ export class TeamSession {
 
   /**
    * Get global error selectors for this session.
-   * Used by flow() to pass to ConcurrentActorHandleImpl.
+   * Used by scene() (reactive) to pass to ConcurrentActorHandleImpl.
    */
   getErrorSelectors(): ErrorSelector[] | undefined {
     return this.errorSelectors
@@ -401,7 +401,7 @@ export class TeamSession {
 
   /**
    * Create a browser context + page for a role and wire up assertion collection.
-   * Returns the Page. Used by flow() to initialize actors after declaration.
+   * Returns the Page. Used by scene() (reactive) to initialize actors after declaration.
    */
   async createPage(role: string): Promise<Page> {
     const config = this.team[role]

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -574,13 +574,17 @@ export interface Actor {
 }
 
 /**
- * Context passed to scene function
+ * Context passed to a `test()` function.
+ *
+ * `test()` is the await-driven authoring model — each DSL call is awaited
+ * in sequence, like Playwright's `test()`.  `actor()` returns a promise
+ * because the actor's browser context is created lazily.
  */
-export interface SceneContext {
+export interface TestContext {
   /** Get an actor by role from the current team */
   actor: (role: string) => Promise<SequentialActorHandle>
 
-  /** The team index assigned to this scene */
+  /** The team index assigned to this test */
   teamIndex: number
 
   /** Team metadata (name, tags) */
@@ -877,9 +881,9 @@ export interface ActionChain extends PromiseLike<void> {
 }
 
 /**
- * Scene definition function
+ * `test()` definition function — await-driven sequential orchestration.
  */
-export type SceneFn = (context: SceneContext) => Promise<void>
+export type TestFn = (context: TestContext) => Promise<void>
 
 /**
  * Options for scene/flow registration.
@@ -890,11 +894,16 @@ export interface SceneOptions {
 }
 
 /**
- * Registered scene
+ * Registered scene — internal runner representation.
+ *
+ * Both `test()` (await-driven) and `scene()` (reactive queue-building)
+ * register here.  The runner is agnostic: the reactive `scene()` wraps
+ * its user fn into an async function so everything in the registry has
+ * the same shape.
  */
 export interface RegisteredScene {
   name: string
-  fn: SceneFn
+  fn: TestFn
   file: string
   /**
    * Pre/post-cleanup expressions from `cleanup:` directives in .spec.md files.
@@ -1076,32 +1085,34 @@ export interface ConcurrentActorHandle {
 }
 
 /**
- * Context passed to a flow function.
+ * Context passed to a `scene()` function.
  *
- * `actor()` is synchronous — it returns a reactive handle immediately.
- * Browser contexts are created in parallel after the declaration phase,
- * before actors begin draining their queues.
+ * `scene()` is the reactive queue-building model — DSL calls are
+ * declarations that push onto each actor's persistent queue and return
+ * immediately.  `actor()` is therefore synchronous: it returns a handle
+ * straight away.  Browser contexts are created in parallel after the
+ * declaration phase, before actors begin draining their queues.
  */
-export interface FlowContext {
+export interface SceneContext {
   /** Get or create a concurrent actor by role (synchronous — no await needed) */
   actor: (role: string) => ConcurrentActorHandle
-  /** The team index assigned to this flow */
+  /** The team index assigned to this scene */
   teamIndex: number
   /** Team metadata (name, tags) */
   team: TeamMeta
 }
 
 /**
- * Flow definition function.
+ * `scene()` definition function — reactive / declarative.
  *
  * The function body is the *declaration phase* — actor creation and DSL
  * calls are all synchronous.  After it returns, browsers launch in parallel,
  * then all actors drain their queues concurrently.
  *
- * The function may be async (for backward compatibility or if you need
- * top-level await for non-actor reasons), but it doesn't need to be.
+ * The function may be async if you need top-level await for non-actor
+ * reasons, but it doesn't need to be.
  */
-export type FlowFn = (context: FlowContext) => void | Promise<void>
+export type SceneFn = (context: SceneContext) => void | Promise<void>
 
 /**
  * CLI options

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",

--- a/packages/vscode-scenetest/package.json
+++ b/packages/vscode-scenetest/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-scenetest",
   "displayName": "Scenetest",
   "description": "Syntax highlighting for Scenetest scene specs (.spec.md)",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "publisher": "scenetest",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

This PR renames the reactive authoring API from `flow()` to `scene()` and the sequential authoring API from `scene()` to `test()`. This change clarifies the distinction between scenetest's two execution models and aligns terminology with the broader testing ecosystem.

## Key Changes

- **Renamed `flow()` → `scene()`**: The reactive queue-building model (scenetest's signature approach) is now called `scene()`. This is the primary authoring surface where DSL calls are declarations that queue actions.

- **Renamed `scene()` → `test()`**: The await-driven sequential model (Playwright-style) is now called `test()`. This clarifies that it's the traditional sequential orchestration pattern.

- **Updated type names**:
  - `FlowContext` → `SceneContext` (context for reactive `scene()`)
  - `FlowFn` → `SceneFn` (function type for reactive `scene()`)
  - `SceneContext` → `TestContext` (context for await-driven `test()`)
  - `SceneFn` → `TestFn` (function type for await-driven `test()`)

- **Extracted `registerScene()` helper**: Created an internal registration function in `scene.js` used by both `test()` and the reactive `scene()` wrapper. This ensures both authoring models register through a uniform interface.

- **Updated exports**: The public API now exports both `test()` and `scene()` as the two primary entry points, with clear documentation distinguishing their execution models.

- **Updated documentation**: All comments, examples, and docstrings now use the new terminology consistently throughout the codebase.

- **Updated markdown scene loader**: Changed to use the reactive `scene()` registration internally (aliased as `registerReactiveScene` for clarity).

## Implementation Details

- The reactive `scene()` function wraps user code into an async function that the runner sees as a `TestFn`, maintaining a uniform registry shape regardless of authoring model.
- Both authoring models now go through `registerScene()` for consistent registration behavior.
- The three-phase execution model (declaration → browser init → drain) remains unchanged; only the naming and API surface have been clarified.
- All internal comments referencing "flow model" or "reactive flow" have been updated to "reactive scene model" or "reactive `scene()`".

https://claude.ai/code/session_014Zjoyc9nHBk3bPM64St8a1