### PR TITLE
Add settle() to flush microtasks/RAFs after navigation and scope changes

### DIFF
--- a/packages/scenes/src/__tests__/reactive.test.ts
+++ b/packages/scenes/src/__tests__/reactive.test.ts
@@ -599,6 +599,42 @@ describe('drainAll', () => {
   })
 })
 
+describe('settle integration', () => {
+  it('flushes microtasks/RAFs after openTo so derived live queries can render', async () => {
+    const { actor, page } = createTestActor()
+
+    actor.openTo('/dashboard')
+    await actor.drain()
+
+    expect(page.goto).toHaveBeenCalledWith('/dashboard', { timeout: 5000 })
+    // settle() runs page.evaluate(...) to flush microtasks + 2 RAFs
+    expect(page.evaluate).toHaveBeenCalled()
+  })
+
+  it('flushes microtasks/RAFs after up(selector) waits for visibility', async () => {
+    const { actor, page } = createTestActor()
+
+    actor.up('header')
+    await actor.drain()
+
+    // Locator was waited on, then page.evaluate ran the settle flush
+    expect(page._locator.waitFor).toHaveBeenCalledWith({
+      state: 'visible',
+      timeout: 5000,
+    })
+    expect(page.evaluate).toHaveBeenCalled()
+  })
+
+  it('flushes microtasks/RAFs after bare up() resets scope', async () => {
+    const { actor, page } = createTestActor()
+
+    actor.up()
+    await actor.drain()
+
+    expect(page.evaluate).toHaveBeenCalled()
+  })
+})
+
 describe('reload()', () => {
   it('queues a reload action', () => {
     const { actor } = createTestActor()

--- a/packages/scenes/src/__tests__/runner.test.ts
+++ b/packages/scenes/src/__tests__/runner.test.ts
@@ -141,6 +141,34 @@ describe('runCleanup', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('notexist'))
     warnSpy.mockRestore()
   })
+
+  it('logs the phase suffix so before/after passes are distinguishable', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const server = { db: { delete: () => Promise.resolve() } }
+    const scene = makeScene({ cleanup: ["db.delete('x')"] })
+
+    await runCleanup(scene, team, teamMeta, server, testStart, 'before')
+    await runCleanup(scene, team, teamMeta, server, testStart, 'after')
+
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('cleanup ran (before)'))
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('cleanup ran (after)'))
+    logSpy.mockRestore()
+  })
+
+  it('runs the cleanup expressions again when invoked with phase=after', async () => {
+    const calls: string[] = []
+    const server = {
+      db: {
+        delete: (table: string) => { calls.push(`delete:${table}`); return Promise.resolve() },
+      },
+    }
+    const scene = makeScene({ cleanup: ["db.delete('user_deck')"] })
+
+    await runCleanup(scene, team, teamMeta, server, testStart, 'before')
+    await runCleanup(scene, team, teamMeta, server, testStart, 'after')
+
+    expect(calls).toEqual(['delete:user_deck', 'delete:user_deck'])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/scenes/src/__tests__/settle.test.ts
+++ b/packages/scenes/src/__tests__/settle.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest'
+import { settle } from '../settle.js'
+
+describe('settle', () => {
+  it('calls page.evaluate to flush the render queue', async () => {
+    const evaluate = vi.fn().mockResolvedValue(undefined)
+    const page = { evaluate } as unknown as Parameters<typeof settle>[0]
+
+    await settle(page)
+
+    expect(evaluate).toHaveBeenCalledTimes(1)
+    // The function passed in must reference requestAnimationFrame so that
+    // pending React renders + TanStack DB derived queries get a chance to
+    // commit before the next action runs.
+    const fn = evaluate.mock.calls[0][0] as () => unknown
+    expect(typeof fn).toBe('function')
+    expect(fn.toString()).toContain('requestAnimationFrame')
+  })
+
+  it('swallows errors from page.evaluate (e.g. page closed mid-flush)', async () => {
+    const page = {
+      evaluate: vi.fn().mockRejectedValue(new Error('Target page, context or browser has been closed')),
+    } as unknown as Parameters<typeof settle>[0]
+
+    await expect(settle(page)).resolves.toBeUndefined()
+  })
+})

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -7,6 +7,7 @@ import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
+import { settle } from './settle.js'
 
 /**
  * Action to be executed in a chain
@@ -185,6 +186,7 @@ class ActionChainImpl implements ActionChain {
       this.scopeStack = []
       this.scopeSetUrl = ''
       this.scopeStackUrls = []
+      await settle(this.page)
     })
   }
 
@@ -503,6 +505,7 @@ class ActionChainImpl implements ActionChain {
         this.scopeStack = []
         this.scopeSetUrl = ''
         this.scopeStackUrls = []
+        await settle(this.page)
       })
     }
     const target = formatSelector(selector)
@@ -510,6 +513,7 @@ class ActionChainImpl implements ActionChain {
       const ancestorLocator = resolveSelector(this.page, selector)
       await ancestorLocator.waitFor({ state: 'visible', timeout: this.actionTimeout })
       this.pushScope(ancestorLocator)
+      await settle(this.page)
     })
   }
 

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -72,6 +72,7 @@ import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
 import { registerScene, getCurrentSession } from './scene.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
+import { settle } from './settle.js'
 
 // ---------------------------------------------------------------------------
 // Interpolation helpers
@@ -397,6 +398,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
       this.scopeStack = []
       this.scopeSetUrl = ''
       this.scopeStackUrls = []
+      await settle(this.page)
     })
   }
 
@@ -688,6 +690,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
         this.scopeStack = []
         this.scopeSetUrl = ''
         this.scopeStackUrls = []
+        await settle(this.page)
       })
     }
     return this.push('up', selector, async () => {
@@ -700,6 +703,7 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
       this.scopeStackUrls.push(this.scopeSetUrl)
       this.currentScope = ancestorLocator
       this.scopeSetUrl = this.page.url()
+      await settle(this.page)
     })
   }
 

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -174,13 +174,17 @@ export class SceneRunner {
           })
 
           // Run pre-cleanup if configured
-          await runCleanup(registered, resolvedTeam.actors, resolvedTeam.meta, server, testStart)
+          await runCleanup(registered, resolvedTeam.actors, resolvedTeam.meta, server, testStart, 'before')
 
           // Run setup if configured (after pre-cleanup, before scene)
           await runSetup(registered, resolvedTeam.actors, resolvedTeam.meta, server, testStart)
 
           // Run the scene
           const report = await runScene(registered, session, timeout)
+
+          // Run post-cleanup so the next scene starts with the documented
+          // pristine state — `cleanup:` is idempotent and runs both sides.
+          await runCleanup(registered, resolvedTeam.actors, resolvedTeam.meta, server, testStart, 'after')
 
           // Enrich actor info with device and navigation mode assignments
           for (const [role, actor] of session.getActors()) {
@@ -504,21 +508,27 @@ function evaluateCleanup(expression: string, server: Record<string, unknown>): u
 }
 
 /**
- * Run pre-cleanup for a scene if it has cleanup expressions.
+ * Run cleanup for a scene if it has cleanup expressions.
  * Each expression is interpolated, evaluated with server context, and awaited.
  * Never throws — failures are logged but don't prevent the scene.
+ *
+ * `phase` controls the suffix on the success log so before/after passes are
+ * distinguishable. The runner calls this twice per scene — once before
+ * `setup` and once after the scene finishes — so cleanup statements stay
+ * idempotent regardless of which scene ran previously.
  */
 export async function runCleanup(
   registered: RegisteredScene,
   team: TeamConfig,
   teamMeta: TeamMeta,
   server: Record<string, unknown> | undefined,
-  testStart: string
+  testStart: string,
+  phase: 'before' | 'after' = 'before'
 ): Promise<void> {
   if (!registered.cleanup || registered.cleanup.length === 0) return
 
   if (!server || Object.keys(server).length === 0) {
-    console.warn(`  ⚠ cleanup: expressions present but no server config provided`)
+    console.warn(`  ⚠ cleanup (${phase}): expressions present but no server config provided`)
     return
   }
 
@@ -531,11 +541,11 @@ export async function runCleanup(
       }
     } catch (err) {
       console.warn(
-        `  ⚠ cleanup failed: ${err instanceof Error ? err.message : String(err)}`
+        `  ⚠ cleanup (${phase}) failed: ${err instanceof Error ? err.message : String(err)}`
       )
     }
   }
-  console.log(`  ♻ cleanup ran`)
+  console.log(`  ♻ cleanup ran (${phase})`)
 }
 
 /**

--- a/packages/scenes/src/settle.ts
+++ b/packages/scenes/src/settle.ts
@@ -1,0 +1,34 @@
+import type { Page } from 'playwright'
+
+/**
+ * Wait for the page to "settle" after navigation or scope change:
+ * flush pending microtasks and let the framework finish two animation
+ * frames so derived state (e.g. TanStack DB live queries, React renders)
+ * has a chance to materialise before the next action runs.
+ *
+ * Without this, a sequence like `openTo('/x') → up('topic-page')` can
+ * resolve while the page is still showing a loading placeholder, because
+ * `Locator.waitFor({ state: 'visible' })` only checks DOM visibility —
+ * it doesn't know that the visible element will be replaced once a
+ * derived collection finishes computing in a microtask.
+ *
+ * Two RAFs guarantee the framework has both scheduled and committed any
+ * pending render. The trailing `setTimeout(0)` drains the macrotask
+ * queue so post-render effects (e.g. setState in useEffect) also flush.
+ */
+export async function settle(page: Page): Promise<void> {
+  try {
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              Promise.resolve().then(() => setTimeout(resolve, 0))
+            })
+          })
+        })
+    )
+  } catch {
+    // Page was closed or navigated mid-settle — not our problem to recover from.
+  }
+}

