### PR TITLE
Fix dashboard stats to track scenes instead of assertions

### DIFF
--- a/docs/public/reference/live-dashboard.md
+++ b/docs/public/reference/live-dashboard.md
@@ -51,8 +51,8 @@ If the Vite dev server isn't running or doesn't have the scenetest plugin, event
 Shows run-level stats updated in real-time:
 
 - **Scenes** — completed / total
-- **Pass** — assertion pass count
-- **Fail** — assertion fail count
+- **Pass** — scenes that completed successfully
+- **Fail** — scenes that failed or timed out
 - **Time** — elapsed duration
 - **Connection indicator** — green (connected), amber (connecting), red (disconnected)
 

--- a/packages/vite-plugin/src/dashboard.ts
+++ b/packages/vite-plugin/src/dashboard.ts
@@ -795,9 +795,6 @@ export function generateDashboardHtml(): string {
             result: event.result,
             timestamp: event.timestamp,
           })
-          if (event.result) state.passCount++
-          else state.failCount++
-          updateStats()
           renderScene(scene)
           break
         }
@@ -809,6 +806,8 @@ export function generateDashboardHtml(): string {
           scene.status = event.status
           scene.duration = event.duration
           scene.error = event.error
+          if (event.status === 'completed') state.passCount++
+          else state.failCount++
           state.currentScene = null
           renderScene(scene)
           updateStats()
@@ -817,8 +816,10 @@ export function generateDashboardHtml(): string {
 
         case 'run:end':
           state.sceneCount = event.summary?.scenes || state.sceneCount
-          state.passCount = event.summary?.assertions?.passed || state.passCount
-          state.failCount = event.summary?.assertions?.failed || state.failCount
+          if (event.summary) {
+            state.passCount = event.summary.completed ?? state.passCount
+            state.failCount = event.summary.failed ?? state.failCount
+          }
           document.getElementById('elapsed').textContent = event.duration + 'ms'
           setRunning(false)
           updateStats()


### PR DESCRIPTION
## Summary
Updated the dashboard statistics tracking to count completed/failed scenes instead of assertion pass/fail counts, aligning the UI with the actual test execution model.

## Key Changes
- **Event handling refactor**: Moved pass/fail count logic from `assertion:end` event handler to `scene:end` event handler, since scenes (not individual assertions) are the primary test unit
- **Status-based counting**: Changed from boolean result-based counting to status-based counting (`'completed'` status increments pass count, all other statuses increment fail count)
- **Summary parsing fix**: Updated `run:end` event handler to use `event.summary.completed` and `event.summary.failed` fields instead of `event.summary.assertions.passed/failed`
- **Documentation update**: Updated live dashboard reference to clarify that Pass/Fail stats represent scene counts, not assertion counts

## Implementation Details
- Removed `updateStats()` call from `assertion:end` handler to avoid premature stat updates
- Pass/fail counting now occurs at the scene completion level, providing more meaningful metrics
- Uses nullish coalescing (`??`) operator for safer fallback to previous state values in the `run:end` handler

https://claude.ai/code/session_01UAhJuUbdo7kTzyTS5JGFER