### PR TITLE
Add PageActions dropdown menu for markdown export options

### DIFF
--- a/docs/app/components/MarkdownSection.tsx
+++ b/docs/app/components/MarkdownSection.tsx
@@ -1,4 +1,4 @@
-import { Children, createElement, useEffect, useMemo, useRef, useState } from 'react'
+import { Children, createElement, useEffect, useMemo, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { Link, useLocation, useRouter } from '@tanstack/react-router'
 import Markdown, { type Options } from 'react-markdown'
@@ -7,6 +7,7 @@ import rehypeHighlight from 'rehype-highlight'
 import remarkGfm from 'remark-gfm'
 import { CodeBlock } from './CodeBlock'
 import { TabbedCode } from './TabbedCode'
+import { PageActions } from './PageActions'
 import { highlightLanguages } from '../lib/highlight'
 import 'highlight.js/styles/github.css'
 
@@ -184,7 +185,6 @@ const remarkPlugins: Options['remarkPlugins'] = [remarkGfm]
 
 export function MarkdownSection({ content, className = '' }: MarkdownSectionProps) {
   const rawMarkdown = content
-  const [copied, setCopied] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const { hash } = useLocation()
   const router = useRouter()
@@ -251,20 +251,9 @@ export function MarkdownSection({ content, className = '' }: MarkdownSectionProp
     [router],
   )
 
-  function handleCopyMarkdown() {
-    if (!rawMarkdown) return
-    navigator.clipboard.writeText(rawMarkdown)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
   return (
     <div className={`markdown-section ${className}`} ref={containerRef}>
-      {rawMarkdown && (
-        <button className="copy-md-btn" onClick={handleCopyMarkdown}>
-          {copied ? 'Copied!' : 'Copy markdown'}
-        </button>
-      )}
+      {rawMarkdown && <PageActions rawMarkdown={rawMarkdown} />}
       {segments.map((seg, i) =>
         seg.type === 'tabs' ? (
           <TabbedCode key={i} tabs={seg.tabs} />

--- a/docs/app/components/PageActions.tsx
+++ b/docs/app/components/PageActions.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from 'react'
+import { useLocation } from '@tanstack/react-router'
+
+interface PageActionsProps {
+  rawMarkdown: string
+}
+
+function buildMarkdownUrl(pathname: string): string {
+  const origin = typeof window === 'undefined' ? '' : window.location.origin
+  const clean = pathname.replace(/\/$/, '') || '/'
+  const path = clean === '/' ? '/main.md' : `${clean}.md`
+  return `${origin}${path}`
+}
+
+function buildPrompt(mdUrl: string): string {
+  return `Read ${mdUrl} so I can ask you questions about it.`
+}
+
+export function PageActions({ rawMarkdown }: PageActionsProps) {
+  const { pathname } = useLocation()
+  const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function onDocClick(e: MouseEvent) {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onEsc)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onEsc)
+    }
+  }, [open])
+
+  const mdUrl = buildMarkdownUrl(pathname)
+  const prompt = buildPrompt(mdUrl)
+  const encoded = encodeURIComponent(prompt)
+
+  function handleCopy() {
+    navigator.clipboard.writeText(rawMarkdown)
+    setCopied(true)
+    setOpen(false)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const items: { label: string; href: string; external?: boolean }[] = [
+    { label: 'View Markdown', href: mdUrl, external: true },
+    { label: 'Open in ChatGPT', href: `https://chatgpt.com/?hints=search&q=${encoded}`, external: true },
+    { label: 'Open in Claude', href: `https://claude.ai/new?q=${encoded}`, external: true },
+    {
+      label: 'Open in Cursor',
+      href: `cursor://anysphere.cursor-deeplink/prompt?text=${encoded}`,
+    },
+    { label: 'Open in Perplexity', href: `https://www.perplexity.ai/search/new?q=${encoded}`, external: true },
+  ]
+
+  return (
+    <div className="page-actions" ref={wrapRef}>
+      <button className="page-actions-main" onClick={handleCopy} aria-label="Copy page as Markdown">
+        {copied ? 'Copied!' : 'Copy page'}
+      </button>
+      <button
+        className="page-actions-toggle"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="More copy options"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+          <path d="M2 4l3 3 3-3" fill="none" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      </button>
+      {open && (
+        <div className="page-actions-menu" role="menu">
+          <button className="page-actions-item" role="menuitem" onClick={handleCopy}>
+            Copy page as Markdown
+          </button>
+          {items.map((item) => (
+            <a
+              key={item.label}
+              className="page-actions-item"
+              role="menuitem"
+              href={item.href}
+              target={item.external ? '_blank' : undefined}
+              rel={item.external ? 'noopener noreferrer' : undefined}
+              onClick={() => setOpen(false)}
+            >
+              <span>{item.label}</span>
+              {item.external && (
+                <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true" className="page-actions-ext">
+                  <path
+                    d="M3.5 2h4.5v4.5M8 2L3 7M2 4v4h4"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.2"
+                  />
+                </svg>
+              )}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/docs/app/components/PageActions.tsx
+++ b/docs/app/components/PageActions.tsx
@@ -52,7 +52,7 @@ export function PageActions({ rawMarkdown }: PageActionsProps) {
   const items: { label: string; href: string; external?: boolean }[] = [
     { label: 'View Markdown', href: mdUrl, external: true },
     { label: 'Open in ChatGPT', href: `https://chatgpt.com/?hints=search&q=${encoded}`, external: true },
-    { label: 'Open in Claude', href: `https://claude.ai/new?q=${encoded}`, external: true },
+    { label: 'Open in Claude Code', href: `https://claude.ai/code?q=${encoded}`, external: true },
     {
       label: 'Open in Cursor',
       href: `cursor://anysphere.cursor-deeplink/prompt?text=${encoded}`,

--- a/docs/app/components/PageActions.tsx
+++ b/docs/app/components/PageActions.tsx
@@ -53,7 +53,7 @@ export function PageActions({ rawMarkdown }: PageActionsProps) {
     { label: 'View Markdown', href: mdUrl, external: true },
     { label: 'Open in ChatGPT', href: `https://chatgpt.com/?hints=search&q=${encoded}`, external: true },
     { label: 'Open in Claude Code', href: `https://claude.ai/code?q=${encoded}`, external: true },
-    { label: 'Open in Codex', href: `https://chatgpt.com/codex?q=${encoded}`, external: true },
+    { label: 'Open in Codex', href: `codex://threads/new?prompt=${encoded}` },
     {
       label: 'Open in Cursor',
       href: `cursor://anysphere.cursor-deeplink/prompt?text=${encoded}`,

--- a/docs/app/components/PageActions.tsx
+++ b/docs/app/components/PageActions.tsx
@@ -53,6 +53,7 @@ export function PageActions({ rawMarkdown }: PageActionsProps) {
     { label: 'View Markdown', href: mdUrl, external: true },
     { label: 'Open in ChatGPT', href: `https://chatgpt.com/?hints=search&q=${encoded}`, external: true },
     { label: 'Open in Claude Code', href: `https://claude.ai/code?q=${encoded}`, external: true },
+    { label: 'Open in Codex', href: `https://chatgpt.com/codex?q=${encoded}`, external: true },
     {
       label: 'Open in Cursor',
       href: `cursor://anysphere.cursor-deeplink/prompt?text=${encoded}`,

--- a/docs/app/routes/__root.tsx
+++ b/docs/app/routes/__root.tsx
@@ -409,29 +409,94 @@ figure.screenshot figcaption {
   position: relative;
 }
 
-.copy-md-btn {
+/* Page actions: split button (copy) + dropdown (view / open-in tools) */
+.page-actions {
   position: absolute;
   top: -36px;
   right: 0;
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.75rem;
-  padding: 4px 10px;
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  cursor: pointer;
+  display: inline-flex;
   opacity: 0;
   transition: opacity 0.2s;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
   color: var(--text-light);
 }
 
-.markdown-section:hover .copy-md-btn {
+.markdown-section:hover .page-actions,
+.page-actions:focus-within {
   opacity: 1;
 }
 
-.copy-md-btn:hover {
+.page-actions-main,
+.page-actions-toggle {
+  font-family: inherit;
+  font-size: inherit;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  color: inherit;
+  padding: 4px 10px;
+}
+
+.page-actions-main {
+  border-radius: 4px 0 0 4px;
+}
+
+.page-actions-toggle {
+  border-left: none;
+  border-radius: 0 4px 4px 0;
+  padding: 4px 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.page-actions-main:hover,
+.page-actions-toggle:hover {
   background: white;
   color: var(--text);
+}
+
+.page-actions-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 200px;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  z-index: 50;
+}
+
+.page-actions-item {
+  font-family: inherit;
+  font-size: inherit;
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 7px 10px;
+  border-radius: 4px;
+  color: var(--text);
+  cursor: pointer;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  white-space: nowrap;
+}
+
+.page-actions-item:hover {
+  background: var(--bg-soft, #f3f3f3);
+}
+
+.page-actions-ext {
+  opacity: 0.5;
+  flex-shrink: 0;
 }
 
 /* ── Tabbed code blocks ── */


### PR DESCRIPTION
## Summary

Refactored the markdown copy button into a split-button component with a dropdown menu offering multiple export and sharing options. Users can now copy the page as markdown, view the raw markdown file, or open the content in ChatGPT, Claude, Cursor, or Perplexity directly from the UI.

## Key Changes

- **New `PageActions` component** (`docs/app/components/PageActions.tsx`):
  - Split-button UI: main "Copy page" button + dropdown toggle
  - Dropdown menu with 5 action items (copy, view markdown, open in ChatGPT/Claude/Cursor/Perplexity)
  - Generates markdown URLs and AI tool prompts dynamically based on current pathname
  - Handles click-outside and Escape key to close menu
  - Feedback state for copy action (shows "Copied!" for 2 seconds)

- **Updated `MarkdownSection` component**:
  - Removed local copy button logic and state management
  - Now delegates to `PageActions` component
  - Cleaner separation of concerns

- **Enhanced styling** (`__root.tsx`):
  - Replaced `.copy-md-btn` with comprehensive `.page-actions` styles
  - Added `.page-actions-menu` for dropdown styling with shadow and proper positioning
  - Added `.page-actions-item` for menu items with hover states
  - Added `.page-actions-ext` for external link icons
  - Maintains existing hover behavior on markdown sections

## Implementation Details

- Uses `@tanstack/react-router`'s `useLocation()` to determine current page pathname
- Builds markdown URLs by appending `.md` extension to pathname (root becomes `/main.md`)
- Generates AI tool prompts with encoded URLs for seamless integration
- Menu positioning uses absolute positioning relative to the button wrapper
- Accessibility: proper ARIA attributes (`aria-expanded`, `aria-haspopup`, `role="menu"`)
- External links open in new tabs with `noopener noreferrer` security attributes

https://claude.ai/code/session_01FHtmSNXaNKaTkbQsmcuZZM