### PR TITLE
fix(vite-plugin): keep control-flow body when stripping unbraced check calls

### DIFF
--- a/docs/public/guides/writing-inline-assertions.md
+++ b/docs/public/guides/writing-inline-assertions.md
@@ -217,6 +217,48 @@ function handleResponse(response) {
 }
 ```
 
+### Fold Guards Into the Check — Don't Wrap It in `if`
+
+In production builds the Vite plugin strips scenetest imports and calls. A `should()`
+call is removed cleanly, but a **bare `if` around it is not** — the guard condition
+stays in your production bundle as dead code.
+
+```tsx
+// Avoid: the `if (items.length > 0)` guard still ships to production
+if (items.length > 0)
+  should('first item has a price', items[0].price > 0)
+```
+
+After stripping, production contains `if (items.length > 0) ;` — the assertion is
+gone, but the guard (and the cost of evaluating it) remains.
+
+Instead, fold the guard into the check's condition so the **whole expression**
+disappears in production:
+
+```tsx
+// Prefer: the entire call, guard included, is stripped from production
+should('first item has a price',
+  items.length === 0 || items[0].price > 0)
+```
+
+For reactive checks that take a callback (`useCheck`, `watchCheck`, `createCheck`,
+`checkEffect`), put the guard **inside the callback body**, not around the call:
+
+```tsx
+// Avoid: the `if` survives stripping (and conditionally calling a hook
+// also breaks the Rules of Hooks)
+if (profile)
+  useCheck(() => { should('name is set', !!profile.name) }, [profile])
+
+// Prefer: the guard lives inside the callback, so it strips with the check
+useCheck(() => {
+  if (!profile) return
+  should('name is set', !!profile.name)
+}, [profile])
+```
+
+This keeps assertion logic — and its runtime cost — entirely out of production.
+
 ## Summary
 
 - `should(description, condition, context?)` - assert something is true
@@ -225,3 +267,4 @@ function handleResponse(response) {
 - Assertions are grouped by timing (50ms threshold)
 - Include context to make debugging easier
 - Use your framework's check hook for reactive assertions
+- Fold guards into the check so the whole call strips from production

--- a/packages/vite-plugin/src/__tests__/strip.test.ts
+++ b/packages/vite-plugin/src/__tests__/strip.test.ts
@@ -309,6 +309,112 @@ console.log(x)`
     })
   })
 
