### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## [0.10.0] — 2026-06-05
+
+### New
+
+* **Teams everywhere.** Each scene now shows which team ran it — in the CLI output, the live dashboard, and reports. A new `--team <name>` flag (and a dashboard dropdown) lets you run or replay just one team.
+* **Clearer failures.** Failed scenes are set off with blank lines and a separator so they're easy to find and copy out of CI logs. Each failure now points at the exact source line that broke, with a couple of lines of surrounding code. The summary also lists scene counts per team.
+* **`/__scenetest/` landing page.** Visiting `/__scenetest/` now shows an index page; the test runner moved to `/__scenetest/runner`.
+* **Friendlier `should()` / `failed()`.** Both now accept a function for the condition (and `failed()` a lazy context), so you can compute values on the spot. Ships with a new inline-assertions Agent Skill that teaches the patterns.
+* **New ESLint rule `inline-server-fn`** — flags when a `serverCheck()` server function isn't written inline (the plugin can't extract it otherwise).
+
+### Fixes
+
+* `serverCheck()` extracted functions are now emitted as async.
+* Stripping a check call written without braces (e.g. `if (x) should(...)`) no longer drops the surrounding code.
+
 ## [0.9.2] — 2026-05-06
 
 * Fix bug with multiple panels showing

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/docs",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.9.2",
+	"version": "0.10.0",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/packages/checks-panel/package.json
+++ b/packages/checks-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-panel",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Observer panel for scenetest - displays assertions in real-time",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-react/package.json
+++ b/packages/checks-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-react",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "React bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-solid/package.json
+++ b/packages/checks-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-solid",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Solid bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-svelte/package.json
+++ b/packages/checks-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-svelte",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Svelte bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks-vue/package.json
+++ b/packages/checks-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks-vue",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Vue bindings for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/eslint-plugin",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "ESLint plugin for scenetest - accessibility and testing best practices",
   "type": "module",
   "license": "MIT",

--- a/packages/playwright-scenetest/package.json
+++ b/packages/playwright-scenetest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/playwright",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Playwright fixtures for scenetest inline assertions",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes-panel/package.json
+++ b/packages/scenes-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes-panel",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Scene recorder for scenetest - records user interactions as DSL",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",

--- a/packages/vscode-scenetest/package.json
+++ b/packages/vscode-scenetest/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-scenetest",
   "displayName": "Scenetest",
   "description": "Syntax highlighting for Scenetest scene specs (.spec.md)",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "publisher": "scenetest",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bumps all packages from 0.9.2 to 0.10.0 and adds a changelog entry covering everything merged since 0.9.2.

### Highlights
- **Teams everywhere** — team shown per scene in CLI, dashboard, and reports; new `--team` filter and dashboard dropdown.
- **Clearer failures** — failed scenes are visually separated and now show the failing source line in context; per-team scene counts in the summary.
- **`/__scenetest/` landing page** — runner moved to `/__scenetest/runner`.
- **Friendlier `should()` / `failed()`** — accept function conditions; ships an inline-assertions Agent Skill.
- **New ESLint rule `inline-server-fn`**.
- Fixes: async `serverCheck()` extracted fns; correct stripping of brace-less check calls.

https://claude.ai/code/session_0153MSgvBuVUhgH1z4UC7r6N

---
_Generated by [Claude Code](https://claude.ai/code/session_0153MSgvBuVUhgH1z4UC7r6N)_