### PR TITLE
Simplify checks-panel initialization and fix operator precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## [0.9.1] — 2026-05-06
+
+* Fix bug with multiple panels showing
+
 ## [0.9.0] — 2026-05-05
 
 ### New features

--- a/docs/app/routes/__root.tsx
+++ b/docs/app/routes/__root.tsx
@@ -5,7 +5,7 @@ import {
   Scripts,
   createRootRoute,
 } from '@tanstack/react-router'
-import { useEffect } from 'react'
+import '@scenetest/checks-panel/auto'
 import { SectionNav } from '../components/SectionNav'
 import { LinkCard } from '../components/LinkCard'
 import { Footer } from '../components/Footer'
@@ -30,13 +30,6 @@ export const Route = createRootRoute({
 })
 
 function RootComponent() {
-  useEffect(() => {
-    // Initialize observer panel for demo
-    import('@scenetest/checks-panel').then(({ initObserver }) => {
-      initObserver()
-    })
-  }, [])
-
   return (
     <html lang="en">
       <head>

--- a/packages/checks-panel/src/index.ts
+++ b/packages/checks-panel/src/index.ts
@@ -126,7 +126,7 @@ function handleAssertion(result: AssertionResult, existingReport?: (result: Asse
   addToGroup(result)
 
   // Create panel on first assertion if not exists (skip under automation)
-  if (!panel && document.body && window.__scenetest_force_panel || (!navigator.webdriver && !window.__scenetest_no_panel)) {
+  if (!panel && document.body && (window.__scenetest_force_panel || (!navigator.webdriver && !window.__scenetest_no_panel))) {
     createPanel()
   }
 


### PR DESCRIPTION
## Summary
This PR refactors the checks-panel initialization approach and fixes a logical operator precedence bug in the panel creation condition.

## Key Changes
- **Simplified initialization**: Replaced the `useEffect` hook with dynamic import logic in the root route with a direct import of `@scenetest/checks-panel/auto`, which handles initialization automatically
- **Fixed operator precedence**: Added parentheses around the OR condition in the panel creation check to ensure correct logical evaluation (`(window.__scenetest_force_panel || (!navigator.webdriver && !window.__scenetest_no_panel))`)

## Implementation Details
- The `auto` export from checks-panel now handles the initialization that was previously done manually in the RootComponent's useEffect
- This change reduces boilerplate code in the application while maintaining the same functionality
- The operator precedence fix ensures that the panel creation logic correctly evaluates the force panel flag independently from the webdriver detection logic

https://claude.ai/code/session_01NHkoHSWu6Eng93z6qd3eb8