### PR TITLE
Extract wire protocol into @scenetest/protocol package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## @scenetest/vite-plugin 0.10.1 — 2026-06-11
+
+* Expose `./dashboard` in the package `exports` map. `dist/dashboard.js` and its types were already shipped but couldn't be imported under `moduleResolution: Bundler` or esbuild. External consumers (e.g. scenetest-cloud's Worker-rendered per-run dashboard) can now `import { generateDashboardHtml } from '@scenetest/vite-plugin/dashboard'` without a `pnpm.patchedDependencies` patch. Note: this subpath is a stopgap — the planned dashboard widget extraction (`mountDashboard` + transport adapters in a dedicated package) will supersede it.
+
 ## [0.10.0] — 2026-06-05
 
 ### New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## @scenetest/protocol 0.10.0 — 2026-06-11
+
+* **New package: `@scenetest/protocol`** — the typed event and command vocabulary shared by the CLI, Vite plugin, dashboard, and the cloud service (architecture step 1 of the scenetest-cloud plan). Defines the `RunEvent` union (the existing `run:start` … `run:end` wire format, unchanged, plus a new `run:progress` rollup event for home-view tiles), the `Command` union (`run:replay`, `run:stop`, `run:pause`, `run:resume`), and a zero-dependency codec: strict `decodeEvent()`/`decodeCommand()` that never throw, and `isEventShaped()` for relays that must pass through event types newer than themselves. `@scenetest/scenes` now sources `TeamMeta`, `RunSummary`, and `DashboardEvent` (a back-compat alias of `RunEvent`) from it, and the Vite middleware validates inbound CLI events with it. No wire-format or behavior changes.
+
 ## @scenetest/vite-plugin 0.10.1 — 2026-06-11
 
 * Expose `./dashboard` in the package `exports` map. `dist/dashboard.js` and its types were already shipped but couldn't be imported under `moduleResolution: Bundler` or esbuild. External consumers (e.g. scenetest-cloud's Worker-rendered per-run dashboard) can now `import { generateDashboardHtml } from '@scenetest/vite-plugin/dashboard'` without a `pnpm.patchedDependencies` patch. Note: this subpath is a stopgap — the planned dashboard widget extraction (`mountDashboard` + transport adapters in a dedicated package) will supersede it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ packages/
 ├── checks-vue/             # Vue bindings — watchCheck composable (re-exports checks)
 ├── checks-solid/           # Solid bindings — createCheck primitive (re-exports checks)
 ├── checks-svelte/          # Svelte bindings — checkEffect helper (re-exports checks)
+├── protocol/               # Wire protocol — typed event/command vocabulary + codec shared by CLI, plugin, dashboard, cloud
 ├── scenes/                 # CLI runner — scene(), test(), actor DSL, selectors, teams, config, recorder
 ├── vite-plugin/            # Vite plugin — dev panel injection, prod stripping, RPC middleware
 ├── eslint-plugin/          # ESLint plugin — prefer-aria-label, inline-server-fn rules
@@ -64,6 +65,13 @@ packages/
 - `styles.ts` — Injected CSS
 - `fixtures.ts` — `scenePage` fixture, `waitForAssertions()`, failure logging
 - `skills/inline-assertions/SKILL.md` — shippable Agent Skill (TanStack Intent) teaching `should()`/`failed()`/`serverCheck()` authoring. Shipped in the npm tarball (`files` includes `skills`, `tanstack-intent` keyword). Validate with `pnpm -C packages/checks skills:validate`. Consumers discover it via `npx @tanstack/intent list` (transitively through any `@scenetest/checks-*` binding) and load `@scenetest/checks#inline-assertions`. Keep it in sync with `docs/public/guides/writing-inline-assertions.md`.
+
+### Protocol (`packages/protocol/src/`)
+- `events.ts` — `RunEvent` union (`run:start` … `run:end`, plus the `run:progress` rollup), `TeamMeta`, `RunSummary`, `PROTOCOL_VERSION`
+- `commands.ts` — `Command` union (`run:replay`, `run:stop`, `run:pause`, `run:resume`)
+- `codec.ts` — `encodeEvent()`/`decodeEvent()` (strict, never throws), `isEventShaped()` (envelope-only check so relays pass through event types newer than themselves)
+
+Zero-dependency package; the seam between the dev tool and scenetest-cloud. Producers (CLI, injected listener) and consumers (dashboard, recorders, cloud worker) share this vocabulary, and wire-format changes route through a published release so version skew stays visible. `@scenetest/scenes` re-exports `RunEvent` as `DashboardEvent` for backwards compatibility.
 
 ### Scenes (`packages/scenes/src/`)
 - `scene.ts` — `test()` registration (await-driven), shared `registerScene()` helper, `runScene()`, session accessors
