### PR TITLE
Keep typed values out of dashboard events; document the test-credentials trust model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## Unreleased
+
+### Security
+
+* **Typed values no longer leave the test process.** `typeInto()` and `select()` used to record their target as `selector=value`, which put the literal value — including `[self.password]` from the builtin login macro — into dashboard events (SSE-visible to anything that could reach the dev server) and into the persisted run-report timeline. The target is now the selector only, in both the `test()` and `scene()` models.
+* The `/__scenetest/events` SSE stream no longer sends `Access-Control-Allow-Origin: *`. Its only legitimate browser consumers are the same-origin dashboard pages; cross-origin pages could previously read the full buffered event stream.
+
 ## @scenetest/protocol 0.10.0 — 2026-06-11
 
 * **New package: `@scenetest/protocol`** — the typed event and command vocabulary shared by the CLI, Vite plugin, dashboard, and the cloud service (architecture step 1 of the scenetest-cloud plan). Defines the `RunEvent` union (the existing `run:start` … `run:end` wire format, unchanged, plus a new `run:progress` rollup event for home-view tiles), the `Command` union (`run:replay`, `run:stop`, `run:pause`, `run:resume`), and a zero-dependency codec: strict `decodeEvent()`/`decodeCommand()` that never throw, and `isEventShaped()` for relays that must pass through event types newer than themselves. `@scenetest/scenes` now sources `TeamMeta`, `RunSummary`, and `DashboardEvent` (a back-compat alias of `RunEvent`) from it, and the Vite middleware validates inbound CLI events with it. No wire-format or behavior changes.

--- a/docs/public/faq/security.md
+++ b/docs/public/faq/security.md
@@ -14,11 +14,8 @@ Scenetest runs with the same trust model as the rest of your development tooling
 
 ## Test credentials are fixtures, not secrets
 
-Actor passwords live in your actor files, checked into the repo and deployed to your test box. Assume they're breached. By convention, make them all the same — one obviously fake value like `password` or `test123` across every actor — partly as a standing reminder of their status, and partly as a forcing function: fixtures that only log into seeded test accounts can't accidentally be pointed at an environment with real users, because nothing would log in.
+Actor passwords are checked into the repo and deployed to your test box — assume they're breached. By convention, give every actor the same obviously fake password (`password`, `test123`): it reminds you they're not secrets, and fixtures that only log into seeded accounts can't be pointed at an environment with real users.
 
-Two things follow from assuming the breach:
+It follows that your test environment must tolerate a hostile logged-in user — the same property production needs so users can't elevate privileges — and that session-derived artifacts (storage state, DOM, dashboard events, reports) are only as private as the box itself. Defend the environment's perimeter, not the credentials.
 
-- **Your test environment must tolerate a hostile logged-in user.** This is not a new requirement — it's the same property you already need in production so that users can't elevate privileges. A breached test credential should buy an attacker exactly what any user has: one seeded account on a disposable box.
-- **Session-derived artifacts inherit the same status.** Warmup storage state (cookies, tokens), DOM contents, dashboard events, and run reports all come from those sessions. Scenetest keeps typed values out of dashboard events and report timelines, but treat all run artifacts as visible to anyone who can reach the test environment, and keep the environment's perimeter — not the credentials — as the boundary you actually defend.
-
-One line to keep sharp: **actor credentials are fixtures; infrastructure credentials are not.** Database connection strings and API keys in `config.server` are real secrets — keep them in environment variables, never in actor files or team tags. Tags ride on dashboard events by design, so anything in a tag is visible wherever events go.
+The exception: **infrastructure credentials are real secrets.** Keep database URLs and API keys in environment variables — never in actor files or team tags (tags ride on dashboard events by design).

--- a/docs/public/faq/security.md
+++ b/docs/public/faq/security.md
@@ -11,3 +11,14 @@ Yes. Scenetest is designed with security in mind, even for dev tooling:
 **Production builds strip everything.** The Vite plugin automatically removes all Scenetest imports and function calls in production builds. No test code, no dev panel, no server endpoints - zero bundle impact and zero attack surface in production.
 
 Scenetest runs with the same trust model as the rest of your development tooling. If you trust your source code and your build process, Scenetest should not increase your risk.
+
+## Test credentials are fixtures, not secrets
+
+Actor passwords live in your actor files, checked into the repo and deployed to your test box. Assume they're breached. By convention, make them all the same — one obviously fake value like `password` or `test123` across every actor — partly as a standing reminder of their status, and partly as a forcing function: fixtures that only log into seeded test accounts can't accidentally be pointed at an environment with real users, because nothing would log in.
+
+Two things follow from assuming the breach:
+
+- **Your test environment must tolerate a hostile logged-in user.** This is not a new requirement — it's the same property you already need in production so that users can't elevate privileges. A breached test credential should buy an attacker exactly what any user has: one seeded account on a disposable box.
+- **Session-derived artifacts inherit the same status.** Warmup storage state (cookies, tokens), DOM contents, dashboard events, and run reports all come from those sessions. Scenetest keeps typed values out of dashboard events and report timelines, but treat all run artifacts as visible to anyone who can reach the test environment, and keep the environment's perimeter — not the credentials — as the boundary you actually defend.
+
+One line to keep sharp: **actor credentials are fixtures; infrastructure credentials are not.** Database connection strings and API keys in `config.server` are real secrets — keep them in environment variables, never in actor files or team tags. Tags ride on dashboard events by design, so anything in a tag is visible wherever events go.

