### PR TITLE
Improve error reporting with stack traces and source context

### DIFF
--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -323,7 +323,9 @@ export class SceneRunner {
           })
 
           // Log progress
-          const passed = report.status === 'completed'
+          const failedAssertions = report.assertions.filter((a) => !a.result)
+          const sceneFailed = report.status !== 'completed'
+          const passed = !sceneFailed && failedAssertions.length === 0
           const statusIcon = passed ? '✓' : report.status === 'timeout' ? '⏱' : '✗'
 
           if (passed) {
@@ -331,19 +333,41 @@ export class SceneRunner {
           } else {
             // Set failing scenes apart with blank lines + a separator so they're
             // easy to scroll to and copy-paste from a long CI log.
-            const label = report.status === 'timeout' ? 'TIMEOUT' : 'FAIL'
+            const label = report.status === 'timeout'
+              ? 'TIMEOUT'
+              : sceneFailed
+                ? 'FAIL'
+                : 'ASSERTION FAIL'
             console.log('')
             console.log('  ' + '─'.repeat(60))
             console.log(`  ${statusIcon} ${label}: ${registered.name} (${report.duration}ms) ${teamLabel}`)
-            console.log(`     file: ${fileWithLine}`)
 
+            // Prefer the failing-line resolved from the stack; fall back to the
+            // scene declaration line so we always print something useful.
             const frame = findFailingFrame(report.errorStack, registered.file)
+            const displayPath = frame
+              ? path.relative(process.cwd(), frame.file)
+              : relativeFile
+            const displayLine = frame?.line ?? registered.line
+            const fileLine = displayLine !== undefined ? `${displayPath}:${displayLine}` : displayPath
+            console.log(`     file: ${fileLine}`)
+
             if (frame) {
-              const frameRel = path.relative(process.cwd(), frame.file)
-              console.log(`     at:   ${frameRel}:${frame.line}`)
               const context = readSourceContext(frame.file, frame.line)
               if (context) {
                 console.log(context)
+              }
+            }
+
+            if (failedAssertions.length > 0) {
+              console.log(`     failed assertion(s): ${failedAssertions.length}`)
+              for (const a of failedAssertions.slice(0, 5)) {
+                const actor = a.actor ? `[${a.actor}] ` : ''
+                const loc = a.location ? ` (${path.relative(process.cwd(), a.location.file)}:${a.location.line})` : ''
+                console.log(`       ✗ ${actor}${a.description}${loc}`)
+              }
+              if (failedAssertions.length > 5) {
+                console.log(`       … and ${failedAssertions.length - 5} more`)
               }
             }
 

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -15,6 +15,11 @@ import { registerBuiltinMacros, registerSelectedMacros } from './builtin-macros.
 import { DashboardReporter, setDashboardReporter, dashboardSend } from './dashboard-reporter.js'
 import { tick as soundTick, fail as soundFail } from './sound.js'
 
+function formatTeamLabel(teamIndex: number, meta: TeamMeta | undefined): string {
+  const name = meta?.name
+  return name ? `[team: ${name} #${teamIndex}]` : `[team: #${teamIndex}]`
+}
+
 function formatConsoleEntry(actor: string, label: string, message: string, bodyLimit: number): string {
   const prefix = `      └─ [${actor}]`
   const lines = message.split('\n')
@@ -187,11 +192,13 @@ export class SceneRunner {
         const session = await this.teamManager.createSession(teamIndex, actionTimeout, warnAfter, this.config.baseUrl, fuzzyFingers, this.config.noPanel, this.config.consoleErrors, this.config.errorSelectors)
 
         try {
-          // Log which scene is starting
-          const relativeFile = path.relative(path.join(process.cwd(), 'scenetest', 'scenes'), registered.file)
-          console.log(`▶ ${registered.name} (${relativeFile})`)
-
           const resolvedTeam = this.teamManager.getTeam(teamIndex)
+
+          // Log which scene is starting (with team label for concurrency debugging)
+          const relativeFile = path.relative(path.join(process.cwd(), 'scenetest', 'scenes'), registered.file)
+          const teamLabel = formatTeamLabel(teamIndex, resolvedTeam.meta)
+          console.log(`▶ ${registered.name} (${relativeFile}) ${teamLabel}`)
+
           const server = this.config.server as Record<string, unknown> | undefined
           const testStart = new Date().toISOString()
 
@@ -245,16 +252,29 @@ export class SceneRunner {
           })
 
           // Log progress
-          const statusIcon = report.status === 'completed' ? '✓' : report.status === 'timeout' ? '⏱' : '✗'
-          console.log(`  ${statusIcon} ${registered.name} (${report.duration}ms)`)
+          const passed = report.status === 'completed'
+          const statusIcon = passed ? '✓' : report.status === 'timeout' ? '⏱' : '✗'
 
-          if (this.config.sound?.enabled) {
-            if (report.status === 'completed') soundTick()
-            else soundFail()
+          if (passed) {
+            console.log(`  ${statusIcon} ${registered.name} (${report.duration}ms) ${teamLabel}`)
+          } else {
+            // Set failing scenes apart with blank lines + a separator so they're
+            // easy to scroll to and copy-paste from a long CI log.
+            const label = report.status === 'timeout' ? 'TIMEOUT' : 'FAIL'
+            console.log('')
+            console.log('  ' + '─'.repeat(60))
+            console.log(`  ${statusIcon} ${label}: ${registered.name} (${report.duration}ms) ${teamLabel}`)
+            console.log(`     file: ${relativeFile}`)
+            if (report.error) {
+              console.log(`     error: ${report.error}`)
+            }
+            console.log('  ' + '─'.repeat(60))
+            console.log('')
           }
 
-          if (report.error) {
-            console.log(`    Error: ${report.error}`)
+          if (this.config.sound?.enabled) {
+            if (passed) soundTick()
+            else soundFail()
           }
 
           if (report.consoleErrors.length > 0) {
@@ -664,6 +684,29 @@ export function printSummary(report: RunReport): void {
 
   if (report.summary.failed > 0) {
     console.log(`\n  ✗ ${report.summary.failed} scene(s) failed`)
+    for (const scene of report.scenes) {
+      if (scene.status !== 'completed') {
+        const label = scene.status === 'timeout' ? '⏱ timeout' : '✗ failed'
+        console.log(`    ${label}: ${scene.name} ${formatTeamLabel(scene.teamIndex, scene.team)}`)
+      }
+    }
+  }
+
+  // Team usage breakdown — handy for verifying that concurrency actually
+  // distributes scenes across the configured teams.
+  const teamCounts = new Map<number, { name?: string; count: number }>()
+  for (const scene of report.scenes) {
+    const entry = teamCounts.get(scene.teamIndex)
+    if (entry) entry.count++
+    else teamCounts.set(scene.teamIndex, { name: scene.team?.name, count: 1 })
+  }
+  if (teamCounts.size > 0) {
+    console.log(`\n  Teams used: ${teamCounts.size}`)
+    const sorted = [...teamCounts.entries()].sort((a, b) => a[0] - b[0])
+    for (const [index, { name, count }] of sorted) {
+      const label = name ? `${name} #${index}` : `#${index}`
+      console.log(`    ${label}: ${count} scene(s)`)
+    }
   }
 
   // Device and navigation mode info

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -1,5 +1,7 @@
 import { chromium, firefox, webkit, type Browser } from 'playwright'
 import { glob } from 'glob'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
 import path from 'path'
 import type { ScenetestConfig, ResolvedTeam, TeamConfig, TeamMeta, RunReport, SceneReport, RegisteredScene } from './types.js'
 import { TeamManager } from './team-manager.js'
@@ -18,6 +20,74 @@ import { tick as soundTick, fail as soundFail } from './sound.js'
 function formatTeamLabel(teamIndex: number, meta: TeamMeta | undefined): string {
   const name = meta?.name
   return name ? `[team: ${name} #${teamIndex}]` : `[team: #${teamIndex}]`
+}
+
+/**
+ * Find the first stack frame pointing into the user's scene file, falling
+ * back to the first frame that isn't inside scenetest itself or node_modules.
+ *
+ * Returns absolute path + 1-indexed line, or `null` if no usable frame was
+ * found. The location of the scene file is used to bias the match toward
+ * user-authored code rather than framework internals.
+ */
+function findFailingFrame(
+  stack: string | undefined,
+  sceneFile: string
+): { file: string; line: number } | null {
+  if (!stack) return null
+
+  // Stack frames look like "  at fn (/abs/path.ts:12:34)" or
+  // "  at /abs/path.ts:12:34" or with file:// URLs.
+  const frameRe = /\((file:\/\/[^)]+|\/[^)\s]+):(\d+):\d+\)|at (file:\/\/\S+|\/\S+):(\d+):\d+/g
+
+  const frames: { file: string; line: number }[] = []
+  let m: RegExpExecArray | null
+  while ((m = frameRe.exec(stack)) !== null) {
+    const rawFile = m[1] ?? m[3]
+    const rawLine = m[2] ?? m[4]
+    if (!rawFile || !rawLine) continue
+    const filePath = rawFile.startsWith('file://') ? fileURLToPath(rawFile) : rawFile
+    frames.push({ file: filePath, line: parseInt(rawLine, 10) })
+  }
+
+  if (frames.length === 0) return null
+
+  // Prefer a frame in the actual scene file
+  const sceneFrame = frames.find((f) => f.file === sceneFile)
+  if (sceneFrame) return sceneFrame
+
+  // Otherwise pick the first frame that's not in node_modules and not in the
+  // scenetest packages themselves
+  const userFrame = frames.find(
+    (f) => !f.file.includes('/node_modules/') && !/\/packages\/(scenes|checks|vite-plugin)\//.test(f.file)
+  )
+  return userFrame ?? null
+}
+
+/**
+ * Read up to 3 lines (the target line + the 2 preceding lines) from `file`,
+ * formatted with line-number gutters. Returns `null` if the file can't be
+ * read or the line is out of range.
+ */
+function readSourceContext(file: string, line: number): string | null {
+  let contents: string
+  try {
+    contents = fs.readFileSync(file, 'utf8')
+  } catch {
+    return null
+  }
+  const lines = contents.split('\n')
+  if (line < 1 || line > lines.length) return null
+
+  const start = Math.max(1, line - 2)
+  const gutterWidth = String(line).length
+  const out: string[] = []
+  for (let i = start; i <= line; i++) {
+    const num = String(i).padStart(gutterWidth, ' ')
+    const marker = i === line ? '>' : ' '
+    out.push(`       ${marker} ${num} | ${lines[i - 1]}`)
+  }
+  return out.join('\n')
 }
 
 function formatConsoleEntry(actor: string, label: string, message: string, bodyLimit: number): string {
@@ -196,8 +266,9 @@ export class SceneRunner {
 
           // Log which scene is starting (with team label for concurrency debugging)
           const relativeFile = path.relative(path.join(process.cwd(), 'scenetest', 'scenes'), registered.file)
+          const fileWithLine = registered.line !== undefined ? `${relativeFile}:${registered.line}` : relativeFile
           const teamLabel = formatTeamLabel(teamIndex, resolvedTeam.meta)
-          console.log(`▶ ${registered.name} (${relativeFile}) ${teamLabel}`)
+          console.log(`▶ ${registered.name} (${fileWithLine}) ${teamLabel}`)
 
           const server = this.config.server as Record<string, unknown> | undefined
           const testStart = new Date().toISOString()
@@ -264,7 +335,18 @@ export class SceneRunner {
             console.log('')
             console.log('  ' + '─'.repeat(60))
             console.log(`  ${statusIcon} ${label}: ${registered.name} (${report.duration}ms) ${teamLabel}`)
-            console.log(`     file: ${relativeFile}`)
+            console.log(`     file: ${fileWithLine}`)
+
+            const frame = findFailingFrame(report.errorStack, registered.file)
+            if (frame) {
+              const frameRel = path.relative(process.cwd(), frame.file)
+              console.log(`     at:   ${frameRel}:${frame.line}`)
+              const context = readSourceContext(frame.file, frame.line)
+              if (context) {
+                console.log(context)
+              }
+            }
+
             if (report.error) {
               console.log(`     error: ${report.error}`)
             }

--- a/packages/scenes/src/scene.ts
+++ b/packages/scenes/src/scene.ts
@@ -154,6 +154,7 @@ export async function runScene(
 
   let status: SceneReport['status'] = 'completed'
   let error: string | undefined
+  let errorStack: string | undefined
 
   try {
     // Run with timeout
@@ -170,6 +171,7 @@ export async function runScene(
       status = 'failed'
     }
     error = err instanceof Error ? err.message : String(err)
+    errorStack = err instanceof Error ? err.stack : undefined
   } finally {
     setCurrentSession(null)
   }
@@ -197,5 +199,6 @@ export async function runScene(
     timeline: session.timeline,
     duration: Date.now() - start,
     error,
+    ...(errorStack ? { errorStack } : {}),
   }
 }

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -397,6 +397,11 @@ export interface SceneReport {
   timeline: TimelineEntry[]
   duration: number
   error?: string
+  /**
+   * Raw stack trace from the failure, when available. Captured so the CLI
+   * can resolve the failing source line and show context around it.
+   */
+  errorStack?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

Enhanced the CLI error reporting to show failing source lines with context, stack trace resolution, and detailed assertion failures. This makes it easier to locate and debug test failures in CI logs and local runs.

## Key Changes

- **Stack trace capture and resolution**: Added `findFailingFrame()` to parse error stack traces and locate the first user-authored frame (preferring the scene file itself, falling back to non-framework code)
- **Source context display**: Added `readSourceContext()` to read and format 3 lines of source code (target line + 2 preceding) with line-number gutters around failing assertions
- **Enhanced failure output**: Restructured failure logging to:
  - Separate failed scenes with visual separators (dashes) for easy scrolling in CI logs
  - Show file path and line number resolved from the stack trace
  - Display source context when available
  - List failed assertions with actor names and locations (up to 5, with count of remaining)
  - Show error messages when present
- **Team labels in output**: Added `formatTeamLabel()` helper and integrated team identification into both passing and failing scene output for concurrency debugging
- **Summary improvements**: Enhanced `printSummary()` to list failed scenes by name and show team usage breakdown (distribution of scenes across configured teams)
- **Type updates**: Added `errorStack` field to `SceneReport` to capture raw stack traces during scene execution

## Implementation Details

- Stack frame regex handles both parenthesized and bare formats, with support for `file://` URLs via `fileURLToPath()`
- Frame filtering excludes `node_modules/` and scenetest framework packages (`/packages/(scenes|checks|vite-plugin)/`)
- Source context uses 1-indexed line numbers with right-padded gutters for alignment
- Failed assertions are now distinguished from scene failures (timeout vs. error vs. assertion failure)
- Sound feedback now triggers on `passed` flag rather than just status check

https://claude.ai/code/session_01W9nQrQo26DLP51jzfgXxTF