@@ -176,5 +184,6 @@ TanStack Start + Nitro app, deployed to **Cloudflare Workers** via `pnpm -C docs
 | Network layer (`network.fail()`, `network.mock()`) | Design only | `cli-v2.md` section 7 |
 | Snapshots (`snapshot()`, `expectSnapshot()`) | Design only | `cli-v2.md` section 8 |
 | Dashboard & JSONL reports | Design only | `dashboard.md` |
+| Dashboard widget extraction (`mountDashboard()` + transport adapters, receiver core) | Protocol package landed; widget/receiver extraction pending | `architecture.md` in scenetest-cloud |
 | Interactive UI mode (`--ui`) | Stub only | `cli-v2.md` |
 | Visualization (timeline/musical) | Conceptual | `cli-v2.md` section 10 |

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"author": "msnook.xyz",
 	"scripts": {
-		"build": "pnpm --filter @scenetest/checks --filter @scenetest/scenes build && pnpm -r build",
+		"build": "pnpm --filter @scenetest/protocol --filter @scenetest/checks --filter @scenetest/scenes build && pnpm -r build",
 		"dev": "pnpm --filter @scenetest/vite-plugin build && pnpm --filter example-app-react dev",
 		"docs": "pnpx serve docs",
 		"typecheck": "pnpm -r typecheck",

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -1,0 +1,52 @@
+# @scenetest/protocol
+
+The typed event and command vocabulary shared by every part of scenetest:
+the CLI runner, the injected client listener, the Vite plugin's dev
+middleware, the dashboard, and the cloud service.
+
+Everything else in the system is an implementation behind this vocabulary.
+The dependency arrow always points here — the open-source tool works
+without the cloud service existing, and the cloud service consumes the
+same published package the CLI does. Producers and consumers routinely run
+at different versions (last month's CLI against today's worker), so wire
+changes route through a release of this package where the skew stays
+visible.
+
+## Events
+
+`RunEvent` is the union of everything that crosses the wire:
+
+| Type | Meaning |
+|---|---|
+| `run:start` | A run began (consumers reset live state) |
+| `scene:start` / `scene:end` | Scene lifecycle, with team metadata |
+| `action:start` / `action:end` | One actor DSL action (click, fill, …) |
+| `assertion` | An inline `should()` / `failed()` resolved |
+| `warning` | Unexpected path in the test script itself |
+| `run:progress` | Throttled coarse rollup (`pct`, `failing`, `flaky`) for home-view tiles |
+| `run:end` | Run finished, with the full `RunSummary` |
+
+## Commands
+
+`Command` flows the reverse path, viewer → runner: `run:replay` (optionally
+scoped to a `file` and/or `team`), `run:stop`, `run:pause`, `run:resume`.
+
+## Codec
+
+```ts
+import { decodeEvent, encodeEvent, isEventShaped } from '@scenetest/protocol'
+
+const event = decodeEvent(wireMessage) // RunEvent | null — strict, never throws
+```
+
+Two levels of validation, for two jobs:
+
+- `decodeEvent` / `decodeCommand` — strict: known type tag, required
+  fields present. For consumers that act on contents (recorders, rollups,
+  command queues).
+- `isEventShaped` — minimal envelope check. For relays that fan events out
+  without interpreting them (the dev SSE hub, a Durable Object fan-out): a
+  relay validating strictly would drop event types newer than itself.
+
+All validators tolerate unknown extra fields; additive changes are
+non-breaking and do not bump `PROTOCOL_VERSION`.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@scenetest/protocol",
+  "version": "0.10.0",
+  "description": "Typed event and command vocabulary shared by the scenetest CLI, Vite plugin, dashboard, and cloud service",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scenetest/scenetest-js",
+    "directory": "packages/protocol"
+  },
+  "keywords": ["testing", "e2e", "playwright", "protocol", "events"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/protocol/src/__tests__/codec.test.ts
+++ b/packages/protocol/src/__tests__/codec.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeCommand,
+  decodeEvent,
+  encodeCommand,
+  encodeEvent,
+  isEventShaped,
+  isRunEvent,
+  type Command,
+  type RunEvent,
+} from '../index.js'
+
+const events: RunEvent[] = [
+  { type: 'run:start', timestamp: 1, sceneCount: 3 },
+  {
+    type: 'scene:start',
+    timestamp: 2,
+    name: 'checkout',
+    file: 'checkout.scene.ts',
+    actors: ['buyer', 'seller'],
+    teamIndex: 0,
+    team: { name: 'fr', tags: { locale: 'fr' } },
+  },
+  { type: 'action:start', timestamp: 3, actor: 'buyer', action: 'click', target: 'submit' },
+  { type: 'action:end', timestamp: 4, actor: 'buyer', action: 'click', target: 'submit', duration: 12 },
+  { type: 'assertion', timestamp: 5, actor: 'buyer', description: 'cart updated', result: true },
+  { type: 'warning', timestamp: 6, actor: 'buyer', selector: '~banner', message: 'unexpected path' },
+  {
+    type: 'scene:end',
+    timestamp: 7,
+    name: 'checkout',
+    status: 'completed',
+    duration: 900,
+    teamIndex: 0,
+    team: {},
+  },
+  { type: 'run:progress', timestamp: 8, pct: 60, failing: 1, flaky: 1 },
+  {
+    type: 'run:end',
+    timestamp: 9,
+    duration: 1000,
+    summary: {
+      scenes: 3,
+      completed: 2,
+      failed: 1,
+      assertions: { total: 10, passed: 9, failed: 1 },
+      warnings: 1,
+      consoleErrors: 0,
+    },
+  },
+]
+
+const commands: Command[] = [
+  { type: 'run:replay' },
+  { type: 'run:replay', file: 'checkout.scene.ts', team: 'fr' },
+  { type: 'run:stop' },
+  { type: 'run:pause' },
+  { type: 'run:resume' },
+]
+
+describe('event codec', () => {
+  it('round-trips every event type', () => {
+    for (const event of events) {
+      expect(decodeEvent(encodeEvent(event))).toEqual(event)
+    }
+  })
+
+  it('decodes already-parsed values', () => {
+    expect(decodeEvent(events[0])).toEqual(events[0])
+  })
+
+  it('rejects malformed JSON without throwing', () => {
+    expect(decodeEvent('{not json')).toBeNull()
+  })
+
+  it('rejects unknown event types', () => {
+    expect(decodeEvent({ type: 'run:imaginary', timestamp: 1 })).toBeNull()
+  })
+
+  it('rejects known types missing required fields', () => {
+    expect(decodeEvent({ type: 'run:start', timestamp: 1 })).toBeNull()
+    expect(decodeEvent({ type: 'assertion', timestamp: 1, description: 'x' })).toBeNull()
+    expect(decodeEvent({ type: 'scene:end', timestamp: 1, name: 'a', status: 'completed', duration: 1, teamIndex: 0, team: { tags: { a: 1 } } })).toBeNull()
+  })
+
+  it('rejects events without a timestamp', () => {
+    expect(decodeEvent({ type: 'run:start', sceneCount: 1 })).toBeNull()
+  })
+
+  it('tolerates unknown extra fields (additive changes are non-breaking)', () => {
+    const withExtra = { ...events[0], futureField: 'x' }
+    expect(decodeEvent(withExtra)).toEqual(withExtra)
+  })
+
+  it('isEventShaped passes unknown event types through for relays', () => {
+    const future = { type: 'run:imaginary', timestamp: 1, payload: {} }
+    expect(isEventShaped(future)).toBe(true)
+    expect(isRunEvent(future)).toBe(false)
+    expect(isEventShaped({ type: 'run:start' })).toBe(false)
+    expect(isEventShaped('run:start')).toBe(false)
+  })
+})
+
+describe('command codec', () => {
+  it('round-trips every command type', () => {
+    for (const command of commands) {
+      expect(decodeCommand(encodeCommand(command))).toEqual(command)
+    }
+  })
+
+  it('rejects unknown command types and bad fields', () => {
+    expect(decodeCommand({ type: 'run:selfdestruct' })).toBeNull()
+    expect(decodeCommand({ type: 'run:replay', team: 42 })).toBeNull()
+    expect(decodeCommand('{not json')).toBeNull()
+  })
+})

--- a/packages/protocol/src/codec.ts
+++ b/packages/protocol/src/codec.ts
@@ -1,0 +1,152 @@
+/**
+ * Serialization and validation for protocol events and commands.
+ *
+ * Two levels of checking, for two different jobs:
+ *
+ * - `decodeEvent` / `decodeCommand` — strict: the type tag is known and
+ *   the required fields for that type are present with the right
+ *   primitive types. For consumers that act on event contents (recorders,
+ *   rollups, the command queue).
+ * - `isEventShaped` — minimal: an object with a string `type` and numeric
+ *   `timestamp`. For relays that fan events out without interpreting them
+ *   (the dev SSE hub, the Durable Object fan-out). A relay validating
+ *   strictly would drop event types newer than itself, which breaks the
+ *   normal version-skew case of an old plugin paired with a newer CLI.
+ *
+ * All validators tolerate unknown extra fields — additive fields are
+ * non-breaking by design.
+ */
+
+import type { Command } from './commands.js'
+import type { RunEvent } from './events.js'
+
+type Raw = Record<string, unknown>
+
+function isObject(value: unknown): value is Raw {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function str(v: unknown): v is string {
+  return typeof v === 'string'
+}
+
+function num(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+function optStr(v: unknown): boolean {
+  return v === undefined || str(v)
+}
+
+function isTeamMeta(v: unknown): boolean {
+  if (!isObject(v)) return false
+  if (!optStr(v.name)) return false
+  if (v.tags !== undefined) {
+    if (!isObject(v.tags)) return false
+    if (!Object.values(v.tags).every(str)) return false
+  }
+  return true
+}
+
+function isRunSummary(v: unknown): boolean {
+  if (!isObject(v)) return false
+  if (!num(v.scenes) || !num(v.completed) || !num(v.failed)) return false
+  if (!num(v.warnings) || !num(v.consoleErrors)) return false
+  const a = v.assertions
+  return isObject(a) && num(a.total) && num(a.passed) && num(a.failed)
+}
+
+/** Per-type required-field validators. `type` and `timestamp` are pre-checked. */
+const EVENT_VALIDATORS: Record<RunEvent['type'], (e: Raw) => boolean> = {
+  'run:start': (e) => num(e.sceneCount),
+  'scene:start': (e) =>
+    str(e.name) &&
+    str(e.file) &&
+    Array.isArray(e.actors) &&
+    e.actors.every(str) &&
+    num(e.teamIndex) &&
+    isTeamMeta(e.team),
+  'action:start': (e) => str(e.actor) && str(e.action) && optStr(e.target),
+  'action:end': (e) =>
+    str(e.actor) && str(e.action) && optStr(e.target) && num(e.duration) && optStr(e.error),
+  assertion: (e) => optStr(e.actor) && str(e.description) && typeof e.result === 'boolean',
+  warning: (e) => str(e.actor) && str(e.selector) && str(e.message),
+  'scene:end': (e) =>
+    str(e.name) &&
+    str(e.status) &&
+    num(e.duration) &&
+    optStr(e.error) &&
+    num(e.teamIndex) &&
+    isTeamMeta(e.team),
+  'run:progress': (e) => num(e.pct) && num(e.failing) && num(e.flaky),
+  'run:end': (e) => num(e.duration) && isRunSummary(e.summary),
+}
+
+const COMMAND_VALIDATORS: Record<Command['type'], (c: Raw) => boolean> = {
+  'run:replay': (c) => optStr(c.file) && optStr(c.team),
+  'run:stop': () => true,
+  'run:pause': () => true,
+  'run:resume': () => true,
+}
+
+/**
+ * Minimal envelope check: an object with a string `type` and a numeric
+ * `timestamp`. Use this when relaying events without interpreting them,
+ * so event types newer than this package pass through instead of being
+ * dropped.
+ */
+export function isEventShaped(value: unknown): value is { type: string; timestamp: number } {
+  return isObject(value) && str(value.type) && num(value.timestamp)
+}
+
+/** Strict structural check against the known event vocabulary. */
+export function isRunEvent(value: unknown): value is RunEvent {
+  if (!isEventShaped(value)) return false
+  const validate = EVENT_VALIDATORS[value.type as RunEvent['type']]
+  return validate !== undefined && validate(value as unknown as Raw)
+}
+
+/** Strict structural check against the known command vocabulary. */
+export function isCommand(value: unknown): value is Command {
+  if (!isObject(value) || !str(value.type)) return false
+  const validate = COMMAND_VALIDATORS[value.type as Command['type']]
+  return validate !== undefined && validate(value)
+}
+
+/** Serialize an event for the wire. */
+export function encodeEvent(event: RunEvent): string {
+  return JSON.stringify(event)
+}
+
+/**
+ * Parse and validate one wire message into an event. Returns `null` for
+ * anything that is not a known, well-formed event — malformed JSON, an
+ * unknown type tag, or missing required fields. Never throws.
+ */
+export function decodeEvent(input: string | unknown): RunEvent | null {
+  const value = parse(input)
+  return isRunEvent(value) ? value : null
+}
+
+/** Serialize a command for the wire. */
+export function encodeCommand(command: Command): string {
+  return JSON.stringify(command)
+}
+
+/**
+ * Parse and validate one wire message into a command. Returns `null` for
+ * anything that is not a known, well-formed command. Never throws.
+ */
+export function decodeCommand(input: string | unknown): Command | null {
+  const value = parse(input)
+  return isCommand(value) ? value : null
+}
+
+function parse(input: string | unknown): unknown {
+  if (typeof input !== 'string') return input
+  try {
+    return JSON.parse(input)
+  } catch {
+    return null
+  }
+}

--- a/packages/protocol/src/commands.ts
+++ b/packages/protocol/src/commands.ts
@@ -1,0 +1,54 @@
+/**
+ * The command vocabulary of the scenetest protocol.
+ *
+ * Commands flow the reverse path of events: a human acting on the
+ * dashboard → transport adapter → backend → down to the CLI, which
+ * executes and emits resulting events back up.
+ *
+ * In dev mode the Vite middleware maps these onto its HTTP endpoints
+ * (`/__scenetest/replay`, `/stop`, `/pause`); in cloud they ride the
+ * runner box's WebSocket back down from the run's Durable Object command
+ * queue. The same versioning rules as events apply (see events.ts).
+ */
+
+/**
+ * Start (or restart) a run. Both fields optional: omit `file` to run all
+ * scenes, omit `team` to run every team.
+ */
+export interface RunReplayCommand {
+  type: 'run:replay'
+  /** Scene file to run, relative to the scenes directory. */
+  file?: string
+  /** Restrict the run to one team by name. */
+  team?: string
+}
+
+/** Stop the active run. */
+export interface RunStopCommand {
+  type: 'run:stop'
+}
+
+/** Suspend the active run without tearing it down. */
+export interface RunPauseCommand {
+  type: 'run:pause'
+}
+
+/** Resume a paused run. */
+export interface RunResumeCommand {
+  type: 'run:resume'
+}
+
+/** Every command a viewer can send toward a runner. */
+export type Command =
+  | RunReplayCommand
+  | RunStopCommand
+  | RunPauseCommand
+  | RunResumeCommand
+
+/** All known command type tags. */
+export const COMMAND_TYPES = [
+  'run:replay',
+  'run:stop',
+  'run:pause',
+  'run:resume',
+] as const satisfies readonly Command['type'][]

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -1,0 +1,183 @@
+/**
+ * The event vocabulary of the scenetest protocol.
+ *
+ * Producers: the CLI runner (Playwright actions, scene lifecycle), the
+ * injected client listener (assertion results). Consumers: the dashboard
+ * (live view), the recorder (`.jsonl` in dev, R2/D1 in cloud), and the
+ * run rollups that feed the home view.
+ *
+ * The shapes here are the wire format. Field changes are breaking changes
+ * and must bump {@link PROTOCOL_VERSION} — users run last month's CLI
+ * against today's cloud worker, so version skew between producer and
+ * consumer is normal, not exceptional. Additive optional fields and new
+ * event types are non-breaking; consumers must ignore unknown fields and
+ * may pass through unknown event types (see `isEventShaped` in codec.ts).
+ */
+
+/**
+ * Wire protocol version. Bump only for incompatible changes to existing
+ * event or command shapes — never for additive ones.
+ */
+export const PROTOCOL_VERSION = 1
+
+/**
+ * Team metadata attached to scene lifecycle events.
+ */
+export interface TeamMeta {
+  /** Human-readable team name (used in reports and CLI output) */
+  name?: string
+
+  /**
+   * Arbitrary key-value tags for filtering and `[team.field]` interpolation.
+   *
+   * @example
+   * ```ts
+   * tags: { locale: 'fr', region: 'europe', tier: 'premium' }
+   * // In DSL: openTo /categories/[team.locale]
+   * ```
+   */
+  tags?: Record<string, string>
+}
+
+/**
+ * Aggregate counts for a finished run. Carried on `run:end` and persisted
+ * in run reports.
+ */
+export interface RunSummary {
+  scenes: number
+  completed: number
+  failed: number
+  assertions: {
+    total: number
+    passed: number
+    failed: number
+  }
+  warnings: number
+  consoleErrors: number
+}
+
+// ─── Event types ─────────────────────────────────────────────────────
+
+/** A run began. Consumers typically reset live state on this event. */
+export interface RunStartEvent {
+  type: 'run:start'
+  timestamp: number
+  sceneCount: number
+}
+
+/** A scene began executing. */
+export interface SceneStartEvent {
+  type: 'scene:start'
+  timestamp: number
+  name: string
+  file: string
+  actors: string[]
+  teamIndex: number
+  team: TeamMeta
+}
+
+/** An actor started a DSL action (click, fill, openTo, …). */
+export interface ActionStartEvent {
+  type: 'action:start'
+  timestamp: number
+  actor: string
+  action: string
+  target?: string
+}
+
+/** An actor finished a DSL action. `error` is set when the action failed. */
+export interface ActionEndEvent {
+  type: 'action:end'
+  timestamp: number
+  actor: string
+  action: string
+  target?: string
+  duration: number
+  error?: string
+}
+
+/** An inline assertion (`should()` / `failed()`) resolved in the app under test. */
+export interface AssertionEvent {
+  type: 'assertion'
+  timestamp: number
+  actor?: string
+  description: string
+  result: boolean
+}
+
+/** A script-level warning — an unexpected path in the test script itself. */
+export interface WarningEvent {
+  type: 'warning'
+  timestamp: number
+  actor: string
+  selector: string
+  message: string
+}
+
+/** A scene finished. */
+export interface SceneEndEvent {
+  type: 'scene:end'
+  timestamp: number
+  name: string
+  status: string
+  duration: number
+  error?: string
+  teamIndex: number
+  team: TeamMeta
+}
+
+/**
+ * Coarse run-status rollup, throttled (on change, at most every ~2s).
+ * Computed by whoever owns the live run state — the run's Durable Object
+ * in cloud — from the fine-grained events above, and fanned out to
+ * home-view consumers so raw assertion events never leave the run's own
+ * viewers.
+ */
+export interface RunProgressEvent {
+  type: 'run:progress'
+  timestamp: number
+  /** Completion estimate, 0–100. */
+  pct: number
+  /** Scenes currently failing. */
+  failing: number
+  /** Scenes flagged flaky so far. */
+  flaky: number
+}
+
+/** The run finished. */
+export interface RunEndEvent {
+  type: 'run:end'
+  timestamp: number
+  duration: number
+  summary: RunSummary
+}
+
+/**
+ * Every event that can cross the wire, from any producer.
+ *
+ * (Known to the dev tool as `DashboardEvent` — `@scenetest/scenes`
+ * re-exports this union under that name for backwards compatibility.)
+ */
+export type RunEvent =
+  | RunStartEvent
+  | SceneStartEvent
+  | ActionStartEvent
+  | ActionEndEvent
+  | AssertionEvent
+  | WarningEvent
+  | SceneEndEvent
+  | RunProgressEvent
+  | RunEndEvent
+
+/** All known event type tags. */
+export const EVENT_TYPES = [
+  'run:start',
+  'scene:start',
+  'action:start',
+  'action:end',
+  'assertion',
+  'warning',
+  'scene:end',
+  'run:progress',
+  'run:end',
+] as const satisfies readonly RunEvent['type'][]

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,0 +1,35 @@
+export {
+  PROTOCOL_VERSION,
+  EVENT_TYPES,
+  type TeamMeta,
+  type RunSummary,
+  type RunEvent,
+  type RunStartEvent,
+  type SceneStartEvent,
+  type ActionStartEvent,
+  type ActionEndEvent,
+  type AssertionEvent,
+  type WarningEvent,
+  type SceneEndEvent,
+  type RunProgressEvent,
+  type RunEndEvent,
+} from './events.js'
+
+export {
+  COMMAND_TYPES,
+  type Command,
+  type RunReplayCommand,
+  type RunStopCommand,
+  type RunPauseCommand,
+  type RunResumeCommand,
+} from './commands.js'
+
+export {
+  isEventShaped,
+  isRunEvent,
+  isCommand,
+  encodeEvent,
+  decodeEvent,
+  encodeCommand,
+  decodeCommand,
+} from './codec.js'

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/__tests__"]
+}

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@scenetest/checks": "workspace:*",
+    "@scenetest/protocol": "workspace:*",
     "playwright": "^1.40.0",
     "commander": "^12.0.0",
     "glob": "^11.1.0",

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -1,6 +1,9 @@
 import type { Page, BrowserContext, Browser } from 'playwright'
 import type { ScenetestConfig as BaseConfig } from '@scenetest/checks'
+import type { RunEvent, RunSummary, TeamMeta } from '@scenetest/protocol'
 import type { DeviceProfile } from './devices.js'
+
+export type { RunEvent, RunSummary }
 
 /**
  * Factory function for creating a new browser page + context.
@@ -70,21 +73,7 @@ export type TeamConfig = Record<string, ActorConfig>
  * }
  * ```
  */
