### PR TITLE
Use Vite's generateBundle hook instead of closeBundle for llms.txt

### DIFF
--- a/docs/vite-plugin-llms-txt.ts
+++ b/docs/vite-plugin-llms-txt.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
+import { readdirSync, readFileSync, existsSync } from 'fs'
 import { join } from 'path'
 import type { Plugin } from 'vite'
 
@@ -144,19 +144,19 @@ export function llmsTxt(): Plugin {
       })
     },
 
-    closeBundle() {
-      // Write to Nitro output directory after build.
-      // Use mkdirSync to ensure the directory exists — our closeBundle may
-      // fire before Nitro's plugin has created .output/public/.
-      const outDir = join(process.cwd(), '.output/public')
-      mkdirSync(outDir, { recursive: true })
+    // Emit during the client build so the files land in whatever static output
+    // directory the active Nitro preset uses (e.g. .vercel/output/static for
+    // the vercel preset, .output/public for node-server). Writing to a fixed
+    // path breaks in production because the preset's static dir differs.
+    generateBundle() {
+      if (this.environment?.name !== 'client') return
 
       const base = join(process.cwd(), PUBLIC_DIR)
       llmsTxtContent ??= buildLlmsTxt(base)
       llmsFullTxtContent ??= buildLlmsFullTxt(base)
 
-      writeFileSync(join(outDir, 'llms.txt'), llmsTxtContent)
-      writeFileSync(join(outDir, 'llms-full.txt'), llmsFullTxtContent)
+      this.emitFile({ type: 'asset', fileName: 'llms.txt', source: llmsTxtContent })
+      this.emitFile({ type: 'asset', fileName: 'llms-full.txt', source: llmsFullTxtContent })
     },
   }
 }


### PR DESCRIPTION
## Summary
Refactored the Vite plugin to emit `llms.txt` and `llms-full.txt` files using Vite's `generateBundle` hook instead of manually writing files in `closeBundle`. This ensures the files are placed in the correct static output directory for the active Nitro preset.

## Key Changes
- Replaced `closeBundle` hook with `generateBundle` hook to emit files during the client build phase
- Removed manual file system operations (`writeFileSync`, `mkdirSync`) in favor of Vite's `emitFile` API
- Added environment check to only emit files during the client build (`this.environment?.name !== 'client'`)
- Removed unused imports (`writeFileSync`, `mkdirSync`) from the `fs` module

## Implementation Details
The previous approach of writing to a fixed `.output/public` directory broke in production when using different Nitro presets (e.g., Vercel preset uses `.vercel/output/static`). By using `generateBundle` with `emitFile`, the files are now automatically placed in whatever static output directory the active preset uses, making the plugin preset-agnostic and more robust.

https://claude.ai/code/session_019kqBvQP3DEFGArjAB8aHZ8