### PR TITLE
Add lazy callback forms to should() and failed() assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ packages/
 - `audio.ts` — Audio feedback (chords per group)
 - `styles.ts` — Injected CSS
 - `fixtures.ts` — `scenePage` fixture, `waitForAssertions()`, failure logging
+- `skills/inline-assertions/SKILL.md` — shippable Agent Skill (TanStack Intent) teaching `should()`/`failed()`/`serverCheck()` authoring. Shipped in the npm tarball (`files` includes `skills`, `tanstack-intent` keyword). Validate with `pnpm -C packages/checks skills:validate`. Consumers discover it via `npx @tanstack/intent list` (transitively through any `@scenetest/checks-*` binding) and load `@scenetest/checks#inline-assertions`. Keep it in sync with `docs/public/guides/writing-inline-assertions.md`.
 
 ### Scenes (`packages/scenes/src/`)
 - `scene.ts` — `test()` registration (await-driven), shared `registerScene()` helper, `runScene()`, session accessors

--- a/docs/public/design/writing-tests.md
+++ b/docs/public/design/writing-tests.md
@@ -91,6 +91,20 @@ function ProfileForm({ user }) {
 }
 ```
 
+`should()`'s condition can be a boolean **or a `() => boolean` predicate**. Prefer
+the predicate form when the check involves real work — it keeps the computation
+inline and strips from production along with the assertion, instead of hoisting it
+into a variable that runs even after stripping:
+
+```tsx
+// Avoid: runs in production even though the should() call is stripped
+const results = expensiveSearch(query)
+should('search returns results', results.length > 0)
+
+// Prefer: the computation only runs when the assertion runs
+should('search returns results', () => expensiveSearch(query).length > 0)
+```
+
 For the full guide on `should()`, `failed()`, multi-context `serverCheck()`, framework imports, and best practices, see [Writing Inline Assertions](/guides/writing-inline-assertions).
 
 ---

--- a/docs/public/guides/writing-inline-assertions.md
+++ b/docs/public/guides/writing-inline-assertions.md
@@ -56,8 +56,8 @@ should(description, condition, context?)
 ```
 
 - `description`: What you're asserting (string)