-export interface TeamMeta {
-  /** Human-readable team name (used in reports and CLI output) */
-  name?: string
-
-  /**
-   * Arbitrary key-value tags for filtering and `[team.field]` interpolation.
-   *
-   * @example
-   * ```ts
-   * tags: { locale: 'fr', region: 'europe', tier: 'premium' }
-   * // In DSL: openTo /categories/[team.locale]
-   * ```
-   */
-  tags?: Record<string, string>
-}
+export type { TeamMeta } from '@scenetest/protocol'
 
 /**
  * Full team definition — actors plus optional metadata.
@@ -411,18 +400,8 @@ export interface RunReport {
   timestamp: string
   duration: number
   scenes: SceneReport[]
-  summary: {
-    scenes: number
-    completed: number
-    failed: number
-    assertions: {
-      total: number
-      passed: number
-      failed: number
-    }
-    warnings: number
-    consoleErrors: number
-  }
+  /** Aggregate counts — same shape that rides on the `run:end` protocol event. */
+  summary: RunSummary
   /** Present when this run was triggered by swarm mode */
   swarm?: SwarmReport
 }
@@ -446,16 +425,11 @@ export interface ErrorSelector {
 /**
  * Events streamed from the CLI runner to the Vite dev server
  * for the live dashboard at /__scenetest/dashboard.
+ *
+ * The vocabulary is defined by `@scenetest/protocol` (where it is named
+ * `RunEvent`); this alias is kept for backwards compatibility.
  */
-export type DashboardEvent =
-  | { type: 'run:start'; timestamp: number; sceneCount: number }
-  | { type: 'scene:start'; timestamp: number; name: string; file: string; actors: string[]; teamIndex: number; team: TeamMeta }
-  | { type: 'action:start'; timestamp: number; actor: string; action: string; target?: string }
-  | { type: 'action:end'; timestamp: number; actor: string; action: string; target?: string; duration: number; error?: string }
-  | { type: 'assertion'; timestamp: number; actor?: string; description: string; result: boolean }
-  | { type: 'warning'; timestamp: number; actor: string; selector: string; message: string }
-  | { type: 'scene:end'; timestamp: number; name: string; status: string; duration: number; error?: string; teamIndex: number; team: TeamMeta }
-  | { type: 'run:end'; timestamp: number; duration: number; summary: RunReport['summary'] }
+export type DashboardEvent = RunEvent
 
 // ─── Swarm Mode Types ────────────────────────────────────────────────
 

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -44,6 +44,7 @@
     "magic-string": "^0.30.10",
     "preact": "^10.22.0",
     "@scenetest/checks": "workspace:*",
+    "@scenetest/protocol": "workspace:*",
     "@scenetest/checks-panel": "workspace:*",
     "@scenetest/scenes-panel": "workspace:*"
   },

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/vite-plugin",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Vite plugin for scenetest - strips assertions in production, injects dev panel",
   "type": "module",
   "license": "MIT",
