### PR TITLE
Fix same-element selector matching for coexisting attributes

### DIFF
--- a/packages/scenes/src/__tests__/selectors.test.ts
+++ b/packages/scenes/src/__tests__/selectors.test.ts
@@ -128,7 +128,7 @@ describe('resolveSelector', () => {
         (c) => c.method === 'locator' && String(c.args[0]).includes('xpath=self')
       )
       expect(xpathCall).toBeTruthy()
-      expect(String(xpathCall!.args[0])).toContain('data-key="review-link"')
+      expect(String(xpathCall!.args[0])).toContain('@data-key="review-link"')
 
       // Step 3: descendant = locator.locator(token2CSS)
       const descendantCall = calls.find(
@@ -166,23 +166,47 @@ describe('resolveSelector', () => {
       expect(firstCalls).toHaveLength(0)
     })
 
-    it('data-key same-element pattern: uses xpath self-match', () => {
+    it('data-key same-element pattern: uses xpath self-match with all attributes', () => {
       const { page, calls } = createMockPage()
 
       resolveSelector(page, 'playlist-row 12345 like-button')
 
-      // For token "12345", should have xpath self::*[@data-key="12345"]
+      // For each non-first token, should have xpath self::*[...all attrs...]
       const xpathCalls = calls.filter(
         (c) => c.method === 'locator' && String(c.args[0]).includes('xpath=self')
       )
       expect(xpathCalls).toHaveLength(2) // once for "12345", once for "like-button"
 
-      expect(String(xpathCalls[0].args[0])).toContain('data-key="12345"')
-      expect(String(xpathCalls[1].args[0])).toContain('data-key="like-button"')
+      // Each xpath predicate covers all attribute types, including data-key
+      expect(String(xpathCalls[0].args[0])).toContain('@data-key="12345"')
+      expect(String(xpathCalls[0].args[0])).toContain('@data-testid="12345"')
+      expect(String(xpathCalls[1].args[0])).toContain('@data-key="like-button"')
+      expect(String(xpathCalls[1].args[0])).toContain('@data-testid="like-button"')
 
       // NO .first() called anywhere
       const firstCalls = calls.filter((c) => c.method === 'first')
       expect(firstCalls).toHaveLength(0)
+    })
+
+    it('same-element data-testid match: deck-tile case where data-key and data-testid share an element', () => {
+      // Regression: selector "decks-list-grid kan deck-tile" where the button has
+      // both data-key="kan" AND data-testid="deck-tile" — the last token must
+      // match the same element via data-testid, not only via data-key.
+      const { page, calls } = createMockPage()
+
+      resolveSelector(page, 'decks-list-grid kan deck-tile')
+
+      const xpathCalls = calls.filter(
+        (c) => c.method === 'locator' && String(c.args[0]).includes('xpath=self')
+      )
+      // Two same-element checks: one for "kan", one for "deck-tile"
+      expect(xpathCalls).toHaveLength(2)
+
+      // "deck-tile" xpath must include data-testid so it can match [data-testid="deck-tile"]
+      const deckTileXpath = String(xpathCalls[1].args[0])
+      expect(deckTileXpath).toContain('@data-testid="deck-tile"')
+      expect(deckTileXpath).toContain('@aria-label="deck-tile"')
+      expect(deckTileXpath).toContain('@data-key="deck-tile"')
     })
 
     it('builds correct CSS selector with all attribute types', () => {

--- a/packages/scenes/src/__tests__/selectors.test.ts
+++ b/packages/scenes/src/__tests__/selectors.test.ts
@@ -238,6 +238,87 @@ describe('resolveSelector', () => {
     })
   })
 
+  // ---------------------------------------------------------------------------
+  // Same-element attribute coexistence
+  //
+  // When data-key and another attribute (e.g. data-testid) share a single DOM
+  // element, the selector chain should resolve regardless of which attribute
+  // comes first in the token sequence.
+  // ---------------------------------------------------------------------------
+  describe('same-element attribute coexistence', () => {
+    /**
+     * Pull out the xpath same-element locator calls in the order they were made.
+     * Each non-first token in a multi-token selector produces exactly one xpath call.
+     */
+    function xpathCalls(calls: Array<{ method: string; args: unknown[]; on: string }>) {
+      return calls
+        .filter((c) => c.method === 'locator' && String(c.args[0]).startsWith('xpath=self'))
+        .map((c) => String(c.args[0]))
+    }
+
+    it('same-element xpath includes all six attribute types', () => {
+      const { page, calls } = createMockPage()
+      resolveSelector(page, 'grid item')
+
+      const [xpath] = xpathCalls(calls)
+      expect(xpath).toContain('@aria-label="item"')
+      expect(xpath).toContain('@id="item"')
+      expect(xpath).toContain('@data-testid="item"')
+      expect(xpath).toContain('@data-name="item"')
+      expect(xpath).toContain('@data-key="item"')
+      expect(xpath).toContain('@name="item"')
+    })
+
+    it('data-key token then data-testid token (kan → deck-tile order)', () => {
+      // Element has data-key="kan" AND data-testid="deck-tile" on the same node.
+      // "kan" is found via descendant data-key match; "deck-tile" must then match
+      // the same element via data-testid — not a child.
+      const { page, calls } = createMockPage()
+      resolveSelector(page, 'decks-list-grid kan deck-tile')
+
+      const [kanXpath, deckTileXpath] = xpathCalls(calls)
+
+      expect(kanXpath).toContain('@data-key="kan"')
+
+      // Critical: deck-tile same-element check must include @data-testid
+      expect(deckTileXpath).toContain('@data-testid="deck-tile"')
+    })
+
+    it('data-testid token then data-key token (deck-tile → kan order)', () => {
+      // Reversed order: "deck-tile" found as descendant via data-testid, then
+      // "kan" matches the same element via data-key.
+      const { page, calls } = createMockPage()
+      resolveSelector(page, 'decks-list-grid deck-tile kan')
+
+      const [deckTileXpath, kanXpath] = xpathCalls(calls)
+
+      expect(deckTileXpath).toContain('@data-testid="deck-tile"')
+      expect(kanXpath).toContain('@data-key="kan"')
+    })
+
+    it('both orderings produce the same chain structure', () => {
+      // Neither ordering should be privileged — same number of or() calls either way.
+      const forward = createMockPage()
+      const reversed = createMockPage()
+
+      resolveSelector(forward.page, 'grid kan deck-tile')
+      resolveSelector(reversed.page, 'grid deck-tile kan')
+
+      const forwardOrCount = forward.calls.filter((c) => c.method === 'or').length
+      const reversedOrCount = reversed.calls.filter((c) => c.method === 'or').length
+      expect(forwardOrCount).toBe(reversedOrCount)
+    })
+
+    it('aria-label and data-key on the same element', () => {
+      const { page, calls } = createMockPage()
+      resolveSelector(page, 'nav Japanese settings')
+
+      const [, settingsXpath] = xpathCalls(calls)
+      expect(settingsXpath).toContain('@aria-label="settings"')
+      expect(settingsXpath).toContain('@data-key="settings"')
+    })
+  })
+
   describe('#N nth-element narrowing', () => {
     it('#1 calls .nth(0) on the current locator', () => {
       const { page, calls } = createMockPage()

--- a/packages/scenes/src/selectors.ts
+++ b/packages/scenes/src/selectors.ts
@@ -54,6 +54,23 @@ function buildTokenSelector(token: string): string {
 }
 
 /**
+ * Build an XPath predicate (without outer brackets) matching any of the same
+ * attributes as buildTokenSelector. Used for same-element filtering in
+ * resolveSelector so that e.g. [data-key="kan"][data-testid="deck-tile"] on
+ * the same element is found when the selector chain ends on that element.
+ */
+function buildXpathTokenPredicate(token: string): string {
+  return [
+    `@aria-label="${token}"`,
+    `@id="${token}"`,
+    `@data-testid="${token}"`,
+    `@data-name="${token}"`,
+    `@data-key="${token}"`,
+    `@name="${token}"`,
+  ].join(' or ')
+}
+
+/**
  * Resolve a single token to a locator.
  * Handles aliases (~) and explicit aria-labels (@).
  */
@@ -143,8 +160,8 @@ export function resolveSelector(base: Page | Locator, selector: string): Locator
       continue
     }
 
-    // Same-element match: current element has data-key=nextToken (stay on it)
-    const sameElement = locator.locator(`xpath=self::*[@data-key="${nextToken}"]`)
+    // Same-element match: current element itself matches nextToken by any attribute
+    const sameElement = locator.locator(`xpath=self::*[${buildXpathTokenPredicate(nextToken)}]`)
     // Descendant match: find child/descendant matching nextToken (descend)
     const descendant = locator.locator(buildTokenSelector(nextToken))
 


### PR DESCRIPTION
## Summary
Fixed selector resolution to correctly match elements when multiple attributes (e.g., `data-key` and `data-testid`) coexist on the same DOM element. Previously, same-element matching only checked `data-key`, causing selectors to fail when the target element used a different attribute type.

## Key Changes
- **New helper function `buildXpathTokenPredicate()`**: Generates XPath predicates that match any of the six supported attribute types (`aria-label`, `id`, `data-testid`, `data-name`, `data-key`, `name`), enabling same-element matching regardless of which attribute is present.

- **Updated same-element matching logic**: Changed from hardcoded `xpath=self::*[@data-key="..."]` to use the new predicate function, allowing the selector chain to correctly resolve when tokens match different attributes on the same element.

- **Comprehensive test coverage**: Added extensive test cases covering:
  - Same-element matching with all six attribute types
  - Attribute coexistence scenarios (e.g., `data-key` and `data-testid` on the same element)
  - Token ordering independence (forward and reversed token sequences)
  - Regression test for the `deck-tile` case

## Implementation Details
The fix ensures that when resolving a multi-token selector like `"decks-list-grid kan deck-tile"`, if both tokens match the same DOM element (e.g., element has `data-key="kan"` AND `data-testid="deck-tile"`), the selector correctly identifies it as a same-element match rather than requiring a descendant relationship. This is critical for selectors that span multiple attribute types.

https://claude.ai/code/session_01SUVxx4TSatGYvpHbKfwNqz