### PR TITLE
Add inline-server-fn ESLint rule and preserve serverFn params

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ packages/
 ├── checks-svelte/          # Svelte bindings — checkEffect helper (re-exports checks)
 ├── scenes/                 # CLI runner — scene(), test(), actor DSL, selectors, teams, config, recorder
 ├── vite-plugin/            # Vite plugin — dev panel injection, prod stripping, RPC middleware
-├── eslint-plugin/          # ESLint plugin — prefer-aria-label rule
+├── eslint-plugin/          # ESLint plugin — prefer-aria-label, inline-server-fn rules
 ├── vscode-scenetest/       # VS Code extension — syntax highlighting for .spec.md scene specs
 ├── example-app-react/      # React demo app with working Scene tests
 ├── example-app-vue/        # Vue demo app
@@ -89,6 +89,7 @@ packages/
 ### ESLint Plugin (`packages/eslint-plugin/src/`)
 - `index.ts` — Plugin entry, `recommended` flat config preset
 - `rules/prefer-aria-label.ts` — Rule: prefer `aria-label` over `data-testid` for selectors
+- `rules/inline-server-fn.ts` — Rule: `serverCheck()`'s server function must be an inline function literal (the Vite plugin extracts it statically; a variable reference can't be)
 
 ### VS Code Extension (`packages/vscode-scenetest/`)
 - `package.json` — Extension manifest (language ID `scenetest-spec`, grammar registration)

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/eslint": "^9.6.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.39.4",
     "typescript": "^5.3.3",
     "vite": "^6.4.2",

--- a/packages/eslint-plugin/src/__tests__/inline-server-fn.test.ts
+++ b/packages/eslint-plugin/src/__tests__/inline-server-fn.test.ts
@@ -1,0 +1,87 @@
+import { describe } from 'vitest'
+import { RuleTester } from 'eslint'
+import * as tsParser from '@typescript-eslint/parser'
+import rule from '../rules/inline-server-fn.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+/** A test case parsed with the TypeScript parser. */
+const ts = { languageOptions: { parser: tsParser } }
+
+describe('inline-server-fn', () => {
+  ruleTester.run('inline-server-fn', rule, {
+    valid: [
+      // Inline arrow function
+      `import { serverCheck } from '@scenetest/checks'
+       serverCheck('t', (server, data) => {})`,
+      // Inline async arrow function
+      `import { serverCheck } from '@scenetest/checks'
+       serverCheck('t', async (server, data) => { await server.db.find(data.id) })`,
+      // Inline function expression
+      `import { serverCheck } from '@scenetest/checks'
+       serverCheck('t', function (server, data) {})`,
+      // Aliased import, still inline
+      `import { serverCheck as sc } from '@scenetest/checks'
+       sc('t', (server, data) => {})`,
+      // No 2nd argument — not this rule's concern
+      `import { serverCheck } from '@scenetest/checks'
+       serverCheck('t')`,
+      // serverCheck not imported from a scenetest package — different function
+      `function serverCheck(a, b) {}
+       const fn = () => {}
+       serverCheck('t', fn)`,
+      // TS: inline function wrapped in an `as` assertion (the plugin unwraps it)
+      {
+        code: `import { serverCheck } from '@scenetest/checks'
+               serverCheck('t', ((server, data) => {}) as ServerFn)`,
+        ...ts,
+      },
+    ],
+
+    invalid: [
+      // Variable reference — the reported bug
+      {
+        code: `import { serverCheck } from '@scenetest/checks'
+               const fn = (server, data) => {}
+               serverCheck('t', fn)`,
+        errors: [{ messageId: 'serverFnMustBeInline', data: { kind: 'variable reference' } }],
+      },
+      // Property reference
+      {
+        code: `import { serverCheck } from '@scenetest/checks'
+               serverCheck('t', handlers.check)`,
+        errors: [{ messageId: 'serverFnMustBeInline', data: { kind: 'property reference' } }],
+      },
+      // Function call result
+      {
+        code: `import { serverCheck } from '@scenetest/checks'
+               serverCheck('t', makeServerFn())`,
+        errors: [{ messageId: 'serverFnMustBeInline', data: { kind: 'function call result' } }],
+      },
+      // Conditional expression
+      {
+        code: `import { serverCheck } from '@scenetest/checks'
+               serverCheck('t', cond ? a : b)`,
+        errors: [{ messageId: 'serverFnMustBeInline', data: { kind: 'conditional expression' } }],
+      },
+      // Aliased import + variable reference
+      {
+        code: `import { serverCheck as sc } from '@scenetest/checks'
+               sc('t', fn)`,
+        errors: [{ messageId: 'serverFnMustBeInline', data: { kind: 'variable reference' } }],
+      },
+      // TS: an `as` assertion around a variable reference is still not inline
+      {
+        code: `import { serverCheck } from '@scenetest/checks'
+               serverCheck('t', fn as ServerFn)`,
+        errors: [{ messageId: 'serverFnMustBeInline', data: { kind: 'variable reference' } }],
+        ...ts,
+      },
+    ],
+  })
+})

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,4 +1,5 @@
 import preferAriaLabel from './rules/prefer-aria-label.js'