@@ -20,6 +20,10 @@
     "./server": {
       "types": "./dist/middleware.d.ts",
       "import": "./dist/middleware.js"
+    },
+    "./dashboard": {
+      "types": "./dist/dashboard.d.ts",
+      "import": "./dist/dashboard.js"
     }
   },
   "files": ["dist"],

--- a/packages/vite-plugin/src/middleware.ts
+++ b/packages/vite-plugin/src/middleware.ts
@@ -1,5 +1,6 @@
 import type { Connect, ViteDevServer } from 'vite'
 import type { AssertionRpcPayload, AssertionRpcResponse, AssertionResult, ServerContext } from '@scenetest/checks'
+import { isEventShaped } from '@scenetest/protocol'
 import { AsyncLocalStorage } from 'async_hooks'
 import { spawn, type ChildProcess } from 'child_process'
 import fs from 'fs'
@@ -301,11 +302,16 @@ export function createScenetestMiddleware(
 
       try {
         const event = JSON.parse(body)
-        // Clear buffer on new run so the dashboard starts fresh
-        if (event.type === 'run:start') {
-          eventHub.clear()
+        // The hub is a relay, not a consumer: require only the protocol
+        // envelope so event types newer than this plugin still fan out
+        // (a newer CLI paired with an older plugin is the normal case).
+        if (isEventShaped(event)) {
+          // Clear buffer on new run so the dashboard starts fresh
+          if (event.type === 'run:start') {
+            eventHub.clear()
+          }
+          eventHub.push(event)
         }
-        eventHub.push(event)
       } catch {
         // Ignore malformed events
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,11 +315,23 @@ importers:
         specifier: ^5.3.3
         version: 5.9.3
 
+  packages/protocol:
+    devDependencies:
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@20.19.30)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/scenes:
     dependencies:
       '@scenetest/checks':
         specifier: workspace:*
         version: link:../checks
+      '@scenetest/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       commander:
         specifier: ^12.0.0
         version: 12.1.0
@@ -375,6 +387,9 @@ importers:
       '@scenetest/checks-panel':
         specifier: workspace:*
         version: link:../checks-panel
+      '@scenetest/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       '@scenetest/scenes-panel':
         specifier: workspace:*
         version: link:../scenes-panel
@@ -4563,6 +4578,14 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.4(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
@@ -6502,6 +6525,33 @@ snapshots:
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
       vite: 6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@types/node@20.19.30)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.30


### PR DESCRIPTION
## Summary

Extracts the event and command vocabulary that flows between the CLI runner, Vite plugin, dashboard, and cloud service into a new `@scenetest/protocol` package. This establishes a single source of truth for the wire format and enables independent versioning of producers and consumers.

## Key Changes

- **New package `@scenetest/protocol`** with three modules:
  - `events.ts` — Defines `RunEvent` union (9 event types: `run:start`, `scene:start`, `action:start`, `action:end`, `assertion`, `warning`, `scene:end`, `run:progress`, `run:end`) and supporting types (`TeamMeta`, `RunSummary`)
  - `commands.ts` — Defines `Command` union (4 command types: `run:replay`, `run:stop`, `run:pause`, `run:resume`)
  - `codec.ts` — Serialization and validation with two levels:
    - `decodeEvent`/`decodeCommand` — strict validation for consumers that act on contents
    - `isEventShaped` — minimal envelope check for relays that fan out without interpreting (allows unknown event types from newer producers to pass through)

- **Moved types from `@scenetest/scenes`** to protocol:
  - `TeamMeta` and `RunSummary` now live in protocol; scenes re-exports them for backwards compatibility
  - `DashboardEvent` in scenes is now an alias to `RunEvent` from protocol

- **Updated `@scenetest/vite-plugin`** to use `isEventShaped()` for event relay validation instead of strict type checking, enabling version skew between older plugin and newer CLI

- **Added comprehensive test suite** (`codec.test.ts`) covering round-trip serialization, malformed input handling, unknown event types, missing required fields, and additive field tolerance

## Implementation Details

- `PROTOCOL_VERSION = 1` provides a single version constant for incompatible wire format changes
- All validators tolerate unknown extra fields; additive changes are non-breaking and do not bump the protocol version
- The codec never throws; `decodeEvent`/`decodeCommand` return `null` for invalid input
- `isEventShaped` enables the normal version-skew case (old plugin paired with newer CLI) by passing through unknown event types rather than dropping them
- Package exports both strict validators (`isRunEvent`, `isCommand`) and minimal envelope check (`isEventShaped`) for different use cases

https://claude.ai/code/session_01DP4jJDPH6TuWwe4EZYfZ9d