### PR TITLE
Document nth-element disambiguation syntax for selectors

### DIFF
--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -88,7 +88,7 @@ user:
 - see other-section
 ```
 
-**Selector resolution is strict.** Every action resolves selectors against the current scope only — there's no silent fallback to the page root. If the element isn't in scope, you get a diagnostic error naming the action, the selector, and the scope. To reach something outside the current scope, widen first with `up` or `prev`.
+**Selector resolution is strict.** Every action resolves selectors against the current scope only — there's no silent fallback to the page root. If the element isn't in scope, you get a diagnostic error naming the action, the selector, and the scope. To reach something outside the current scope, widen first with `up` or `prev`. If the selector matches multiple elements in scope, the error is also strict — pick one with an Nth-element token: `click feed-item #1` (or `#2`, `#3`…).
 
 ## Conditional Handling
 

--- a/docs/public/reference/selectors.md
+++ b/docs/public/reference/selectors.md
@@ -190,6 +190,18 @@ user:
 
 Prefer a container with `data-testid` when one exists. Use `data-name` + `data-key` on items only when the DOM structure doesn't have a natural wrapper to label.
 
+## Nth-Element Disambiguation
+
+Selector resolution is **strict** in both directions: a selector that matches zero elements in scope fails with a diagnostic error, and so does one that matches more than one. When multiple elements legitimately share the same selector and you want a specific one, append an `#N` token (1-based):
+
+```scenetest
+user:
+- click feed-item #1            # the first feed-item in scope
+- click feed-item #2 like-button # the like-button inside the second feed-item
+```
+
+`#N` narrows the locator built so far to its Nth match, so it can appear mid-chain as well as at the end. Prefer `data-key` when the item has a stable identifier (see [Key Selectors](#key-selectors)) — `#N` is the right tool when items genuinely have no identity beyond their position (e.g. an "at least 3 results" assertion, or stress-testing an arbitrary row).
+
 ## Sigil Prefixes
 
 - `~name` — Alias lookup (configured in your config file)

--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -58,7 +58,7 @@ Control:
 
 **`see` vs `scope`:** `see` is a pure assertion — it checks that an element is visible but does not narrow scope. Use `scope` when you need subsequent actions (like `typeInto` or `check`) to resolve within a specific container.
 
-**Selector resolution is strict.** Selectors resolve against the current scope only; if nothing matches, you get a diagnostic error naming the action, the selector, and the scope rather than a silent fallback. If you need to reach an element outside the current scope, widen with `up` or `prev` first.
+**Selector resolution is strict.** Selectors resolve against the current scope only; if nothing matches, you get a diagnostic error naming the action, the selector, and the scope rather than a silent fallback. If you need to reach an element outside the current scope, widen with `up` or `prev` first. If multiple elements match in scope, resolution is also strict — disambiguate with an Nth-element token (`#1`, `#2`, `#3`…) appended to the selector.
 
 ### Nested selectors
 


### PR DESCRIPTION
## Summary
Added documentation for the nth-element disambiguation feature (`#N` syntax) that allows users to select specific elements when multiple elements match the same selector in scope.

## Changes
- **selectors.md**: Added new "Nth-Element Disambiguation" section explaining:
  - How strict selector resolution works in both directions (zero and multiple matches)
  - Syntax for using `#N` tokens (1-based indexing) to narrow to specific matches
  - Examples showing `#N` usage at the end and mid-chain
  - Guidance on when to prefer `data-key` vs `#N` for identifying elements

- **writing-scene-specs.md**: Updated the "Selector resolution is strict" explanation to mention the `#N` token as the solution for handling multiple matches

- **text-dsl.md**: Updated the "Selector resolution is strict" explanation to mention nth-element tokens (`#1`, `#2`, `#3`…) as the disambiguation mechanism

## Details
The changes clarify that selector resolution fails with a diagnostic error when multiple elements match, and documents the `#N` syntax as the tool for disambiguating between them. The documentation emphasizes that this feature is most useful when items lack stable identifiers (as opposed to using `data-key`), such as in position-based assertions or stress testing.

https://claude.ai/code/session_01JbHgy1DxJ9wfBjQhA5Dt8p