+import inlineServerFn from './rules/inline-server-fn.js'
 
 const plugin = {
   meta: {
@@ -7,6 +8,7 @@ const plugin = {
   },
   rules: {
     'prefer-aria-label': preferAriaLabel,
+    'inline-server-fn': inlineServerFn,
   },
   configs: {} as Record<string, unknown>,
 }
@@ -18,6 +20,7 @@ plugin.configs['recommended'] = {
   },
   rules: {
     'scenetest/prefer-aria-label': 'warn',
+    'scenetest/inline-server-fn': 'error',
   },
 }
 

--- a/packages/eslint-plugin/src/rules/inline-server-fn.ts
+++ b/packages/eslint-plugin/src/rules/inline-server-fn.ts
@@ -1,0 +1,139 @@
+import type { Rule } from 'eslint'
+
+/**
+ * Scenetest packages that may export `serverCheck`.
+ */
+const SCENETEST_PACKAGES = new Set([
+  '@scenetest/checks',
+  '@scenetest/checks-react',
+  '@scenetest/checks-vue',
+  '@scenetest/checks-solid',
+  '@scenetest/checks-svelte',
+])
+
+/**
+ * Node types the Vite plugin can statically extract as the server function.
+ */
+const INLINE_FN_TYPES = new Set(['ArrowFunctionExpression', 'FunctionExpression'])
+
+/**
+ * TypeScript-only wrappers the Vite plugin unwraps before extraction, e.g.
+ * `((server, data) => {}) as ServerFn`.
+ */
+const TS_WRAPPER_TYPES = new Set([
+  'TSAsExpression',
+  'TSSatisfiesExpression',
+  'TSNonNullExpression',
+  'TSInstantiationExpression',
+])
+
+interface Node {
+  type: string
+  expression?: Node
+}
+
+interface ImportSpecifierNode {
+  type: string
+  imported?: { type: string; name?: string; value?: string }
+  local: { name: string }
+}
+
+interface ImportDeclarationNode {
+  source: { value: string }
+  specifiers: ImportSpecifierNode[]
+}
+
+interface CallExpressionNode {
+  callee: { type: string; name?: string }
+  arguments: Node[]
+}
+
+/**
+ * Strip TS-only wrappers so we inspect the underlying expression — the same
+ * unwrapping the Vite plugin's transform does.
+ */
+function unwrap(node: Node): Node {
+  let current = node
+  while (TS_WRAPPER_TYPES.has(current.type) && current.expression) {
+    current = current.expression
+  }
+  return current
+}
+
+/**
+ * Human-readable description of why a node is not an inline function.
+ */
+function describe(type: string): string {
+  switch (type) {
+    case 'Identifier':
+      return 'variable reference'
+    case 'MemberExpression':
+      return 'property reference'
+    case 'CallExpression':
+      return 'function call result'
+    case 'ConditionalExpression':
+      return 'conditional expression'
+    default:
+      return 'non-function value'
+  }
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Require serverCheck()'s server function to be an inline function so the Vite plugin can statically extract it",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      serverFnMustBeInline:
+        "serverCheck()'s second argument must be an inline function. A {{ kind }} cannot be statically " +
+        'extracted by the Vite plugin — inline the function literal.',
+    },
+  },
+
+  create(context) {
+    // Local names bound to an imported `serverCheck` from a scenetest package.
+    const serverCheckNames = new Set<string>()
+
+    return {
+      ImportDeclaration(node: unknown) {
+        const decl = node as unknown as ImportDeclarationNode
+        if (!SCENETEST_PACKAGES.has(decl.source.value)) return
+        for (const spec of decl.specifiers) {
+          if (spec.type !== 'ImportSpecifier' || !spec.imported) continue
+          const importedName =
+            spec.imported.type === 'Identifier' ? spec.imported.name : spec.imported.value
+          if (importedName === 'serverCheck') {
+            serverCheckNames.add(spec.local.name)
+          }
+        }
+      },
+
+      CallExpression(node: unknown) {
+        const call = node as unknown as CallExpressionNode
+        const callee = call.callee
+        if (callee.type !== 'Identifier' || !callee.name || !serverCheckNames.has(callee.name)) {
+          return
+        }
+
+        // serverCheck(title, serverFn, withData?) — inspect the serverFn.
+        const serverFnArg = call.arguments[1]
+        if (!serverFnArg || serverFnArg.type === 'SpreadElement') return
+
+        const unwrapped = unwrap(serverFnArg)
+        if (INLINE_FN_TYPES.has(unwrapped.type)) return
+
+        context.report({
+          node: serverFnArg as unknown as Rule.Node,
+          messageId: 'serverFnMustBeInline',
+          data: { kind: describe(unwrapped.type) },
+        })
+      },
+    }
+  },
+}
+
+export default rule