--- a/docs/public/guides/building-teams.md
+++ b/docs/public/guides/building-teams.md
@@ -21,6 +21,8 @@ actors/team-maria.ts:
 
 If a scene calls `actor('existing-friend')`, that actor must already be friends with `actor('primary-learner')` in the database. The actor files don't create these relationships -- your seed data does.
 
+A note on the passwords: they're fixtures, not secrets. Use one obviously fake value (like `test123` above) for every actor, and assume it's public -- see [Is Scenetest Safe?](/faq/security) for what that implies about your test environment.
+
 ## Step 1: Identify Roles From Your Scenes
 
 Start with the scenes you want to test. Each distinct persona in a scene becomes a **role**. Name roles by their relationship to the story, not by system role:

--- a/packages/protocol/README.md
+++ b/packages/protocol/README.md
@@ -50,3 +50,14 @@ Two levels of validation, for two jobs:
 
 All validators tolerate unknown extra fields; additive changes are
 non-breaking and do not bump `PROTOCOL_VERSION`.
+
+## Payloads are viewer-visible
+
+Events fan out to every connected dashboard viewer and persist in run
+artifacts (`.jsonl`, reports). Producers must not place secrets in event
+fields: action targets carry selectors only (never typed values), and
+`TeamMeta.tags` are public by design. Test-account credentials are
+fixtures, not secrets — see the
+[security FAQ](https://scenetest.msnook.xyz/faq/security) — but infrastructure
+credentials (database URLs, API keys) must never appear in any event
+field.

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -369,7 +369,10 @@ class ActionChainImpl implements ActionChain {
   }
 
   typeInto(selector: Selector, value: string): ActionChain {
-    const target = `${formatSelector(selector)}=${value}`
+    // Selector only — never the typed value. The target rides on dashboard
+    // events and the persisted timeline, and the value may be a credential
+    // (the builtin login macro types [self.password]).
+    const target = formatSelector(selector)
     return this.addAction('typeInto', target, async () => {
       const locator = resolveSelector(this.getScope(), selector)
       if (this.isKeyboard) {
@@ -401,7 +404,8 @@ class ActionChainImpl implements ActionChain {
   }
 
   select(selector: Selector, value: string): ActionChain {
-    const target = `${formatSelector(selector)}=${value}`
+    // Selector only — see typeInto.
+    const target = formatSelector(selector)
     return this.addAction('select', target, async () => {
       const locator = resolveSelector(this.getScope(), selector)
       if (this.isKeyboard) {

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -610,7 +610,10 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   }
 
   typeInto(selector: Selector, value: string): this {
-    return this.push('typeInto', `${selector}=${value}`, async () => {
+    // Selector only — never the typed value. The target rides on dashboard
+    // events and the persisted timeline, and the value may be a credential
+    // (the builtin login macro types [self.password]).
+    return this.push('typeInto', selector, async () => {
       const locator = resolveSelector(this.activeScope, selector)
       if (this.isKeyboard) {
         await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
@@ -640,7 +643,8 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   }
 
   select(selector: Selector, value: string): this {
-    return this.push('select', `${selector}=${value}`, async () => {
+    // Selector only — see typeInto.
+    return this.push('select', selector, async () => {
       const locator = resolveSelector(this.activeScope, selector)
       if (this.isKeyboard) {
         await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })

--- a/packages/vite-plugin/src/event-hub.ts
+++ b/packages/vite-plugin/src/event-hub.ts
@@ -22,12 +22,14 @@ export class EventHub {
 
   /** Register an SSE client connection. */
   addClient(res: ServerResponse): void {
-    // Set up SSE headers
+    // Set up SSE headers. Deliberately no Access-Control-Allow-Origin:
+    // the only browser consumers are the dashboard pages this same
+    // middleware serves (same-origin), and the buffered events may
+    // reference test activity that shouldn't be readable cross-origin.
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
-      'Access-Control-Allow-Origin': '*',
     })
 
     // Send buffered events so late joiners catch up


### PR DESCRIPTION
Follow-up to #197 (landed on that branch after it merged).

**Fix:** `typeInto()`/`select()` put the typed value in the action `target` (`selector=value`), leaking credentials like `[self.password]` into dashboard events and report timelines. Now selector-only, in both models. Also drops `Access-Control-Allow-Origin: *` from the SSE stream — its only legitimate consumers are same-origin.

**Docs:** test credentials are fixtures, not secrets — assume breached, use one fake value everywhere, defend the environment perimeter instead. Added to the security FAQ, building-teams guide, and protocol README (no secrets in event fields).

Tests: 285 + 79 pass.

https://claude.ai/code/session_01DP4jJDPH6TuWwe4EZYfZ9d