### PR TITLE
Remove scope reset on navigation from click and ifClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## [0.8.3] — 2026-05-03
+
+### API
+
+#### `click` and `ifClick` no longer mutate scope
+
+`click()` and `ifClick()` now leave the scope stack untouched in **every** case — including clicks that navigate to a new URL. The 0.7.2 "reset scope on URL change" behaviour is removed; it was redundant defensive logic on top of `validateScope()`, which already runs before every action and walks up the scope stack to the nearest surviving ancestor (or page root) when the URL has changed since the scope was set.
+
+The mental model is now uniform: **`click` is a leaf action, not a scope verb.** Only `scope`, `up`, `prev`, `openTo`, `reload`, `goBack`, `goForward`, and `switchDevice` change scope.
+
+This eliminates the common "scope X / click / up" tax that crept into specs as authors guessed (correctly, in some cases) that `click` might leave them in a stale scope. With `validateScope()` doing the work, that `up` is unnecessary in *all* cases.
+
+**No code change required for correct specs.** Removing redundant `up` lines is opportunistic — they're now dead code, not bugs. Two cleanup paths:
+
+1. **Specs in this repo / your spec files.** Paste the prompt below into your coding agent.
+2. **Project-level `CLAUDE.md` / agent notes.** If you previously documented "after a navigating click, add `up` to reset scope" in your project's CLAUDE.md, agent rules, or onboarding doc, delete that guidance — it's now wrong. Replace it with the rule from the docs: *"`click` never changes scope. Use `up` only when you explicitly want to widen scope."*
+
+##### Migration prompt for coding agents
+
+> I upgraded `@scenetest/scenes` to 0.8.3. As of this version, **`click` and `ifClick` never change the scope stack** — including clicks that navigate to a new URL. The runtime's `validateScope` step handles stale-scope cleanup automatically before the next action. The previous 0.7.2 "reset scope on URL change" behaviour is gone, and you no longer need `up` (or bare `up`) after a navigating click.
+>
+> Please do two things in this repo:
+>
+> 1. **Scan all `.spec.md` files and TypeScript scenes (`scene(...)` / `test(...)`) and remove now-redundant `up` lines.** Be conservative:
+>    - Remove `up` (or bare `up()` in TS) only when the line immediately preceding it is a `click` / `ifClick` / `pressKey Enter`-style action whose purpose is to commit/submit/navigate. The `up` was paying the old "reset after navigation" tax.
+>    - Do **not** remove `up` lines that come after a `scope X` block where the author is widening back out to do unrelated work — those are real, intentional scope mutations.
+>    - Do **not** touch `up <selector>` calls (climbing to a named ancestor) or `prev` calls.
+>    - When in doubt, leave the `up` and add a `# kept: explicit widen` comment so a human can review.
+> 2. **Update the project's `CLAUDE.md` (and any other agent rules / onboarding docs) to remove guidance that says clicks reset scope on navigation, or that recommends adding `up` after navigating clicks.** Replace any such guidance with: *"`click` never changes scope. Only `scope`, `up`, `prev`, `openTo`, `reload`, `goBack`, `goForward`, and `switchDevice` change scope. Use `up` only when you want to widen scope explicitly."*
+>
+> Show me a diff of every file you change, with a one-line note per removal explaining why each `up` was safe to drop. After editing, re-run the affected scenes (`pnpm scenetest`) and confirm they still pass.
+
+---
+
 ## [0.8.2] — 2026-04-23
 
 ### Improvements