--- a/packages/vite-plugin/src/__tests__/transform.test.ts
+++ b/packages/vite-plugin/src/__tests__/transform.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { parse } from '@babel/parser'
+import { transformAssertions } from '../transform.js'
+import {
+  registerAssertions,
+  clearRegistry,
+  generateVirtualModuleCode,
+} from '../virtual-module.js'
+
+describe('transformAssertions — serverCheck extraction', () => {
+  it('returns null when there is no serverCheck call', () => {
+    expect(transformAssertions('export const x = 1')).toBeNull()
+  })
+
+  it('extracts an async serverFn body and its parameters', () => {
+    const code = `
+import { serverCheck, should } from '@scenetest/checks'
+
+serverCheck(
+  'row matches',
+  async (server, data) => {
+    const { data: row } = await server.supabase
+      .from('user_card').select().eq('id', data.id).maybeSingle()
+    should('status matches', row?.status === data.status)
+  },
+  () => ({ id: 1, status: 'ok' }),
+)
+`
+    const result = transformAssertions(code, { filename: '/abs/file.ts' })
+    expect(result).not.toBeNull()
+    expect(result!.extractedAssertions).toHaveLength(1)
+
+    const extracted = result!.extractedAssertions[0]
+    expect(extracted.title).toBe('row matches')
+    expect(extracted.params).toBe('server, data')
+    expect(extracted.serverFnBodyCode).toContain('await server.supabase')
+
+    // The call is replaced with an RPC call carrying withData.
+    expect(result!.code).toContain('__scenetest_rpc(')
+    expect(result!.code).toContain('withData:')
+  })
+
+  it('preserves a destructured data parameter', () => {
+    const code = `
+import { serverCheck, should } from '@scenetest/checks'
+
+serverCheck('has id', async (server, { id }) => {
+  const row = await server.db.find(id)
+  should('found', !!row)
+})
+`
+    const result = transformAssertions(code, { filename: 'file.ts' })
+    expect(result!.extractedAssertions[0].params).toBe('server, { id }')
+  })
+
+  it('strips TypeScript type annotations from parameters', () => {
+    const code = `
+import { serverCheck, should } from '@scenetest/checks'
+
+serverCheck('typed', async (server: ServerContext, data: { id: number }) => {
+  should('ok', true)
+})
+`
+    const result = transformAssertions(code, { filename: 'file.ts' })
+    expect(result!.extractedAssertions[0].params).toBe('server, data')
+  })
+
+  it('falls back to canonical names when parameters are omitted', () => {
+    const code = `
+import { serverCheck, should } from '@scenetest/checks'
+
+serverCheck('no params', async () => {
+  should('ok', true)
+})
+`
+    const result = transformAssertions(code, { filename: 'file.ts' })
+    expect(result!.extractedAssertions[0].params).toBe('server, data')
+  })
+
+  it('unwraps a TS "as" assertion around the serverFn', () => {
+    const code = `
+import { serverCheck, should } from '@scenetest/checks'
+
+serverCheck('wrapped', (async (server, data) => {
+  should('ok', true)
+}) as ServerFn)
+`
+    const result = transformAssertions(code, { filename: 'file.ts' })
+    expect(result!.extractedAssertions).toHaveLength(1)
+    expect(result!.extractedAssertions[0].params).toBe('server, data')
+  })
+
+  it('warns and skips when the serverFn is a variable reference', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const code = `
+import { serverCheck } from '@scenetest/checks'
+
+const fn = async (server, data) => {}
+serverCheck('by reference', fn)
+`
+    const result = transformAssertions(code, { filename: 'file.ts' })
+    expect(result).toBeNull()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('must be an inline function'))
+    warn.mockRestore()
+  })
+})
+
+describe('transformAssertions + generateVirtualModuleCode integration', () => {
+  beforeEach(() => {
+    clearRegistry()
+  })
+
+  it('produces a virtual module that parses when the body uses await', () => {
+    const code = `
+import { serverCheck, should } from '@scenetest/checks'
+
+serverCheck('row matches', async (server, { id, status }) => {
+  const { data: row } = await server.supabase
+    .from('user_card').select().eq('id', id).maybeSingle()
+  should('status matches', row?.status === status)
+})
+`
+    const result = transformAssertions(code, { filename: '/abs/file.ts' })
+    registerAssertions(result!.extractedAssertions)
+
+    const moduleCode = generateVirtualModuleCode()
+    expect(moduleCode).toContain('async (server, { id, status }, { should, failed })')
+    // Regression: an `await` body inside a non-async wrapper fails to parse.
+    expect(() => parse(moduleCode, { sourceType: 'module' })).not.toThrow()
+  })
+})

