### PR TITLE
Clarify typeInto behavior in text DSL documentation

### DIFF
--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -30,7 +30,7 @@ Scope:
 
 Interactions (resolve within current scope):
   click [<selector>]              Click element (bare click = click current scope)
-  typeInto <selector> <value>     Fill input
+  typeInto <selector> <value>     Fill input (replaces existing content)
   check <selector>                Check checkbox
   select <selector> <value>       Select dropdown option
   ifClick <selector>              Click element if visible, skip silently if not
@@ -138,6 +138,7 @@ returning-user:
 - Bare `click` (no selector) clicks the current scope element
 - Bare `up` (no selector) resets scope to the page root
 - Multi-word values must be quoted: `typeInto some-selector "quoted text for words"`. Without quotes, only the last word is the value — `typeInto some-selector quoted text for words` types `words` into the compound selector `some-selector quoted text for`. Single or double quotes both work; applies anywhere a value follows a selector (`typeInto`, `select`, `warnIf`).
+- `typeInto` always clears the field first, then enters the value — it replaces, never appends. This holds in every mode (mouse, keyboard, fuzzy-finger), so a pre-filled input (e.g. an edit dialog) needs no separate clear step. There is no append-style entry in the DSL.
 
 ### Cleanup and setup directives
 


### PR DESCRIPTION
## Summary
Updated the text DSL reference documentation to clarify the behavior of the `typeInto` command, making it explicit that it always replaces existing content rather than appending to it.

## Changes
- Updated the `typeInto` command description from "Fill input" to "Fill input (replaces existing content)" for immediate clarity in the command reference
- Added a detailed note in the "Tips and gotchas" section explaining that `typeInto` always clears the field first across all input modes (mouse, keyboard, fuzzy-finger), eliminating the need for separate clear steps in scenarios like edit dialogs
- Clarified that there is no append-style entry mechanism in the DSL

## Details
This documentation change addresses a potential source of confusion for users writing scene specs. The `typeInto` command's replace-always behavior is important for predictable test execution, especially in pre-filled input scenarios (e.g., edit dialogs). The expanded explanation helps users understand why no separate clear step is needed and sets expectations about the available DSL operations.

https://claude.ai/code/session_01D33Jj6hT8eFi92du4EWihY