### PR TITLE
Improve selector error messages for ambiguous and scoped selectors

### DIFF
--- a/packages/scenes/src/__tests__/selectors.test.ts
+++ b/packages/scenes/src/__tests__/selectors.test.ts
@@ -353,7 +353,16 @@ describe('buildSelectorMissError', () => {
   })
 
   it('does not mask the original error if diagnostic count() throws', async () => {
-    const scope: any = { locator: vi.fn(() => createCountingLocator(0)) }
+    const scope: any = {
+      locator: vi.fn(() => ({
+        count: vi.fn(async () => {
+          throw new Error('diagnostic blew up')
+        }),
+        locator: vi.fn(() => createCountingLocator(0)),
+        or: vi.fn(() => createCountingLocator(0)),
+        nth: vi.fn(() => createCountingLocator(0)),
+      })),
+    }
     const page: any = {
       locator: vi.fn(() => ({
         count: vi.fn(async () => {
@@ -371,5 +380,45 @@ describe('buildSelectorMissError', () => {
     // Should still produce an error with the original cause attached
     expect(err.message).toContain('scope(btn) timed out')
     expect((err as Error & { cause?: unknown }).cause).toBe(cause)
+  })
+
+  it('flags ambiguous selector and suggests `#N` when scope has multiple matches', async () => {
+    // Strict-mode violation: 3 matches in the current scope. The underlying
+    // Playwright error gets caught and wrapped — we want a message that
+    // points at `#1`, not the misleading "not visible" wording.
+    const scope: any = { locator: vi.fn(() => createCountingLocator(3)) }
+    const page: any = { locator: vi.fn(() => createCountingLocator(3)) }
+    const cause = new Error('strict mode violation: locator resolved to 3 elements')
+
+    const err = await buildSelectorMissError(scope, page, 'click', 'admin-phrase-detail-link', cause)
+
+    expect(err.message).toContain('matched 3 elements in current scope')
+    expect(err.message).toContain('selector is ambiguous')
+    expect(err.message).toContain('`admin-phrase-detail-link #1`')
+    expect(err.message).not.toContain('not visible in current scope')
+    expect((err as Error & { cause?: unknown }).cause).toBe(cause)
+  })
+
+  it('suggests `#N` even when scope is the page root', async () => {
+    // Multi-match at top-level — still ambiguous, still wants disambiguation.
+    const page: any = { locator: vi.fn(() => createCountingLocator(2)) }
+
+    const err = await buildSelectorMissError(page, page, 'click', 'submit-btn', new Error())
+
+    expect(err.message).toContain('matched 2 elements in current scope')
+    expect(err.message).toContain('`submit-btn #1`')
+  })
+
+  it('omits the "scope too narrow" hint when selector resolves once in scope', async () => {
+    // Single match in scope means it really is a visibility timeout, not a
+    // scoping problem. Don't muddy the message with a root-count hint.
+    const scope: any = { locator: vi.fn(() => createCountingLocator(1)) }
+    const page: any = { locator: vi.fn(() => createCountingLocator(5)) }
+
+    const err = await buildSelectorMissError(scope, page, 'see', 'spinner', new Error('timeout'))
+
+    expect(err.message).toContain('see(spinner) timed out')
+    expect(err.message).not.toContain('document root')
+    expect(err.message).not.toContain('selector is ambiguous')
   })
 })

--- a/packages/scenes/src/selectors.ts
+++ b/packages/scenes/src/selectors.ts
@@ -174,19 +174,45 @@ export async function buildSelectorMissError(
   selector: string,
   cause: unknown
 ): Promise<Error> {
-  let rootCount = 0
+  let scopeCount = 0
   try {
-    rootCount = await resolveSelector(page, selector).count()
+    scopeCount = await resolveSelector(scope, selector).count()
   } catch {
     // diagnostic best-effort — don't mask the original timeout
   }
+
+  // Multiple matches in scope: Playwright's strict mode rejects this, but the
+  // generic "not visible" wrapper hides what really happened. Steer the user
+  // to the `#N` escape hatch.
+  if (scopeCount > 1) {
+    const base = `${action}(${selector}) matched ${scopeCount} elements in current scope — selector is ambiguous.`
+    const hint = `\n  Disambiguate with an Nth-element token: \`${selector} #1\` (or #2, #3…) to pick a specific match.`
+    const err = new Error(base + hint)
+    ;(err as Error & { cause?: unknown }).cause = cause
+    return err
+  }
+
+  // Selector resolves to 0 or 1 in scope. If 1, it's a true visibility
+  // timeout. If 0, look at the page root to distinguish "scope too narrow"
+  // from "selector typo".
+  let rootCount = 0
+  if (scopeCount === 0 && scope !== page) {
+    try {
+      rootCount = await resolveSelector(page, selector).count()
+    } catch {
+      // diagnostic best-effort
+    }
+  }
+
   const base = `${action}(${selector}) timed out — not visible in current scope.`
   const hint =
     scope === page
       ? '' // scope was already page — no narrowing to blame
-      : rootCount > 0
-        ? `\n  Found ${rootCount} match${rootCount === 1 ? '' : 'es'} at document root. Your scope may be too narrow — adjust scope or use the full selector path.`
-        : `\n  Not found anywhere on the page. Check the selector spelling.`
+      : scopeCount === 1
+        ? '' // present in scope but never became visible — true timeout
+        : rootCount > 0
+          ? `\n  Found ${rootCount} match${rootCount === 1 ? '' : 'es'} at document root. Your scope may be too narrow — adjust scope or use the full selector path.`
+          : `\n  Not found anywhere on the page. Check the selector spelling.`
   const err = new Error(base + hint)
   ;(err as Error & { cause?: unknown }).cause = cause
   return err


### PR DESCRIPTION
## Summary
Enhanced error messages in `buildSelectorMissError` to better diagnose selector issues, particularly when selectors are ambiguous (match multiple elements) or when scoping is involved.

## Key Changes
- **Ambiguous selector detection**: When a selector matches multiple elements in the current scope, the error now explicitly states this is a strict-mode violation and suggests using the `#N` nth-element token to disambiguate (e.g., `selector #1`)
- **Improved scope diagnostics**: Changed the diagnostic count from checking the page root first to checking the scope first, providing more accurate context about where the selector resolves
- **Refined hint logic**: 
  - Omits the "scope too narrow" hint when a selector resolves to exactly 1 element in scope (indicating a true visibility timeout rather than a scoping problem)
  - Only checks the page root for additional matches when the selector doesn't exist in the current scope
  - Provides clearer, more actionable error messages based on the actual resolution counts

## Implementation Details
- The function now distinguishes between three scenarios: multiple matches in scope (ambiguous), single match in scope (visibility timeout), and no matches in scope (scope too narrow or selector typo)
- Error messages now include the `#N` syntax suggestion when ambiguity is detected, helping users quickly resolve strict-mode violations
- Maintains backward compatibility by preserving the original error as the `cause` property on all error objects

https://claude.ai/code/session_0167oXs6Dksia13EYgCXtNBN