### PR TITLE
Exit with error code when test report indicates failures

### DIFF
--- a/packages/checks/tsconfig.json
+++ b/packages/checks/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__"]
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__"]
 }

--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -72,6 +72,8 @@ program
       // Initialize browser
       await runner.init()
 
+      let exitCode = 0
+
       try {
         // Resolve scene file paths
         let sceneFiles: string[] | undefined
@@ -92,12 +94,14 @@ program
             const report = await runner.runSwarmMode('manual')
             printSummary(report)
             await writeReport(report, config.reportDir!, config.reportFormat!)
+            if (reportFailed(report)) exitCode = 1
           }
         } else {
           // ── Normal run ──
           const report = await runner.run(sceneFiles)
           printSummary(report)
           await writeReport(report, config.reportDir!, config.reportFormat!)
+          if (reportFailed(report)) exitCode = 1
 
           // Check if swarm should auto-trigger
           const triggeringScenes = runner.checkSwarmTrigger()
@@ -122,11 +126,23 @@ program
           await runner.close()
         }
       }
+
+      if (exitCode !== 0) {
+        process.exit(exitCode)
+      }
     } catch (err) {
       console.error('Error:', err instanceof Error ? err.message : err)
       process.exit(1)
     }
   })
+
+function reportFailed(report: RunReport): boolean {
+  return (
+    report.summary.failed > 0 ||
+    report.summary.completed < report.summary.scenes ||
+    report.summary.assertions.failed > 0
+  )
+}
 
 /**
  * Write report to files

--- a/packages/scenes/tsconfig.json
+++ b/packages/scenes/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__"]
 }

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["src/dev-panel"]
+  "exclude": ["src/dev-panel", "src/**/__tests__"]
 }


### PR DESCRIPTION
## Summary
Modified the CLI to properly exit with a non-zero exit code when test runs result in failures, allowing CI/CD pipelines to detect and respond to test failures appropriately.

## Key Changes
- Added `exitCode` variable to track whether tests failed
- Introduced `reportFailed()` helper function that checks if a report indicates failure by examining:
  - Failed test count
  - Incomplete test execution (completed < total scenes)
  - Failed assertions
- Updated both normal run and swarm mode paths to set `exitCode = 1` when `reportFailed()` returns true
- Added exit handler that calls `process.exit(exitCode)` after cleanup when failures are detected

## Implementation Details
The `reportFailed()` function uses three conditions to determine failure status, ensuring that not only explicit test failures but also incomplete test execution (which may indicate a crash or timeout) are properly reported as failures. This comprehensive check ensures CI/CD systems can reliably detect problematic test runs.

https://claude.ai/code/session_017RncEH1x1Kk7aAduGmNDuo