@@ -177,18 +211,7 @@ Now `resolveSelectorWithFallback` waits for the scoped locator first (full timeo
 
 This fixes tests where `see()` timed out searching within a stale scope after a click navigated to a new route.
 
-**Migration:** existing specs that manually called `up` (or bare `up`) immediately after a navigation-causing click will still pass — bare `up` on an already-page-root scope is a no-op. But the redundant lines are now noise. Paste the following into your coding agent to clean them up:
-
-> I upgraded to `@scenetest/scenes` 0.7.2. As of this version, `click` and `ifClick` automatically reset scope to the page root when the click causes a URL change (same as `openTo`, `goBack`). That means `up` / `up <selector>` lines that were placed after a navigation-causing click purely to reset scope are now redundant.
->
-> Please scan all `.spec.md` files and any TypeScript scenes (`scene(...)` / `test(...)`) in this repo and remove `up` lines that follow a click which navigates to a new route. Be conservative:
->
-> 1. Only remove an `up` (or bare `up()` in TS) when the immediately preceding action is a `click` / `ifClick` whose target is clearly a navigation control — a link, sidebar item, menu entry, or a button whose handler routes to a different URL. If you can't tell from the selector name and surrounding `openTo` / `see` lines whether the click navigates, leave the `up` alone.
-> 2. Do **not** remove `up` lines after clicks on in-page controls (modal close buttons, dropdown toggles, accordion headers, form submits that stay on the same page) — those don't trigger the auto-reset.
-> 3. Do **not** touch `scope` / `prev` lines, or `up <selector>` calls that climb to a specific named ancestor for a *non-navigating* click — those are still doing real work.
-> 4. After editing, re-run `pnpm scenetest` (or your project's equivalent) to confirm the touched scenes still pass.
->
-> Show me a diff of each file you change with a one-line note explaining why each removed `up` was safe to drop.
+> **Note (0.8.3):** the click/navigation reset described here was removed in 0.8.3. `click` and `ifClick` now never change scope; `validateScope()` handles stale-scope cleanup. See the 0.8.3 entry for the migration prompt.
 
 ### Migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,19 @@ Now `resolveSelectorWithFallback` waits for the scoped locator first (full timeo
 
 This fixes tests where `see()` timed out searching within a stale scope after a click navigated to a new route.
 
+**Migration:** existing specs that manually called `up` (or bare `up`) immediately after a navigation-causing click will still pass — bare `up` on an already-page-root scope is a no-op. But the redundant lines are now noise. Paste the following into your coding agent to clean them up:
+
+> I upgraded to `@scenetest/scenes` 0.7.2. As of this version, `click` and `ifClick` automatically reset scope to the page root when the click causes a URL change (same as `openTo`, `goBack`). That means `up` / `up <selector>` lines that were placed after a navigation-causing click purely to reset scope are now redundant.
+>
+> Please scan all `.spec.md` files and any TypeScript scenes (`scene(...)` / `test(...)`) in this repo and remove `up` lines that follow a click which navigates to a new route. Be conservative:
+>
+> 1. Only remove an `up` (or bare `up()` in TS) when the immediately preceding action is a `click` / `ifClick` whose target is clearly a navigation control — a link, sidebar item, menu entry, or a button whose handler routes to a different URL. If you can't tell from the selector name and surrounding `openTo` / `see` lines whether the click navigates, leave the `up` alone.
+> 2. Do **not** remove `up` lines after clicks on in-page controls (modal close buttons, dropdown toggles, accordion headers, form submits that stay on the same page) — those don't trigger the auto-reset.
+> 3. Do **not** touch `scope` / `prev` lines, or `up <selector>` calls that climb to a specific named ancestor for a *non-navigating* click — those are still doing real work.
+> 4. After editing, re-run `pnpm scenetest` (or your project's equivalent) to confirm the touched scenes still pass.
+>
+> Show me a diff of each file you change with a one-line note explaining why each removed `up` was safe to drop.
+
 ### Migration
 
 #### `see` → `scope` codemod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,31 +10,11 @@ All notable changes to Scenetest are documented here.
 
 #### `click` and `ifClick` no longer mutate scope
 
-`click()` and `ifClick()` now leave the scope stack untouched in **every** case — including clicks that navigate to a new URL. The 0.7.2 "reset scope on URL change" behaviour is removed; it was redundant defensive logic on top of `validateScope()`, which already runs before every action and walks up the scope stack to the nearest surviving ancestor (or page root) when the URL has changed since the scope was set.
+`click` and `ifClick` were never meant to change scope — but on navigating clicks (the 0.7.2 fix), they did. That's gone. They now leave the scope stack alone in every case; `validateScope()` already handles stale scope after navigation, so the extra reset was just making the rules harder to explain.
 
-The mental model is now uniform: **`click` is a leaf action, not a scope verb.** Only `scope`, `up`, `prev`, `openTo`, `reload`, `goBack`, `goForward`, and `switchDevice` change scope.
+If you've been writing `click` followed by `up` to work around this, you don't need to anymore. Paste this into your coding agent:
 
-This eliminates the common "scope X / click / up" tax that crept into specs as authors guessed (correctly, in some cases) that `click` might leave them in a stale scope. With `validateScope()` doing the work, that `up` is unnecessary in *all* cases.
-
-**No code change required for correct specs.** Removing redundant `up` lines is opportunistic — they're now dead code, not bugs. Two cleanup paths:
-
-1. **Specs in this repo / your spec files.** Paste the prompt below into your coding agent.
-2. **Project-level `CLAUDE.md` / agent notes.** If you previously documented "after a navigating click, add `up` to reset scope" in your project's CLAUDE.md, agent rules, or onboarding doc, delete that guidance — it's now wrong. Replace it with the rule from the docs: *"`click` never changes scope. Use `up` only when you explicitly want to widen scope."*
-
-##### Migration prompt for coding agents
-
-> I upgraded `@scenetest/scenes` to 0.8.3. As of this version, **`click` and `ifClick` never change the scope stack** — including clicks that navigate to a new URL. The runtime's `validateScope` step handles stale-scope cleanup automatically before the next action. The previous 0.7.2 "reset scope on URL change" behaviour is gone, and you no longer need `up` (or bare `up`) after a navigating click.
->
-> Please do two things in this repo:
->
-> 1. **Scan all `.spec.md` files and TypeScript scenes (`scene(...)` / `test(...)`) and remove now-redundant `up` lines.** Be conservative:
->    - Remove `up` (or bare `up()` in TS) only when the line immediately preceding it is a `click` / `ifClick` / `pressKey Enter`-style action whose purpose is to commit/submit/navigate. The `up` was paying the old "reset after navigation" tax.
->    - Do **not** remove `up` lines that come after a `scope X` block where the author is widening back out to do unrelated work — those are real, intentional scope mutations.
->    - Do **not** touch `up <selector>` calls (climbing to a named ancestor) or `prev` calls.
->    - When in doubt, leave the `up` and add a `# kept: explicit widen` comment so a human can review.
-> 2. **Update the project's `CLAUDE.md` (and any other agent rules / onboarding docs) to remove guidance that says clicks reset scope on navigation, or that recommends adding `up` after navigating clicks.** Replace any such guidance with: *"`click` never changes scope. Only `scope`, `up`, `prev`, `openTo`, `reload`, `goBack`, `goForward`, and `switchDevice` change scope. Use `up` only when you want to widen scope explicitly."*
->
-> Show me a diff of every file you change, with a one-line note per removal explaining why each `up` was safe to drop. After editing, re-run the affected scenes (`pnpm scenetest`) and confirm they still pass.
+> Heads up: in `@scenetest/scenes` 0.8.3, `click` and `ifClick` no longer change scope (they weren't supposed to — old versions reset it on navigation as a workaround). If you've been writing `click \n up` in a bunch of places to deal with that, you can stop. Please go over the `.spec.md` files and any TypeScript scenes, look for places where this was happening, and drop the useless `up`s. It's totally fine to keep an `up` if it's actually doing something — just clean up the ones that aren't. Give me a short list of what you changed and what you left alone (and why) when you're done.
 
 ---
 

--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -88,7 +88,7 @@ user:
 - see other-section
 ```
 
-**Fallback resolution:** `see`, `click`, and `scope` try the current scope first. If no match is found, they retry from the page root and log a warning. This prevents silent failures when an element exists outside the expected scope. Form interactions (`typeInto`, `check`, `select`) do **not** fall back — they resolve strictly within the current scope so you can be sure which form you're interacting with.
+**Selector resolution is strict.** Every action resolves selectors against the current scope only — there's no silent fallback to the page root. If the element isn't in scope, you get a diagnostic error naming the action, the selector, and the scope. To reach something outside the current scope, widen first with `up` or `prev`.
 
 ## Conditional Handling
 

--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -71,6 +71,8 @@ user:
 - typeInto search-input foo   # searches within settings-modal
 ```
 
+**`click` does not change scope.** Even when a click navigates to a new URL, the scope stack is left untouched; the runtime walks up the stack to the nearest surviving ancestor before the next action. There is no need to follow a navigating click with `up` — and adding one is a common source of unnecessary churn in specs. Only use `up` when *you* want to widen scope explicitly (e.g. after `scope`-ing into a sub-region you've finished working with).
+
 `up` with a selector navigates to an ancestor matching that selector. `up` with no selector resets scope to the page root:
 
 ```scenetest

--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -137,6 +137,7 @@ returning-user:
 - `waitFor <message>` blocks the actor until a bus message arrives
 - Bare `click` (no selector) clicks the current scope element
 - Bare `up` (no selector) resets scope to the page root
+- Multi-word values must be quoted: `typeInto some-selector "quoted text for words"`. Without quotes, only the last word is the value — `typeInto some-selector quoted text for words` types `words` into the compound selector `some-selector quoted text for`. Single or double quotes both work; applies anywhere a value follows a selector (`typeInto`, `select`, `warnIf`).
 
 ### Cleanup and setup directives
 

--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -56,8 +56,9 @@ Every action falls into one of four categories:
 |----------|---------|--------------|
 | **Sets scope** | `scope`, `up` | Narrows subsequent interactions to within the matched element. `scope` pushes onto a stack; `up` navigates to an ancestor or resets to page root. |
 | **Resets scope** | `openTo`, `reload`, `goBack`, `goForward`, `switchDevice` | Clears scope entirely — back to page root. |
-| **Resets scope on navigation** | `click`, `ifClick` | If the click triggers a URL change, scope resets to page root. Otherwise scope is unchanged. |
-| **Does not change scope** | `see`, `seeInView`, `notSee`, `seeText`, `seeToast`, `typeInto`, `check`, `select`, `wait`, `emit`, `waitFor`, `pressKey`, `warnIf`, `scrollToBottom`, `prev` | Scope stays where it is. (`prev` pops the scope stack, returning to the previous scope.) |
+| **Does not change scope** | `click`, `ifClick`, `see`, `seeInView`, `notSee`, `seeText`, `seeToast`, `typeInto`, `check`, `select`, `wait`, `emit`, `waitFor`, `pressKey`, `warnIf`, `scrollToBottom`, `prev` | Scope stays where it is. (`prev` pops the scope stack, returning to the previous scope.) |
+
+**`click` does not change scope.** A click that navigates to a new URL leaves the scope stack as-is; the runtime validates the scope before the next action and walks up the stack to the nearest surviving ancestor (or page root) automatically. You do **not** need to follow a navigating click with `up` — and adding one is a common source of unnecessary churn in specs.
 
 **`see` vs `scope`:** `see` is a pure assertion — it checks that an element is visible but does not narrow scope. Use `scope` when you need subsequent actions (like `typeInto` or `check`) to resolve within a specific container.
 

--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -50,19 +50,15 @@ Control:
 
 ### How actions affect scope
 
-Every action falls into one of four categories:
-
 | Category | Actions | What happens |
 |----------|---------|--------------|
-| **Sets scope** | `scope`, `up` | Narrows subsequent interactions to within the matched element. `scope` pushes onto a stack; `up` navigates to an ancestor or resets to page root. |
+| **Changes scope** | `scope`, `up`, `prev` | `scope` pushes onto the scope stack and narrows. `up` widens — bare `up` resets to page root, `up <selector>` climbs to a matching ancestor. `prev` pops the stack, returning to the previous scope. |
 | **Resets scope** | `openTo`, `reload`, `goBack`, `goForward`, `switchDevice` | Clears scope entirely — back to page root. |
-| **Does not change scope** | `click`, `ifClick`, `see`, `seeInView`, `notSee`, `seeText`, `seeToast`, `typeInto`, `check`, `select`, `wait`, `emit`, `waitFor`, `pressKey`, `warnIf`, `scrollToBottom`, `prev` | Scope stays where it is. (`prev` pops the scope stack, returning to the previous scope.) |
-
-**`click` does not change scope.** A click that navigates to a new URL leaves the scope stack as-is; the runtime validates the scope before the next action and walks up the stack to the nearest surviving ancestor (or page root) automatically. You do **not** need to follow a navigating click with `up` — and adding one is a common source of unnecessary churn in specs.
+| **Leaves scope alone** | `click`, `ifClick`, `see`, `seeInView`, `notSee`, `seeText`, `seeToast`, `typeInto`, `check`, `select`, `wait`, `emit`, `waitFor`, `pressKey`, `warnIf`, `scrollToBottom` | Scope stays where it is. Even when `click` causes navigation, the scope stack is left intact; the runtime walks up to the nearest surviving ancestor before the next action. |
 
 **`see` vs `scope`:** `see` is a pure assertion — it checks that an element is visible but does not narrow scope. Use `scope` when you need subsequent actions (like `typeInto` or `check`) to resolve within a specific container.
 
-**Fallback resolution:** `see`, `click`, and `scope` try the current scope first. If no match is found, they retry from the page root and log a warning. This prevents silent failures when an element exists outside the expected scope. Form interactions (`typeInto`, `check`, `select`) do **not** fall back — they resolve strictly within the current scope so you can be sure which form you're interacting with.
+**Selector resolution is strict.** Selectors resolve against the current scope only; if nothing matches, you get a diagnostic error naming the action, the selector, and the scope rather than a silent fallback. If you need to reach an element outside the current scope, widen with `up` or `prev` first.
 
 ### Nested selectors
 

--- a/packages/scenes/src/__tests__/dsl.test.ts
+++ b/packages/scenes/src/__tests__/dsl.test.ts
@@ -156,6 +156,26 @@ describe('parseAction', () => {
     })
   })
 
+  // Pins the footgun documented in text-dsl.md ### Format rules.  An unquoted
+  // multi-word value is parsed as "last word = value, everything else = compound
+  // selector".  If you "fix" this, update the doc rule too.
+  it('treats unquoted multi-word tail as compound selector + last-word value', () => {
+    expect(parseAction('typeInto some-selector quoted text for words')).toEqual({
+      action: 'typeInto', selector: 'some-selector quoted text for', value: 'words',
+    })
+    // Quoting the value fixes it.
+    expect(parseAction('typeInto some-selector "quoted text for words"')).toEqual({
+      action: 'typeInto', selector: 'some-selector', value: 'quoted text for words',
+    })
+    // Same footgun applies to select and warnIf.
+    expect(parseAction('select role admin user')).toEqual({
+      action: 'select', selector: 'role admin', value: 'user',
+    })
+    expect(parseAction('warnIf modal should not appear')).toEqual({
+      action: 'warnIf', selector: 'modal should not', value: 'appear',
+    })
+  })
+
   it('handles selector-only for typeInto/select (no value)', () => {
     // Only selector, no value
     expect(parseAction('typeInto email-input')).toEqual({

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -319,7 +319,6 @@ class ActionChainImpl implements ActionChain {
         if (scope === this.page) {
           throw new Error('click with no selector requires a scope (use see() first)')
         }
-        const urlBefore = this.page.url()
         if (this.isKeyboard) {
           await tabToElement(this.page, scope as Locator, { timeout: this.actionTimeout })
           await pressEnter(this.page)
@@ -328,18 +327,10 @@ class ActionChainImpl implements ActionChain {
         } else {
           await (scope as Locator).click({ timeout: this.actionTimeout })
         }
-        // If the click caused navigation, reset scope to page root
-        if (this.page.url() !== urlBefore) {
-          this.currentScope = this.page
-          this.scopeStack = []
-          this.scopeSetUrl = ''
-          this.scopeStackUrls = []
-        }
       })
     }
     const target = formatSelector(selector)
     return this.addAction('click', target, async () => {
-      const urlBefore = this.page.url()
       const locator = resolveSelector(this.getScope(), selector)
       try {
         await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
@@ -354,13 +345,6 @@ class ActionChainImpl implements ActionChain {
       } else {
         await locator.click({ timeout: this.actionTimeout })
       }
-      // If the click caused navigation, reset scope to page root
-      if (this.page.url() !== urlBefore) {
-        this.currentScope = this.page
-        this.scopeStack = []
-        this.scopeSetUrl = ''
-        this.scopeStackUrls = []
-      }
     })
   }
 
@@ -372,7 +356,6 @@ class ActionChainImpl implements ActionChain {
       const locator = resolveSelector(this.getScope(), selector)
       const visible = await locator.isVisible()
       if (visible) {
-        const urlBefore = this.page.url()
         if (this.isKeyboard) {
           await tabToElement(this.page, locator, { timeout: this.actionTimeout })
           await pressEnter(this.page)
@@ -380,13 +363,6 @@ class ActionChainImpl implements ActionChain {
           await fuzzyFingerClick(this.page, locator, this.actionTimeout, selector)
         } else {
           await locator.click({ timeout: this.actionTimeout })
-        }
-        // If the click caused navigation, reset scope to page root
-        if (this.page.url() !== urlBefore) {
-          this.currentScope = this.page
-          this.scopeStack = []
-          this.scopeSetUrl = ''
-          this.scopeStackUrls = []
         }
       }
     })

--- a/packages/scenes/src/dsl.ts
+++ b/packages/scenes/src/dsl.ts
@@ -25,11 +25,11 @@ import type { DslTarget, Selector } from './types.js'
  *   prev                            - Return to previous scope
  *
  * Interactions (resolve within current scope):
- *   click [<selector>]              - Click element; resets scope if URL changes (with fallback to root)
+ *   click [<selector>]              - Click element; never changes scope (validateScope handles stale scope after navigation)
  *   typeInto <selector> <value>     - Fill input (strict scope, no fallback)
  *   check <selector>                - Check checkbox (strict scope, no fallback)
  *   select <selector> <value>       - Select dropdown option (strict scope, no fallback)
- *   ifClick <selector>              - Click if visible; resets scope if URL changes (with fallback to root)
+ *   ifClick <selector>              - Click if visible; never changes scope
  *   pressKey <key>                  - Send raw keyboard event (Playwright key name)
  *
  * Control:

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -561,7 +561,6 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
         if (scope === this.page) {
           throw new Error('click with no selector requires a scope (use see() first)')
         }
-        const urlBefore = this.page.url()
         if (this.isKeyboard) {
           await tabToElement(this.page, scope as Locator, { timeout: this.actionTimeout })
           await pressEnter(this.page)
@@ -570,17 +569,9 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
         } else {
           await (scope as Locator).click({ timeout: this.actionTimeout })
         }
-        // If the click caused navigation, reset scope to page root
-        if (this.page.url() !== urlBefore) {
-          this.currentScope = this.page
-          this.scopeStack = []
-          this.scopeSetUrl = ''
-          this.scopeStackUrls = []
-        }
       })
     }
     return this.push('click', selector, async () => {
-      const urlBefore = this.page.url()
       const locator = resolveSelector(this.activeScope, selector)
       try {
         await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
@@ -595,13 +586,6 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
       } else {
         await locator.click({ timeout: this.actionTimeout })
       }
-      // If the click caused navigation, reset scope to page root
-      if (this.page.url() !== urlBefore) {
-        this.currentScope = this.page
-        this.scopeStack = []
-        this.scopeSetUrl = ''
-        this.scopeStackUrls = []
-      }
     })
   }
 
@@ -612,7 +596,6 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
       const locator = resolveSelector(this.activeScope, selector)
       const visible = await locator.isVisible()
       if (visible) {
-        const urlBefore = this.page.url()
         if (this.isKeyboard) {
           await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
           await tabToElement(this.page, locator, { timeout: this.actionTimeout })
@@ -621,13 +604,6 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
           await fuzzyFingerClick(this.page, locator, this.actionTimeout, selector)
         } else {
           await locator.click({ timeout: this.actionTimeout })
-        }
-        // If the click caused navigation, reset scope to page root
-        if (this.page.url() !== urlBefore) {
-          this.currentScope = this.page
-          this.scopeStack = []
-          this.scopeSetUrl = ''
-          this.scopeStackUrls = []
         }
       }
     })


### PR DESCRIPTION
## Summary

Remove the automatic scope reset behavior that was triggered when `click` or `ifClick` caused a URL navigation. These actions should never mutate the scope stack; the runtime's `validateScope()` already handles stale scope cleanup after navigation.

## Changes

- **actor.ts & reactive.ts**: Removed URL-before/after comparison logic and scope reset code from three click-related methods:
  - `click()` with no selector (keyboard/click path)
  - `click()` with selector
  - `ifClick()` with selector
  
  This eliminates ~40 lines of scope mutation code across both files.

- **Documentation updates**:
  - Updated reference guide to clarify that `click` and `ifClick` do not change scope
  - Added explicit note that navigating clicks do not require a following `up` action
  - Updated DSL comments to reflect the new behavior
  - Added migration guidance in CHANGELOG explaining the change and prompting cleanup of unnecessary `up` calls

## Rationale

The scope reset on navigation was a workaround added in 0.7.2 but made the behavior rules harder to explain. Since `validateScope()` already walks up the scope stack to find the nearest surviving ancestor after navigation, the explicit reset was redundant. This change simplifies the mental model: `click` and `ifClick` never change scope, period.

## Migration

Users who added `up` after navigating clicks to work around the old behavior should remove those unnecessary calls. The runtime now handles this automatically.

https://claude.ai/code/session_0146J5QeeMStK2mYHsxgkmqV