### PR TITLE
Add terminal-bell sound feedback for CLI test runs

### DIFF
--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -6,6 +6,7 @@ import fs from 'fs'
 import { loadConfig } from './config.js'
 import { SceneRunner, printSummary } from './runner.js'
 import { init } from './init.js'
+import { finish as soundFinish, resolveSoundEnabled } from './sound.js'
 import {
   gatherProjectContext,
   generatePrompt,
@@ -31,6 +32,8 @@ program
   .option('--fuzzy-fingers', 'Enable fuzzy-finger touch behavior (simulates imprecise human touch ~1 in 5 clicks)')
   .option('--swarm', 'Force swarm mode: run all teams against all scenes to classify failures')
   .option('--no-panel', 'Suppress the dev panel in the browser (useful for CI / headless runs)')
+  .option('--sound', 'Enable terminal-bell sound feedback (1 bell pass, 2 fail, 3 finish)')
+  .option('--no-sound', 'Disable terminal-bell sound feedback')
   .action(async (scenes: string[], options: CLIOptions) => {
     try {
       // Load config and discover actor teams
@@ -58,6 +61,7 @@ program
       if (options.noPanel) {
         config.noPanel = true
       }
+      config.sound = { enabled: resolveSoundEnabled(config, options) }
 
       // Interactive UI mode
       if (options.ui) {
@@ -115,6 +119,8 @@ program
             await writeReport(swarmReport, config.reportDir!, config.reportFormat!)
           }
         }
+
+        if (config.sound?.enabled) soundFinish()
 
         // In UI mode, keep browser open
         if (options.ui) {

--- a/packages/scenes/src/init.ts
+++ b/packages/scenes/src/init.ts
@@ -33,6 +33,7 @@ export async function init(cwd: string, options: InitOptions = {}): Promise<void
 
 export default defineConfig({
   baseUrl: 'http://localhost:5173',
+  sound: { enabled: true },
 })
 `)
     console.log('Created scenetest/config.ts')

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -13,6 +13,7 @@ import { loadMarkdownScene } from './markdown-scene.js'
 import { SwarmTrigger, runSwarm } from './swarm.js'
 import { registerBuiltinMacros, registerSelectedMacros } from './builtin-macros.js'
 import { DashboardReporter, setDashboardReporter, dashboardSend } from './dashboard-reporter.js'
+import { tick as soundTick, fail as soundFail } from './sound.js'
 
 /**
  * Main scene runner
@@ -217,6 +218,11 @@ export class SceneRunner {
           // Log progress
           const statusIcon = report.status === 'completed' ? '✓' : report.status === 'timeout' ? '⏱' : '✗'
           console.log(`  ${statusIcon} ${registered.name} (${report.duration}ms)`)
+
+          if (this.config.sound?.enabled) {
+            if (report.status === 'completed') soundTick()
+            else soundFail()
+          }
 
           if (report.error) {
             console.log(`    Error: ${report.error}`)

--- a/packages/scenes/src/sound.ts
+++ b/packages/scenes/src/sound.ts
@@ -1,0 +1,25 @@
+import type { ScenetestConfig, CLIOptions } from './types.js'
+
+const BELL = ''
+
+export function tick(): void {
+  process.stderr.write(BELL)
+}
+
+export function fail(): void {
+  process.stderr.write(BELL + BELL)
+}
+
+export function finish(): void {
+  process.stderr.write(BELL + BELL + BELL)
+}
+
+/** Precedence: CLI flags > SCENETEST_SOUND env > config.sound.enabled. */
+export function resolveSoundEnabled(config: ScenetestConfig, cli: CLIOptions): boolean {
+  if (cli.noSound) return false
+  if (cli.sound) return true
+  const env = process.env.SCENETEST_SOUND
+  if (env === '0' || env === 'false') return false
+  if (env === '1' || env === 'true') return true
+  return config.sound?.enabled === true
+}

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -245,6 +245,14 @@ export interface ScenetestConfig extends BaseConfig {
   noPanel?: boolean
 
   /**
+   * Terminal-bell sound feedback during CLI runs.
+   * 1 bell per scene pass, 2 for a failure, 3 when the run finishes.
+   * Off by default. Override at runtime with `--sound`/`--no-sound` or
+   * `SCENETEST_SOUND=0|1`.
+   */
+  sound?: { enabled?: boolean }
+
+  /**
    * Capture browser console errors and surface them in the CLI output.
    *
    * - `true` or `'error'`: capture `console.error` messages only (default: `true`)
@@ -1147,4 +1155,10 @@ export interface CLIOptions {
 
   /** Suppress the dev panel in the browser (useful for CI / headless runs) */
   noPanel?: boolean
+
+  /** Enable terminal-bell sound feedback */
+  sound?: boolean
+
+  /** Disable terminal-bell sound feedback */
+  noSound?: boolean
 }


### PR DESCRIPTION
## Summary
This PR adds optional terminal-bell sound feedback during CLI test runs to provide audio cues for test results without requiring visual attention to the terminal.

## Key Changes
- **New `sound.ts` module**: Implements sound feedback functions (`tick()` for passes, `fail()` for failures, `finish()` for completion) that write bell characters to stderr
- **Sound configuration**: Added `sound` config option to `ScenetestConfig` with `enabled` boolean flag
- **CLI options**: Added `--sound` and `--no-sound` flags to enable/disable sound feedback at runtime
- **Environment variable support**: Added `SCENETEST_SOUND` environment variable for runtime control (supports `0|1|true|false`)
- **Priority resolution**: Implemented `resolveSoundEnabled()` with clear precedence: CLI flags > environment variable > config file
- **Integration**: Wired sound feedback into the test runner to emit sounds on individual test completion and at the end of the full run
- **Default config**: Updated init template to enable sound by default in generated config files

## Implementation Details
- Sound feedback uses terminal bell character (ASCII 0x07) written to stderr
- Feedback pattern: 1 bell for pass, 2 bells for failure, 3 bells for run completion
- Sound is disabled by default in the config but can be easily enabled via CLI flags or environment variables
- The feature gracefully integrates with existing test runner and CLI infrastructure without affecting non-sound modes

https://claude.ai/code/session_01QvYLES3CshCtc4wLG2T2V3