-- `condition`: Boolean expression to check
-- `context`: Optional object with debugging info
+- `condition`: A boolean expression, **or a function returning a boolean** (see [Lazy conditions](#lazy-conditions-with-a-callback))
+- `context`: Optional object with debugging info, **or a function returning one** (evaluated lazily)
 
 ```typescript
 import { should } from '@scenetest/checks-react'
@@ -74,6 +74,35 @@ function UserProfile({ user }) {
 }
 ```
 
+### Lazy Conditions with a Callback
+
+`condition` can be a **function** that returns a boolean. Scenetest calls it and
+evaluates the return value. This lets you keep a computation *inside* the
+assertion instead of hoisting it into a variable:
+
+```typescript
+// Avoid: the work is hoisted into a variable, so it runs in production even
+// after the Vite plugin strips the should() call
+const results = expensiveSearch(query)
+should('search returns results', results.length > 0)
+
+// Prefer: the whole computation lives in the callback, so it only runs when the
+// assertion runs — and strips from production along with the call
+should('search returns results', () => expensiveSearch(query).length > 0)
+```
+
+The predicate receives the resolved `context`, so you can reuse it:
+
+```typescript
+should('all items are priced', (ctx) => ctx.items.every((i) => i.price > 0), { items })
+```
+
+If the predicate **throws**, Scenetest reports a failed assertion (with the error
+message in context) rather than letting the exception escape into your render.
+
+The `context` argument can likewise be a function — `should('...', cond, () => buildContext())` —
+so expensive debugging context is only built when the assertion actually runs.
+
 ## Using `failed()`
 
 Use `failed()` when something **should not happen**:
@@ -83,7 +112,7 @@ failed(description, context?)
 ```
 
 - `description`: What went wrong (string)
-- `context`: Optional object with debugging info
+- `context`: Optional object with debugging info, **or a function returning one** (evaluated lazily, only when `failed()` runs)
 
 ```typescript
 import { failed } from '@scenetest/checks-react'
@@ -241,6 +270,14 @@ should('first item has a price',
   items.length === 0 || items[0].price > 0)
 ```
 
+Or use the **callback condition** when the check involves real work — the guard
+and the computation both live in the function body and strip together:
+
+```tsx
+// Prefer: nothing here survives stripping
+should('first item has a price', () => items.length === 0 || items[0].price > 0)
+```
+
 For reactive checks that take a callback (`useCheck`, `watchCheck`, `createCheck`,
 `checkEffect`), put the guard **inside the callback body**, not around the call:
 
@@ -261,8 +298,8 @@ This keeps assertion logic — and its runtime cost — entirely out of producti
 
 ## Summary
 
-- `should(description, condition, context?)` - assert something is true
-- `failed(description, context?)` - mark code paths that should never run
+- `should(description, condition, context?)` - assert something is true; `condition` may be a boolean or a `() => boolean` predicate (lazy)
+- `failed(description, context?)` - mark code paths that should never run; `context` may be an object or a `() => object` (lazy)
 - `serverCheck()` with test effects - compare browser and server data
 - Assertions are grouped by timing (50ms threshold)
 - Include context to make debugging easier

--- a/docs/public/guides/writing-inline-assertions.md
+++ b/docs/public/guides/writing-inline-assertions.md
@@ -56,8 +56,8 @@ should(description, condition, context?)
 ```
 
 - `description`: What you're asserting (string)
-- `condition`: A boolean expression, **or a function returning a boolean** (see [Lazy conditions](#lazy-conditions-with-a-callback))
-- `context`: Optional object with debugging info, **or a function returning one** (evaluated lazily)
+- `condition`: A boolean expression, or a function returning a boolean
+- `context`: Optional object with debugging info, or a function returning one (evaluated lazily)
 
 ```typescript
 import { should } from '@scenetest/checks-react'
@@ -112,7 +112,7 @@ failed(description, context?)
 ```
 
 - `description`: What went wrong (string)
-- `context`: Optional object with debugging info, **or a function returning one** (evaluated lazily, only when `failed()` runs)
+- `context`: Optional object with debugging info, or a function returning one (evaluated lazily, only when `failed()` runs)
 
 ```typescript
 import { failed } from '@scenetest/checks-react'

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/scenetest/scenetest-js",
     "directory": "packages/checks"
   },
-  "keywords": ["testing", "e2e", "playwright", "assertions", "inline-assertions"],
+  "keywords": ["testing", "e2e", "playwright", "assertions", "inline-assertions", "tanstack-intent"],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -22,7 +22,7 @@
       "import": "./dist/runtime.js"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "skills", "!skills/_artifacts"],
   "publishConfig": {
     "access": "public"
   },
@@ -30,9 +30,11 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "skills:validate": "intent validate"
   },
   "devDependencies": {
+    "@tanstack/intent": "^0.0.41",
     "typescript": "^5.3.3",
     "vite": "^6.4.2",
     "vitest": "^4.1.4"

--- a/packages/checks/skills/inline-assertions/SKILL.md
+++ b/packages/checks/skills/inline-assertions/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: inline-assertions
+description: >-
+  Use when writing, reviewing, or generating Scenetest inline assertions —
+  `should()`, `failed()`, and `serverCheck()` — inside application code
+  (components, hooks, event handlers) for any framework (React, Vue, Solid,
+  Svelte, or vanilla) via the @scenetest/checks family of packages. Covers the
+  correct call signatures, the lazy callback form of `should()` that keeps
+  expensive computation inline and strips from production, multi-context
+  `serverCheck()`, context for debugging, and the production-stripping rules
+  that determine where guards may live. Apply this whenever a task adds or edits
+  `should(...)`, `failed(...)`, or `serverCheck(...)` calls.
+---
+
+# Writing Scenetest Inline Assertions
+
+Inline assertions live **inside application code** and verify internal state
+that external tests can't easily observe. They run during normal execution and
+report to the Scenetest observer. In production, the Vite plugin **strips every
+`@scenetest/*` import and call** via an AST transform — so assertions add zero
+runtime cost to shipped code, *as long as you follow the stripping rules below*.
+
+Import from the binding that matches the app's framework. All bindings
+re-export the same `should` / `failed` / `serverCheck`:
+
+```ts
+import { should, failed, serverCheck } from '@scenetest/checks-react'  // or -vue / -solid / -svelte
+import { should, failed, serverCheck } from '@scenetest/checks'        // framework-agnostic
+```
+
+## `should(description, condition, context?)`
+
+Assert that something **is true**.
+
+- `description` — a natural "should" sentence (string).
+- `condition` — a **boolean OR a `() => boolean` predicate** (see below).
+- `context?` — optional debugging object, **or a `() => object`** evaluated lazily.
+
+```ts
+should('user has a display name', !!user.displayName)
+should('email is verified', user.emailVerified, { email: user.email })
+```
+
+### Prefer the lazy callback form for any non-trivial computation
+
+`condition` accepts a function returning a boolean. **Use it whenever the check
+involves real work.** This is the single most important pattern in this skill.
+
+```ts
+// ❌ AVOID — the computation is hoisted into a variable, so it runs in
+//    PRODUCTION even though the should() call itself is stripped out.
+const results = expensiveSearch(query)
+should('search returns results', results.length > 0)
+
+// ✅ PREFER — the whole computation lives in the callback. It only runs when
+//    the assertion runs, and strips from production together with the call.
+should('search returns results', () => expensiveSearch(query).length > 0)
+```
+
+Why this matters: stripping removes the `should(...)` call, but a variable
+declared *before* it (`const results = expensiveSearch(query)`) is ordinary
+application code and stays in the bundle, running on every render in production.
+Folding the work into the predicate moves it inside the call that gets removed.
+
+The predicate receives the resolved `context`, so you can reuse it:
+
+```ts
+should('all items are priced', (ctx) => ctx.items.every((i) => i.price > 0), { items })
+```
+
+A predicate that **throws** is reported as a *failed* assertion (with the error
+message in context) — it never escapes into your render. Do **not** wrap
+`should()` in `try/catch` to guard against this.
+
+> Note: a function is always truthy. `should('x', () => cond)` is evaluated as a
+> predicate (correct). Never write `should('x', someFunction)` expecting the
+> function *reference* to be the condition — pass a call or an arrow.
+
+## `failed(description, context?)`
+
+Mark a code path that **should never execute**. It always reports a failure.
+
+- `context?` — object, **or a `() => object`** evaluated lazily (only when
+  `failed()` runs), so expensive context construction strips with the call.
+
+```ts
+switch (response.type) {
+  case 'success': return processSuccess(response)
+  case 'error':   return processError(response)
+  default:        failed('unknown response type', { type: response.type })
+}
+```
+
+Use `failed()` for impossible branches and unexpected error states — think of it
+as a tracked `console.error` for "this should not happen".
+
+## `serverCheck(title, serverFn, withData?)` — multi-context
+
+Compare browser data against server/database data. Run it from your framework's
+reactive check hook (`useCheck` / `watchCheck` / `createCheck` / `checkEffect`),
+guarding inside the callback:
+
+```tsx
+import { should, serverCheck, useCheck } from '@scenetest/checks-react'
+
+useCheck(() => {
+  if (isLoading || !profile) return
+  serverCheck(
+    'Profile matches database',
+    async (server, data) => {
+      const dbUser = await server.getUser(data.userId)
+      should('name should match', dbUser.name === data.localName)
+    },
+    () => ({ userId, localName: profile.name }),
+  )
+}, [isLoading, profile?.id])
+```
+
+- `serverFn(server, data)` runs in the test-runner context; `server` is the
+  `server` object from `scenetest/config.ts`. Use `should()` inside it.
+- `withData()` collects browser-side data to send to the server. Keep it
+  serializable.
+
+## Production stripping rules (critical)
+
+The plugin strips `should()` / `failed()` / `serverCheck()` calls cleanly, but
+**a bare `if` wrapped around a call is NOT stripped** — the guard condition
+survives as dead code.
+
+```tsx
+// ❌ AVOID — after stripping, `if (items.length > 0) ;` remains in production
+if (items.length > 0) should('first item priced', items[0].price > 0)
+```
+
+Fold the guard into the condition (or the predicate) so the **entire** call
+disappears:
+
+```tsx
+// ✅ boolean form, guard folded in
+should('first item priced', items.length === 0 || items[0].price > 0)
+
+// ✅ callback form — guard AND computation both strip
+should('first item priced', () => items.length === 0 || items[0].price > 0)
+```
+
+For reactive checks, put the guard **inside the callback body**, never around
+the hook call (wrapping the hook also breaks the Rules of Hooks):
+
+```tsx
+// ✅
+useCheck(() => {
+  if (!profile) return
+  should('name is set', !!profile.name)
+}, [profile])
+```
+
+## Best practices
+
+- **Assert invariants, not values.** `should('total matches sum', total === sum(items))`
+  beats `should('total is set', total !== undefined)`.
+- **Include context** that helps debug failures — it shows in the observer panel.
+- **Reserve `failed()`** for paths that indicate a bug, not normal control flow.
+- **Reach for the lazy form by default** for anything beyond a cheap comparison.
+
+## Quick reference
+
+| Call | Signature | Lazy forms |
+| --- | --- | --- |
+| `should` | `(description, condition, context?)` | `condition` may be `() => boolean`; `context` may be `() => object` |
+| `failed` | `(description, context?)` | `context` may be `() => object` |
+| `serverCheck` | `(title, serverFn, withData?)` | `serverFn`/`withData` are callbacks by design |

--- a/packages/checks/src/__tests__/callback-conditions.test.ts
+++ b/packages/checks/src/__tests__/callback-conditions.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the lazy/callback forms of should() and failed().
+ *
+ * should() accepts either a boolean or a predicate function; failed() accepts
+ * either a context object or a function returning one. The function forms are
+ * evaluated lazily so expensive work stays inline with the assertion (and
+ * strips from production along with it).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { should, failed } from '../assertions.js'
+
+describe('should() / failed() callback forms', () => {
+  let reportedResults: Record<string, unknown>[]
+
+  beforeEach(() => {
+    reportedResults = []
+    vi.stubGlobal('window', {
+      __scenetest_report: (result: Record<string, unknown>) => {
+        reportedResults.push(result)
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('should() with a predicate', () => {
+    it('passes when the predicate returns truthy', () => {
+      should('list is non-empty', () => [1, 2, 3].length > 0)
+
+      expect(reportedResults).toHaveLength(1)
+      expect(reportedResults[0].type).toBe('pass')
+      expect(reportedResults[0].result).toBe(true)
+    })
+
+    it('fails when the predicate returns falsy', () => {
+      should('list is non-empty', () => [].length > 0)
+
+      expect(reportedResults[0].type).toBe('fail')
+      expect(reportedResults[0].result).toBe(false)
+    })
+
+    it('coerces non-boolean return values to a boolean', () => {
+      should('value present', () => 'hello' as unknown as boolean)
+
+      expect(reportedResults[0].result).toBe(true)
+    })
+
+    it('only invokes the predicate once', () => {
+      const predicate = vi.fn(() => true)
+      should('runs once', predicate)
+
+      expect(predicate).toHaveBeenCalledTimes(1)
+    })
+
+    it('passes the resolved context to the predicate', () => {
+      should('all priced', (ctx) => (ctx!.items as number[]).every((p) => p > 0), {
+        items: [1, 2, 3],
+      })
+
+      expect(reportedResults[0].type).toBe('pass')
+    })
+
+    it('reports a failure (not a throw) when the predicate throws', () => {
+      expect(() =>
+        should('throwing predicate', () => {
+          throw new Error('boom')
+        })
+      ).not.toThrow()
+
+      expect(reportedResults).toHaveLength(1)
+      expect(reportedResults[0].type).toBe('fail')
+      expect((reportedResults[0].context as Record<string, unknown>).error).toBe('boom')
+    })
+  })
+
+  describe('should() with a boolean (unchanged behavior)', () => {
+    it('still accepts a plain boolean condition', () => {
+      should('plain true', true)
+      should('plain false', false)
+
+      expect(reportedResults[0].result).toBe(true)
+      expect(reportedResults[1].result).toBe(false)
+    })
+
+    it('still attaches a plain context object', () => {
+      should('with context', true, { userId: 42 })
+
+      expect(reportedResults[0].context).toEqual({ userId: 42 })
+    })
+  })
+
+  describe('lazy context', () => {
+    it('should() evaluates a function context lazily', () => {
+      const build = vi.fn(() => ({ snapshot: 'data' }))
+      should('lazy ctx', true, build)
+
+      expect(build).toHaveBeenCalledTimes(1)
+      expect(reportedResults[0].context).toEqual({ snapshot: 'data' })
+    })
+
+    it('failed() evaluates a function context lazily', () => {
+      const build = vi.fn(() => ({ reason: 'bad' }))
+      failed('something broke', build)
+
+      expect(build).toHaveBeenCalledTimes(1)
+      expect(reportedResults[0].type).toBe('fail')
+      expect(reportedResults[0].context).toEqual({ reason: 'bad' })
+    })
+
+    it('captures errors from a throwing context provider', () => {
+      failed('broke', () => {
+        throw new Error('ctx boom')
+      })
+
+      expect(reportedResults[0].context).toEqual({ contextError: 'ctx boom' })
+    })
+  })
+})

--- a/packages/checks/src/__tests__/callback-conditions.test.ts
+++ b/packages/checks/src/__tests__/callback-conditions.test.ts
@@ -63,6 +63,29 @@ describe('should() / failed() callback forms', () => {
       expect(reportedResults[0].type).toBe('pass')
     })
 
+    it('resolves a lazy context before passing it to the predicate (fn, fn)', () => {
+      const order: string[] = []
+      const buildContext = vi.fn(() => {
+        order.push('context')
+        return { items: [1, 2, 3] }
+      })
+      const predicate = vi.fn((ctx?: Record<string, unknown>) => {
+        order.push('predicate')
+        return (ctx!.items as number[]).every((p) => p > 0)
+      })
+
+      should('all priced', predicate, buildContext)
+
+      // Context provider runs first, exactly once, before the predicate.
+      expect(order).toEqual(['context', 'predicate'])
+      expect(buildContext).toHaveBeenCalledTimes(1)
+      expect(predicate).toHaveBeenCalledTimes(1)
+      // The same resolved object is passed to the predicate and attached to the result.
+      expect(predicate.mock.calls[0][0]).toEqual({ items: [1, 2, 3] })
+      expect(reportedResults[0].type).toBe('pass')
+      expect(reportedResults[0].context).toEqual({ items: [1, 2, 3] })
+    })
+
     it('reports a failure (not a throw) when the predicate throws', () => {
       expect(() =>
         should('throwing predicate', () => {

--- a/packages/checks/src/assertions.ts
+++ b/packages/checks/src/assertions.ts
@@ -1,4 +1,11 @@
-import type { AssertionResult, AssertServerFn, AssertDataFn } from './types.js'
+import type {
+  AssertionResult,
+  AssertServerFn,
+  AssertDataFn,
+  CheckContext,
+  CheckCondition,
+  LazyContext,
+} from './types.js'
 
 /**
  * Compare pairs of values for equality.
@@ -76,6 +83,29 @@ function parseLocation(stack: string | undefined): AssertionResult['location'] {
 }
 
 /**
+ * Normalize a thrown value into a readable string for context.
+ */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * Resolve a possibly-lazy context into a plain object.
+ *
+ * If the context is a function it is invoked here so that expensive context
+ * construction is deferred until the assertion actually runs. A throwing
+ * context provider is reported rather than allowed to crash the caller.
+ */
+function resolveContext(context?: LazyContext): CheckContext | undefined {
+  if (typeof context !== 'function') return context
+  try {
+    return context()
+  } catch (err) {
+    return { contextError: errorMessage(err) }
+  }
+}
+
+/**
  * Report an assertion result to the test runner (if available)
  */
 function report(result: AssertionResult): void {
@@ -90,6 +120,11 @@ function report(result: AssertionResult): void {
  * Use this in your components to validate your mental model of how the code works.
  * The description should read as a natural "should" statement.
  *
+ * The `condition` may be a boolean, or a function returning a boolean. The
+ * function form is evaluated lazily, so keep expensive computation inline with
+ * the assertion instead of hoisting it into a variable that still runs after
+ * the assertion is stripped from production:
+ *
  * @example
  * ```tsx
  * function ProfileForm() {
@@ -97,18 +132,48 @@ function report(result: AssertionResult): void {
  *   should('profile should be loaded without pending state', profile !== undefined)
  *   // With context for debugging:
  *   should('user should have valid ID', !!user.id, { userId: user.id, userName: user.name })
+ *
+ *   // Lazy form — the computation only runs when the assertion runs, and the
+ *   // whole call (computation included) is stripped from production builds:
+ *   should('search returns results', () => expensiveSearch(query).length > 0)
+ *
+ *   // The predicate receives the resolved context:
+ *   should('all items priced', (ctx) => ctx.items.every((i) => i.price > 0), { items })
  * }
  * ```
  */
-export function should(description: string, condition: boolean, context?: Record<string, unknown>): void {
+export function should(description: string, condition: CheckCondition, context?: LazyContext): void {
   const stack = getStack()
+  const resolvedContext = resolveContext(context)
+
+  let result: boolean
+  if (typeof condition === 'function') {
+    try {
+      result = !!condition(resolvedContext)
+    } catch (err) {
+      // A throwing predicate is a failed assertion, not a crashed component.
+      report({
+        type: 'fail',
+        description,
+        result: false,
+        timestamp: Date.now(),
+        stack,
+        context: { ...resolvedContext, error: errorMessage(err) },
+        location: parseLocation(stack),
+      })
+      return
+    }
+  } else {
+    result = condition
+  }
+
   report({
-    type: condition ? 'pass' : 'fail',
+    type: result ? 'pass' : 'fail',
     description,
-    result: condition,
+    result,
     timestamp: Date.now(),
     stack,
-    context,
+    context: resolvedContext,
     location: parseLocation(stack),
   })
 }
@@ -134,8 +199,12 @@ export function should(description: string, condition: boolean, context?: Record
  *   })
  * }
  * ```
+ *
+ * The `context` may be a function returning an object; it is only evaluated
+ * when `failed()` runs, so expensive context construction can live with the
+ * call and still strip cleanly from production builds.
  */
-export function failed(description: string, context?: Record<string, unknown>): void {
+export function failed(description: string, context?: LazyContext): void {
   const stack = getStack()
   report({
     type: 'fail',
@@ -143,7 +212,7 @@ export function failed(description: string, context?: Record<string, unknown>): 
     result: false,
     timestamp: Date.now(),
     stack,
-    context,
+    context: resolveContext(context),
     location: parseLocation(stack),
   })
 }

--- a/packages/checks/src/index.ts
+++ b/packages/checks/src/index.ts
@@ -1,6 +1,9 @@
 export { should, failed, serverCheck, match, isValidFilePath } from './assertions.js'
 export { defineConfig } from './types.js'
 export type {
+  CheckContext,
+  LazyContext,
+  CheckCondition,
   AssertionResult,
   ScenetestReporter,
   ScenetestConfig,

--- a/packages/checks/src/types.ts
+++ b/packages/checks/src/types.ts
@@ -21,6 +21,38 @@ export interface AssertionResult {
 }
 
 /**
+ * Debugging context attached to an assertion result.
+ */
+export type CheckContext = Record<string, unknown>
+
+/**
+ * Context passed to `should()` / `failed()`. Either an object, or a function
+ * that returns one — the function form is only evaluated when the assertion
+ * runs, so expensive context construction is deferred (and stripped entirely
+ * from production builds along with the rest of the call).
+ */
+export type LazyContext = CheckContext | (() => CheckContext)
+
+/**
+ * The condition argument to `should()`. Either a boolean, or a predicate that
+ * returns one. The predicate form lets you keep the (possibly expensive)
+ * computation inline with the assertion instead of hoisting it into a
+ * variable that runs even when assertions are stripped:
+ *
+ * ```ts
+ * // Hoisted — runs in production even though the assertion is stripped
+ * const items = expensiveQuery()
+ * should('has items', items.length > 0)
+ *
+ * // Lazy — the whole thing, query included, strips from production
+ * should('has items', () => expensiveQuery().length > 0)
+ * ```
+ *
+ * The predicate receives the resolved `context` so you can reuse it.
+ */
+export type CheckCondition = boolean | ((context?: CheckContext) => boolean)
+
+/**
  * Server function that runs assertions with access to server context.
  */
 export type AssertServerFn<TData = unknown> = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-start':
         specifier: ^1.167.0
-        version: 1.167.41(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 1.167.41(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -68,34 +68,37 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       '@vitejs/plugin-react':
         specifier: ^4.5.0
-        version: 4.7.0(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.7.0(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       nitro:
         specifier: ^3.0.0
-        version: 3.0.0(chokidar@4.0.3)(lru-cache@11.3.5)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 3.0.0(chokidar@4.0.3)(lru-cache@11.3.5)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
       vite:
         specifier: ^7.3.2
-        version: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
         specifier: ^4.0.0
         version: 4.84.0
 
   packages/checks:
     devDependencies:
+      '@tanstack/intent':
+        specifier: ^0.0.41
+        version: 0.0.41
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/checks-panel:
     devDependencies:
@@ -104,10 +107,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/checks-react:
     dependencies:
@@ -177,10 +180,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/example-app-react:
     dependencies:
@@ -211,13 +214,13 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.7.0(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/example-app-solid:
     dependencies:
@@ -236,10 +239,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-solid:
         specifier: ^2.11.0
-        version: 2.11.10(solid-js@1.9.11)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 2.11.10(solid-js@1.9.11)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/example-app-svelte:
     dependencies:
@@ -252,7 +255,7 @@ importers:
         version: link:../vite-plugin
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       svelte:
         specifier: ^5.53.5
         version: 5.53.5
@@ -264,7 +267,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/example-app-vue:
     dependencies:
@@ -280,13 +283,13 @@ importers:
         version: link:../vite-plugin
       '@vitejs/plugin-vue':
         specifier: ^5.2.0
-        version: 5.2.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))(vue@3.5.27(typescript@5.9.3))
+        version: 5.2.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.27(typescript@5.9.3))
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vue-tsc:
         specifier: ^2.2.0
         version: 2.2.12(typescript@5.9.3)
@@ -330,10 +333,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/scenes-panel:
     devDependencies:
@@ -342,10 +345,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/vite-plugin:
     dependencies:
@@ -388,10 +391,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+        version: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/vscode-scenetest: {}
 
@@ -1427,6 +1430,10 @@ packages:
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/intent@0.0.41':
+    resolution: {integrity: sha512-Psl+oDiidLvtctswkTQ1P6sQIihwrMLcdfQVfkLpO42oKwxWEr1lodWUHiOG5jFXsGwDDvpUv/WAdlmJF+yGpw==}
+    hasBin: true
+
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
@@ -1822,6 +1829,10 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2381,6 +2392,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3351,6 +3365,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4071,29 +4090,36 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       debug: 4.4.3
       svelte: 5.53.5
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.53.5)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.53.5
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.1(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
   '@tanstack/history@1.161.6': {}
+
+  '@tanstack/intent@0.0.41':
+    dependencies:
+      cac: 6.7.14
+      jsonc-parser: 3.3.1
+      semver: 7.7.4
+      yaml: 2.8.3
 
   '@tanstack/query-core@5.90.20': {}
 
@@ -4119,7 +4145,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@tanstack/react-start-rsc@0.0.20(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/react-start-rsc@0.0.20(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tanstack/react-router': 1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-start-server': 1.166.40(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4127,7 +4153,7 @@ snapshots:
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
       '@tanstack/start-fn-stubs': 1.161.6
-      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(crossws@0.4.4(srvx@0.8.16))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(crossws@0.4.4(srvx@0.8.16))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.4(srvx@0.8.16))
       '@tanstack/start-storage-context': 1.166.29
       pathe: 2.0.3
@@ -4153,20 +4179,20 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.167.41(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/react-start@1.167.41(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tanstack/react-router': 1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-start-client': 1.166.39(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@tanstack/react-start-rsc': 0.0.20(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/react-start-rsc': 0.0.20(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/react-start-server': 1.166.40(crossws@0.4.4(srvx@0.8.16))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
-      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(crossws@0.4.4(srvx@0.8.16))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/start-plugin-core': 1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(crossws@0.4.4(srvx@0.8.16))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.4(srvx@0.8.16))
       pathe: 2.0.3
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - crossws
@@ -4201,7 +4227,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/router-plugin@1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -4218,8 +4244,8 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
-      vite-plugin-solid: 2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-solid: 2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -4246,7 +4272,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(crossws@0.4.4(srvx@0.8.16))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tanstack/start-plugin-core@1.167.35(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(crossws@0.4.4(srvx@0.8.16))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -4254,7 +4280,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.168.15
       '@tanstack/router-generator': 1.166.32
-      '@tanstack/router-plugin': 1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      '@tanstack/router-plugin': 1.167.22(@tanstack/react-router@1.168.22(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.17
       '@tanstack/start-server-core': 1.167.19(crossws@0.4.4(srvx@0.8.16))
@@ -4267,8 +4293,8 @@ snapshots:
       srvx: 0.11.15
       tinyglobby: 0.2.15
       ufo: 1.6.3
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.1(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       xmlbuilder2: 4.0.3
       zod: 3.25.76
     transitivePeerDependencies:
@@ -4384,7 +4410,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4392,11 +4418,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4404,13 +4430,13 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))(vue@3.5.27(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.27(typescript@5.9.3))':
     dependencies:
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.27(typescript@5.9.3)
 
   '@vitest/expect@4.1.4':
@@ -4422,13 +4448,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -4635,6 +4661,8 @@ snapshots:
       electron-to-chromium: 1.5.283
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  cac@6.7.14: {}
 
   callsites@3.1.0: {}
 
@@ -5253,6 +5281,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5682,7 +5712,7 @@ snapshots:
 
   nf3@0.1.12: {}
 
-  nitro@3.0.0(chokidar@4.0.3)(lru-cache@11.3.5)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)):
+  nitro@3.0.0(chokidar@4.0.3)(lru-cache@11.3.5)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       cookie-es: 2.0.0
@@ -5702,7 +5732,7 @@ snapshots:
       unenv: 2.0.0-rc.21
       unstorage: 2.0.0-alpha.3(chokidar@4.0.3)(db0@0.3.4)(lru-cache@11.3.5)(ofetch@1.5.1)
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6262,7 +6292,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)):
+  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -6270,12 +6300,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.11
       solid-refresh: 0.6.3(solid-js@1.9.11)
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.1(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)):
+  vite-plugin-solid@2.11.10(solid-js@1.9.11)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -6283,24 +6313,24 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.11
       solid-refresh: 0.6.3(solid-js@1.9.11)
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitefu: 1.1.1(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0):
+  vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6313,8 +6343,9 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0):
+  vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6327,19 +6358,20 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitefu@1.1.1(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)):
+  vitefu@1.1.1(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitefu@1.1.1(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)):
+  vitefu@1.1.1(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.4(@types/node@20.19.30)(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -6356,7 +6388,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.30
@@ -6436,6 +6468,8 @@ snapshots:
       js-yaml: 4.1.1
 
   yallist@3.1.1: {}
+
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Extends `should()` and `failed()` to accept lazy callback forms for both conditions and context, enabling expensive computations to stay inline with assertions and strip cleanly from production builds. Adds comprehensive tests, documentation, and a TanStack Intent skill guide.

## Key Changes

- **Lazy conditions**: `should()` now accepts `condition` as either a boolean or `(context?) => boolean` predicate. The predicate form keeps expensive work inline instead of hoisting it into a variable that survives stripping.
- **Lazy context**: Both `should()` and `failed()` accept `context` as either an object or `() => object`. Context functions are only evaluated when the assertion runs, deferring expensive debugging context construction.
- **Error handling**: Predicates and context functions that throw are caught and reported as failed assertions (with error message in context) rather than crashing the component.
- **Type exports**: Added `CheckCondition`, `LazyContext`, and `CheckContext` types to the public API.
- **Comprehensive tests**: New test suite (`callback-conditions.test.ts`) covering predicate evaluation, lazy context, error handling, and context passing to predicates.
- **Documentation**: Updated guides and added a TanStack Intent skill (`SKILL.md`) with production stripping rules, best practices, and quick reference.
- **Package metadata**: Added `tanstack-intent` keyword and `skills/` directory to published files for skill distribution.

## Implementation Details

- `resolveContext()` helper normalizes lazy context into plain objects, catching and reporting errors from context providers.
- `errorMessage()` utility converts thrown values to readable strings for context.
- Predicates receive the resolved context as an argument, enabling reuse: `should('all priced', (ctx) => ctx.items.every(i => i.price > 0), { items })`.
- The callback condition form is the primary pattern for keeping assertions production-safe — the entire computation (guard + work) lives in the function body and strips together with the call.

https://claude.ai/code/session_013H9VgaSNNg3chuFHTrcPj9