--- a/packages/vite-plugin/src/__tests__/virtual-module.test.ts
+++ b/packages/vite-plugin/src/__tests__/virtual-module.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { parse } from '@babel/parser'
 import {
   registerAssertions,
   clearRegistry,
@@ -22,6 +23,7 @@ describe('generateVirtualModuleCode', () => {
         title: 'test-id',
         location: { file: 'test.tsx', line: 10, column: 1 },
         serverFnBodyCode: 'should("test", true)',
+        params: 'server, data',
       },
     ])
 
@@ -41,6 +43,7 @@ describe('generateVirtualModuleCode', () => {
         title: 'my-assertion',
         location: { file: 'app.tsx', line: 42, column: 1 },
         serverFnBodyCode: 'const result = server.validate(data.email)\nshould("email valid", result)',
+        params: 'server, data',
       },
     ])
 
@@ -58,12 +61,14 @@ describe('generateVirtualModuleCode', () => {
         title: 'assertion-1',
         location: { file: 'a.tsx', line: 1, column: 1 },
         serverFnBodyCode: 'should("first", true)',
+        params: 'server, data',
       },
       {
         id: 'assertion-2',
         title: 'assertion-2',
         location: { file: 'b.tsx', line: 2, column: 1 },
         serverFnBodyCode: 'should("second", false)',
+        params: 'server, data',
       },
     ])
 