--- a/packages/scenes/src/swarm.ts
+++ b/packages/scenes/src/swarm.ts
@@ -224,10 +224,12 @@ export async function runSwarm(
             // Run pre-cleanup and setup if configured
             const swarmTeam = teamManager.getTeam(task.teamIndex)
             const swarmTestStart = new Date().toISOString()
-            await runCleanup(scene, swarmTeam.actors, swarmTeam.meta, server, swarmTestStart)
+            await runCleanup(scene, swarmTeam.actors, swarmTeam.meta, server, swarmTestStart, 'before')
             await runSetup(scene, swarmTeam.actors, swarmTeam.meta, server, swarmTestStart)
 
             const report = await runScene(scene, session, timeout)
+
+            await runCleanup(scene, swarmTeam.actors, swarmTeam.meta, server, swarmTestStart, 'after')
 
             const detail: SwarmRunDetail = {
               teamIndex: task.teamIndex,


### PR DESCRIPTION
## Summary
This PR introduces a `settle()` function that flushes pending microtasks and animation frames after navigation or scope changes in actor tests. This ensures derived state (e.g., TanStack DB live queries, React renders) has time to materialize before the next action runs.

## Key Changes

- **New `settle.ts` module**: Implements `settle(page)` which calls `page.evaluate()` to run two `requestAnimationFrame` cycles followed by a `setTimeout(0)`, ensuring the framework has both scheduled and committed pending renders before continuing.

- **Integration in actor methods**:
  - `openTo()`: Calls `settle()` after navigation to allow derived queries to compute
  - `up(selector)`: Calls `settle()` after waiting for element visibility
  - `up()` (bare): Calls `settle()` after resetting scope

- **Cleanup phase tracking**: Modified `runCleanup()` to accept a `phase` parameter ('before' or 'after') so cleanup expressions run both before setup and after the scene completes. This ensures idempotent cleanup regardless of previous scene state.

- **Post-scene cleanup**: Updated `SceneRunner` and `runSwarm()` to call cleanup with `phase='after'` following scene execution, maintaining pristine state between scenes.

## Implementation Details

- The `settle()` function gracefully handles page closure/navigation errors by catching and suppressing exceptions
- Cleanup logging now includes the phase suffix (e.g., "cleanup ran (before)") for distinguishability
- Two RAF cycles guarantee both scheduling and committing of React renders, with a trailing `setTimeout(0)` to drain post-render effects
- Tests verify that `settle()` is called after navigation and scope changes, and that cleanup runs in both phases

https://claude.ai/code/session_016ZjfdegKYb8SDpunJRpURo