+  describe('unbraced control-flow bodies', () => {
+    it('keeps the if body when should() is an unbraced consequent', () => {
+      const code = `import { should } from '@scenetest/checks'
+if (row)
+  should('row exists', row != null)
+const x = 1`
+
+      const result = stripScenetest(code)
+      expect(result).not.toBeNull()
+      expect(result!.code).not.toContain('should(')
+      expect(result!.code).toContain('if (row)')
+      expect(result!.code).toContain('const x = 1')
+      // Must still parse - if the body were removed entirely this would throw.
+      expect(() => stripScenetest(result!.code + '\nimport "scenetest"')).not.toThrow()
+    })
+
+    it('keeps a multi-line unbraced call body intact', () => {
+      const code = `import { should } from '@scenetest/checks'
+const collections = items.map((row) => ({
+  ...row,
+  ok: true,
+}))
+if (row)
+  should('row is valid', (() => {
+    const a = 1
+    const b = 2
+    return a + b > 0
+  })())`
+
+      const result = stripScenetest(code)
+      expect(result).not.toBeNull()
+      expect(result!.code).not.toContain('should(')
+      expect(result!.code).toContain('if (row)')
+      expect(result!.code).toContain('const collections = items.map')
+    })
+
+    it('handles should() as an unbraced consequent with an else branch', () => {
+      const code = `import { should } from '@scenetest/checks'
+if (cond)
+  should('a', true)
+else
+  console.log('else branch')`
+
+      const result = stripScenetest(code)
+      expect(result).not.toBeNull()
+      expect(result!.code).not.toContain('should(')
+      expect(result!.code).toContain('if (cond)')
+      expect(result!.code).toContain("console.log('else branch')")
+    })
+
+    it('handles failed() as an unbraced else branch', () => {
+      const code = `import { failed } from '@scenetest/checks'
+if (cond)
+  console.log('then branch')
+else
+  failed('bad')
+const x = 1`
+
+      const result = stripScenetest(code)
+      expect(result).not.toBeNull()
+      expect(result!.code).not.toContain('failed(')
+      expect(result!.code).toContain("console.log('then branch')")
+      expect(result!.code).toContain('const x = 1')
+    })
+
+    it('handles should() as an unbraced for-loop body', () => {
+      const code = `import { should } from '@scenetest/checks'
+for (const row of rows)
+  should('row ok', row != null)
+const x = 1`
+
+      const result = stripScenetest(code)
+      expect(result).not.toBeNull()
+      expect(result!.code).not.toContain('should(')
+      expect(result!.code).toContain('for (const row of rows)')
+      expect(result!.code).toContain('const x = 1')
+    })
+
+    it('handles should() as an unbraced while-loop body', () => {
+      const code = `import { should } from '@scenetest/checks'
+while (cond)
+  should('looping', true)
+const x = 1`
+
+      const result = stripScenetest(code)
+      expect(result).not.toBeNull()
+      expect(result!.code).not.toContain('should(')
+      expect(result!.code).toContain('while (cond)')
+      expect(result!.code).toContain('const x = 1')
+    })
+
+    it('still removes the whole statement when should() is inside a block', () => {
+      const code = `import { should } from '@scenetest/checks'
+if (row) {
+  should('row exists', row != null)
+}
+const x = 1`
+
+      const result = stripScenetest(code)
+      expect(result).not.toBeNull()
+      expect(result!.code).not.toContain('should(')
+      expect(result!.code).toContain('if (row) {')
+      expect(result!.code).toContain('const x = 1')
+    })
+  })
+
   describe('source maps', () => {
     it('generates source map by default', () => {
       const code = `import { should } from '@scenetest/checks'

--- a/packages/vite-plugin/src/strip.ts
+++ b/packages/vite-plugin/src/strip.ts
@@ -174,10 +174,18 @@ export function stripScenetest(code: string, options: StripOptions = {}): StripR
       // Check if this call is an ExpressionStatement (standalone call)
       const parent = path.parentPath
       if (parent && t.isExpressionStatement(parent.node)) {
-        // Remove the entire statement
         const start = parent.node.start!
         const end = parent.node.end!
-        rangesToRemove.push({ start, end, type: 'statement' })
+        if (parent.inList) {
+          // Statement lives in a statement list (block, program, switch case) -
+          // safe to remove entirely.
+          rangesToRemove.push({ start, end, type: 'statement' })
+        } else {
+          // Statement is the single-statement body of a control structure
+          // (e.g. `if (x) should(...)` without braces). Removing it would
+          // leave a dangling `if (x)`, so replace it with an empty statement.
+          rangesToRemove.push({ start, end, type: 'empty-statement' })
+        }
         hasChanges = true
       } else {
         // Call is in an expression context - replace with void 0
@@ -202,6 +210,10 @@ export function stripScenetest(code: string, options: StripOptions = {}): StripR
     if (range.type === 'expression') {
       // Replace with void 0 to maintain expression validity
       s.overwrite(range.start, range.end, 'void 0')
+    } else if (range.type === 'empty-statement') {
+      // Replace with an empty statement so a control structure that uses this
+      // as its unbraced body still has a body.
+      s.overwrite(range.start, range.end, ';')
     } else {
       // For imports and statements, remove entirely
       // Also try to remove trailing newline for cleaner output


### PR DESCRIPTION
## Summary

Fixes a production build `PARSE_ERROR` reported by a consumer (`vite v8.0.13`, rolldown). When a scenetest call was the **unbraced body of a control statement** —

```js
if (row)
  should('row valid', () => { /* ...many lines... */ })
```

— the strip transform removed the entire `ExpressionStatement`, leaving a dangling `if (row)` with no body. The next token (e.g. `}))` closing a surrounding `.map(...)`) then became the syntax error:

```
[PARSE_ERROR] Unexpected token
 25 │   if (row)        }));
```

### The fix

In `packages/vite-plugin/src/strip.ts`, when a stripped call is an `ExpressionStatement`, check whether it lives in a real statement list (block, program, switch case) via Babel's `NodePath.inList`:

- **In a statement list** → delete it entirely (unchanged behavior).
- **Not in a list** (single-statement body of `if`/`else`/`for`/`while`) → replace it with an empty statement (`;`) so the control structure keeps a valid body.

### Docs

Also adds guidance to `docs/public/guides/writing-inline-assertions.md`: prefer folding a guard into the check's condition (or the callback body for reactive checks) rather than wrapping the check in a bare `if`. A bare `if` survives production stripping as dead code; folding the guard in lets the whole call strip cleanly.

## Test plan

- [x] 7 new tests in `strip.test.ts` cover unbraced `if`/`else`/`for`/`while` bodies plus the multi-line case from the report
- [x] All 64 `@scenetest/vite-plugin` tests pass
- [x] `pnpm build` succeeds; package typecheck is clean

https://claude.ai/code/session_01Ac6xn1MKKpQEzCzGUgZEDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ac6xn1MKKpQEzCzGUgZEDK)_