@@ -73,5 +78,58 @@ describe('generateVirtualModuleCode', () => {
     expect(code).toContain('"assertion-2"')
     expect(code).toContain('should("first", true)')
     expect(code).toContain('should("second", false)')
+  })
+
+  it('should emit async wrappers so bodies using await parse', () => {
+    registerAssertions([
+      {
+        id: 'async-id',
+        title: 'async-id',
+        location: { file: 'app.tsx', line: 5, column: 1 },
+        serverFnBodyCode: 'const row = await server.db.find(data.id)\nshould("found", !!row)',
+        params: 'server, data',
+      },
+    ])
+
+    const code = generateVirtualModuleCode()
+
+    expect(code).toContain('async (server, data, { should, failed })')
+    // The whole module must be valid JS — `await` outside async would throw.
+    expect(() => parse(code, { sourceType: 'module' })).not.toThrow()
+  })
+
+  it('should preserve a destructured data parameter', () => {
+    registerAssertions([
+      {
+        id: 'destructured-id',
+        title: 'destructured-id',
+        location: { file: 'app.tsx', line: 7, column: 1 },
+        serverFnBodyCode: 'const row = await server.db.find(id)\nshould("match", row?.status === status)',
+        params: 'server, { id, status }',
+      },
+    ])
+
+    const code = generateVirtualModuleCode()
+
+    // Author destructured `data` — the wrapper must keep that pattern so the
+    // body references (`id`, `status`) still resolve.
+    expect(code).toContain('async (server, { id, status }, { should, failed })')
+    expect(() => parse(code, { sourceType: 'module' })).not.toThrow()
+  })
+
+  it('should fall back to server, data when params are missing', () => {
+    registerAssertions([
+      {
+        id: 'fallback-id',
+        title: 'fallback-id',
+        location: { file: 'app.tsx', line: 9, column: 1 },
+        serverFnBodyCode: 'should("ok", true)',
+        params: '',
+      },
+    ])
+
+    const code = generateVirtualModuleCode()
+
+    expect(code).toContain('async (server, data, { should, failed })')
   })
 })

--- a/packages/vite-plugin/src/transform.ts
+++ b/packages/vite-plugin/src/transform.ts
@@ -20,6 +20,13 @@ export interface ExtractedAssertion {
   title: string
   /** The serverFn body code (without function wrapper) */
   serverFnBodyCode: string
+  /**
+   * The serverFn's first two parameters, source-preserved (names and
+   * destructuring patterns) so the inlined body keeps resolving the symbols
+   * it references. Always exactly two slots; missing ones fall back to the
+   * canonical `server` / `data` names.
+   */
+  params: string
   /** Source location */
   location: {
     file: string
@@ -45,21 +52,70 @@ export interface TransformOptions {
 }
 
 /**
- * Helper to extract serverFn body code from a function node
+ * Unwrap TypeScript-only and parenthesized wrappers so the underlying
+ * function expression can be found, e.g. `((s, d) => {...}) as ServerFn`.
  */
-function extractServerFnBody(code: string, serverFnNode: t.Node, filename: string, line: number): string | null {
-  if (t.isArrowFunctionExpression(serverFnNode) || t.isFunctionExpression(serverFnNode)) {
-    const body = serverFnNode.body
-    if (t.isBlockStatement(body)) {
-      const bodyCode = code.slice(body.start!, body.end!)
-      return bodyCode.slice(1, -1).trim() // Remove { and }
-    } else {
-      return `return ${code.slice(body.start!, body.end!)}`
-    }
-  } else {
-    console.warn(`[vite-plugin-scenetest] serverFn is not a function at ${filename}:${line}`)
+function unwrapExpression(node: t.Node): t.Node {
+  let current = node
+  while (
+    t.isTSAsExpression(current) ||
+    t.isTSSatisfiesExpression(current) ||
+    t.isTSNonNullExpression(current) ||
+    t.isParenthesizedExpression(current)
+  ) {
+    current = current.expression
+  }
+  return current
+}
+
+/**
+ * Print a single parameter pattern without its TypeScript type annotation.
+ * The virtual module is evaluated as plain JS, so annotations must be dropped
+ * while destructuring patterns and default values are preserved.
+ */
+function cleanParam(code: string, node: t.Node): string {
+  if (t.isAssignmentPattern(node)) {
+    return `${cleanParam(code, node.left)} = ${code.slice(node.right.start!, node.right.end!)}`
+  }
+  const annotation = (node as t.Identifier | t.ObjectPattern | t.ArrayPattern | t.RestElement).typeAnnotation
+  const end = annotation && annotation.start != null ? annotation.start : node.end!
+  // Drop a trailing TS optional marker, e.g. `data?`.
+  return code.slice(node.start!, end).replace(/\?\s*$/, '').trim()
+}
+
+/**
+ * Extract the serverFn body and its first two parameters from a function node.
+ *
+ * The body is inlined verbatim into the virtual module. The parameters are
+ * source-preserved (including destructuring patterns) so a serverFn written as
+ * `(server, { id }) => ...` keeps working — the canonical `server` / `data`
+ * names are only used as fallbacks when the author omits a parameter.
+ */
+function extractServerFn(
+  code: string,
+  serverFnNode: t.Node,
+  filename: string,
+  line: number
+): { body: string; params: string } | null {
+  if (!t.isArrowFunctionExpression(serverFnNode) && !t.isFunctionExpression(serverFnNode)) {
+    console.warn(
+      `[vite-plugin-scenetest] serverCheck() second argument must be an inline function at ` +
+        `${filename}:${line} (got ${serverFnNode.type}). A variable reference or other expression ` +
+        `cannot be statically extracted — inline the function literal.`
+    )
     return null
   }
+
+  const fnParams = serverFnNode.params
+  const p0 = fnParams[0] ? cleanParam(code, fnParams[0]) : 'server'
+  const p1 = fnParams[1] ? cleanParam(code, fnParams[1]) : 'data'
+  const params = `${p0}, ${p1}`
+
+  const body = serverFnNode.body
+  if (t.isBlockStatement(body)) {
+    return { params, body: code.slice(body.start! + 1, body.end! - 1).trim() } // Remove { and }
+  }
+  return { params, body: `return ${code.slice(body.start!, body.end!)}` }
 }
 
 /**
@@ -164,7 +220,7 @@ export function transformAssertions(code: string, options: TransformOptions = {}
       }
 
       const titleArg = args[0]
-      const serverFnArg = args[1]
+      const serverFnArg = unwrapExpression(args[1])
       const withDataArg = args[2] // optional
 
       // Get the source location
@@ -183,9 +239,9 @@ export function transformAssertions(code: string, options: TransformOptions = {}
         titleValue = titleArg.quasis[0].value.raw
       }
 
-      // Extract serverFn body code
-      const serverFnBodyCode = extractServerFnBody(code, serverFnArg, filename, line)
-      if (!serverFnBodyCode) {
+      // Extract serverFn body code and parameters
+      const extracted = extractServerFn(code, serverFnArg, filename, line)
+      if (!extracted) {
         return
       }
 
@@ -193,7 +249,8 @@ export function transformAssertions(code: string, options: TransformOptions = {}
       extractedAssertions.push({
         id,
         title: titleValue,
-        serverFnBodyCode,
+        serverFnBodyCode: extracted.body,
+        params: extracted.params,
         location: { file: filename, line, column },
       })
 

--- a/packages/vite-plugin/src/virtual-module.ts
+++ b/packages/vite-plugin/src/virtual-module.ts
@@ -56,9 +56,11 @@ export function removeAssertionsForFile(filename: string): void {
  * Generate the virtual module code.
  * This module exports a map of assertion IDs to their serverFn functions.
  *
- * Each serverFn receives (server, data, { pass, fail }) where pass/fail
- * are destructured in the function parameters, making them available in scope
- * for the inlined body code.
+ * Each serverFn is wrapped as an `async` arrow so that bodies using `await`
+ * (the common case — serverCheck exists to do async server work) parse and
+ * run. It receives the author's first two parameters followed by an injected
+ * `{ should, failed }` argument, making those helpers available in scope for
+ * the inlined body code.
  *
  * SECURITY NOTE: This function embeds user-provided assertion code directly
  * into the generated module. The code runs in the Vite dev server context
@@ -73,11 +75,13 @@ export function generateVirtualModuleCode(): string {
     return `export const assertions = {}`
   }
 
-  // Generate an object with all serverFn functions
-  // The original serverFn body is inlined into a wrapper function that
-  // provides should/failed in scope via parameter destructuring
+  // Generate an object with all serverFn functions.
+  // The original serverFn body is inlined into an async wrapper function that
+  // provides should/failed in scope via parameter destructuring. The author's
+  // own parameters are kept so destructured patterns keep resolving.
   const entries = assertions.map((assertion) => {
-    return `  ${JSON.stringify(assertion.id)}: (server, data, { should, failed }) => {
+    const params = assertion.params || 'server, data'
+    return `  ${JSON.stringify(assertion.id)}: async (${params}, { should, failed }) => {
     ${assertion.serverFnBodyCode}
   }`
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@types/eslint':
         specifier: ^9.6.0
         version: 9.6.1
+      '@typescript-eslint/parser':
+        specifier: ^8.0.0
+        version: 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -1626,6 +1629,43 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
@@ -2072,6 +2112,10 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
@@ -2954,6 +2998,12 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -4382,6 +4432,58 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/types@8.59.4': {}
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
@@ -4910,6 +5012,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.39.4(jiti@2.6.1):
     dependencies:
@@ -6140,6 +6244,10 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary

This PR adds static analysis and parameter preservation for `serverCheck()` to ensure the Vite plugin can extract server functions correctly.

## Key Changes

- **New ESLint rule `inline-server-fn`**: Enforces that `serverCheck()`'s second argument must be an inline function (arrow or function expression), not a variable reference, property access, or other expression. The rule detects imports from scenetest packages and unwraps TypeScript type assertions (`as`, `satisfies`, non-null, instantiation) before checking the underlying expression type.

- **Parameter preservation in Vite plugin**: The `transformAssertions()` function now extracts and preserves the author's first two parameters from the serverFn, including destructuring patterns and default values. TypeScript type annotations are stripped (since the virtual module is evaluated as plain JS) but parameter names and patterns are kept so the inlined body continues to resolve the symbols it references.

- **Virtual module async wrapping**: Updated `generateVirtualModuleCode()` to emit `async` arrow functions so that serverFn bodies using `await` (the common case) parse and run correctly. The wrapper receives the author's parameters followed by an injected `{ should, failed }` argument.

- **Test coverage**: Added comprehensive tests for both the ESLint rule (valid/invalid cases) and the Vite plugin's parameter extraction and virtual module generation.

## Implementation Details

- The ESLint rule mirrors the Vite plugin's unwrapping logic (both handle `TSAsExpression`, `TSSatisfiesExpression`, `TSNonNullExpression`, and parenthesized expressions).
- Parameter cleaning via `cleanParam()` preserves destructuring patterns and default values while removing TypeScript annotations.
- The `ExtractedAssertion` interface now includes a `params` field that stores the source-preserved parameter string.
- Fallback to canonical `server` / `data` names only when parameters are omitted by the author.

https://claude.ai/code/session_01HctYUyGct2yQXsDetpDE6z