### PR TITLE
Extract receiver core as @scenetest/receiver (Hono app + pluggable sinks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Scenetest are documented here.
 
 ## Unreleased
 
+### @scenetest/receiver 0.10.0
+
+* **New package: `@scenetest/receiver`** — the receiver core extracted from the Vite middleware as a framework-agnostic Hono app. `createReceiverApp({ sinks })` accepts protocol events on `POST /events` (envelope-validated with `isEventShaped()` so it relays event types newer than itself, always responding 200 so old CLIs never break) and fans them out to `Sink`s, calling `clear()` on `run:start`. Ships a `JsonlSink` (one protocol event per JSON line) and a `toNodeHandler()` adapter; the Vite middleware now delegates `POST /__scenetest/events` to it with the SSE `EventHub` as a sink, and dev behavior is unchanged.
+
 ### Security
 
 * **Typed values no longer leave the test process.** `typeInto()` and `select()` used to record their target as `selector=value`, which put the literal value — including `[self.password]` from the builtin login macro — into dashboard events (SSE-visible to anything that could reach the dev server) and into the persisted run-report timeline. The target is now the selector only, in both the `test()` and `scene()` models.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ packages/
 ├── checks-solid/           # Solid bindings — createCheck primitive (re-exports checks)
 ├── checks-svelte/          # Svelte bindings — checkEffect helper (re-exports checks)
 ├── protocol/               # Wire protocol — typed event/command vocabulary + codec shared by CLI, plugin, dashboard, cloud
+├── receiver/               # Receiver core — framework-agnostic Hono app that accepts protocol events and fans them out to sinks
 ├── scenes/                 # CLI runner — scene(), test(), actor DSL, selectors, teams, config, recorder
 ├── vite-plugin/            # Vite plugin — dev panel injection, prod stripping, RPC middleware
 ├── eslint-plugin/          # ESLint plugin — prefer-aria-label, inline-server-fn rules
@@ -72,6 +73,13 @@ packages/
 - `codec.ts` — `encodeEvent()`/`decodeEvent()` (strict, never throws), `isEventShaped()` (envelope-only check so relays pass through event types newer than themselves)
 
 Zero-dependency package; the seam between the dev tool and scenetest-cloud. Producers (CLI, injected listener) and consumers (dashboard, recorders, cloud worker) share this vocabulary, and wire-format changes route through a published release so version skew stays visible. `@scenetest/scenes` re-exports `RunEvent` as `DashboardEvent` for backwards compatibility.
+
+### Receiver (`packages/receiver/src/`)
+- `app.ts` — `createReceiverApp({ sinks })`, a Hono app with `POST /events` (envelope-validated via `isEventShaped()`, always responds 200, calls sink `clear?.()` on `run:start`), `ReceiverAppType` for `hono/client`
+- `sink.ts` — `Sink` interface (`write()`, optional `clear()`), `JsonlSink` (one protocol event per JSON line, lazy open, `close()`)
+- `node.ts` — `toNodeHandler(app)` via `@hono/node-server`'s `getRequestListener`, for mounting in connect-style servers (Vite dev server)
+
+The receiver core extracted from the Vite middleware, framework-agnostic so scenetest-cloud can mount the same app. It is a relay: envelope-only validation passes through event types newer than itself, and responses are always `200` (`{"ok":true}`/`{"ok":false}`) because the CLI's reporter is fire-and-forget. The Vite middleware delegates `POST /__scenetest/events` to it with the SSE `EventHub` as a sink; serving SSE itself stays in the middleware (dev-transport concern). Only this package depends on `hono`/`@hono/node-server`.
 
 ### Scenes (`packages/scenes/src/`)
 - `scene.ts` — `test()` registration (await-driven), shared `registerScene()` helper, `runScene()`, session accessors
@@ -184,6 +192,6 @@ TanStack Start + Nitro app, deployed to **Cloudflare Workers** via `pnpm -C docs
 | Network layer (`network.fail()`, `network.mock()`) | Design only | `cli-v2.md` section 7 |
 | Snapshots (`snapshot()`, `expectSnapshot()`) | Design only | `cli-v2.md` section 8 |
 | Dashboard & JSONL reports | Design only | `dashboard.md` |
-| Dashboard widget extraction (`mountDashboard()` + transport adapters, receiver core) | Protocol package landed; widget/receiver extraction pending | `architecture.md` in scenetest-cloud |
+| Dashboard widget extraction (`mountDashboard()` + transport adapters) | Protocol and receiver packages landed; widget extraction pending | `architecture.md` in scenetest-cloud |
 | Interactive UI mode (`--ui`) | Stub only | `cli-v2.md` |
 | Visualization (timeline/musical) | Conceptual | `cli-v2.md` section 10 |

--- a/packages/receiver/package.json
+++ b/packages/receiver/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@scenetest/receiver",
+  "version": "0.10.0",
+  "description": "Framework-agnostic receiver core for scenetest protocol events - a Hono app that accepts events and fans them out to sinks",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scenetest/scenetest-js",
+    "directory": "packages/receiver"
+  },
+  "keywords": ["testing", "e2e", "playwright", "protocol", "events", "receiver", "hono"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@scenetest/protocol": "workspace:*",
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.3.3",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/receiver/src/__tests__/app.test.ts
+++ b/packages/receiver/src/__tests__/app.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { createReceiverApp } from '../app.js'
+import type { Sink, SinkEvent } from '../sink.js'
+
+function recordingSink(): Sink & { events: SinkEvent[]; cleared: number } {
+  const sink = {
+    events: [] as SinkEvent[],
+    cleared: 0,
+    write(event: SinkEvent) {
+      sink.events.push(event)
+    },
+    clear() {
+      sink.cleared++
+    },
+  }
+  return sink
+}
+
+function post(app: ReturnType<typeof createReceiverApp>, body: string) {
+  return app.request('/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+}
+
+describe('createReceiverApp', () => {
+  it('writes a valid event to every sink and responds ok:true', async () => {
+    const a = recordingSink()
+    const b = recordingSink()
+    const app = createReceiverApp({ sinks: [a, b] })
+
+    const event = { type: 'assertion', timestamp: 123, description: 'works', result: true }
+    const res = await post(app, JSON.stringify(event))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(a.events).toEqual([event])
+    expect(b.events).toEqual([event])
+    expect(a.cleared).toBe(0)
+  })
+
+  it('calls clear() on each sink when run:start arrives, before writing it', async () => {
+    const order: string[] = []
+    const sink: Sink = {
+      write: (e) => order.push(`write:${e.type}`),
+      clear: () => order.push('clear'),
+    }
+    const app = createReceiverApp({ sinks: [sink] })
+
+    await post(app, JSON.stringify({ type: 'assertion', timestamp: 1, result: true }))
+    await post(app, JSON.stringify({ type: 'run:start', timestamp: 2, sceneCount: 3 }))
+
+    expect(order).toEqual(['write:assertion', 'clear', 'write:run:start'])
+  })
+
+  it('tolerates sinks without clear() on run:start', async () => {
+    const events: SinkEvent[] = []
+    const app = createReceiverApp({ sinks: [{ write: (e) => events.push(e) }] })
+
+    const res = await post(app, JSON.stringify({ type: 'run:start', timestamp: 1, sceneCount: 0 }))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(events).toHaveLength(1)
+  })
+
+  it('passes through unknown future event types that carry the envelope', async () => {
+    const sink = recordingSink()
+    const app = createReceiverApp({ sinks: [sink] })
+
+    const future = { type: 'hologram:flicker', timestamp: 999, intensity: 0.7 }
+    const res = await post(app, JSON.stringify(future))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(sink.events).toEqual([future])
+  })
+
+  it('responds 200 ok:false for malformed JSON without writing to sinks', async () => {
+    const sink = recordingSink()
+    const app = createReceiverApp({ sinks: [sink] })
+
+    const res = await post(app, '{not json')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: false })
+    expect(sink.events).toEqual([])
+  })
+
+  it('responds 200 ok:false for bodies that are not event-shaped', async () => {
+    const sink = recordingSink()
+    const app = createReceiverApp({ sinks: [sink] })
+
+    for (const body of ['null', '[]', '{"type":"x"}', '{"timestamp":1}', '{"type":1,"timestamp":1}']) {
+      const res = await post(app, body)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: false })
+    }
+    expect(sink.events).toEqual([])
+    expect(sink.cleared).toBe(0)
+  })
+})

--- a/packages/receiver/src/__tests__/sink.test.ts
+++ b/packages/receiver/src/__tests__/sink.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { decodeEvent } from '@scenetest/protocol'
+import { JsonlSink } from '../sink.js'
+
+describe('JsonlSink', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'scenetest-receiver-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('writes one JSON line per event, creating parent directories lazily', async () => {
+    const file = path.join(tmp, 'nested', 'dir', 'events.jsonl')
+    const sink = new JsonlSink(file)
+
+    // Lazy open: nothing on disk until the first write
+    expect(fs.existsSync(path.dirname(file))).toBe(false)
+
+    sink.write({ type: 'run:start', timestamp: 1, sceneCount: 2 })
+    sink.write({ type: 'run:progress', timestamp: 2, pct: 50, failing: 0, flaky: 0 })
+    sink.close()
+
+    const lines = fs.readFileSync(file, 'utf-8').split('\n')
+    expect(lines).toHaveLength(3) // two events + trailing newline
+    expect(lines[2]).toBe('')
+    expect(JSON.parse(lines[0])).toEqual({ type: 'run:start', timestamp: 1, sceneCount: 2 })
+    expect(JSON.parse(lines[1])).toEqual({
+      type: 'run:progress',
+      timestamp: 2,
+      pct: 50,
+      failing: 0,
+      flaky: 0,
+    })
+  })
+
+  it('round-trips known event types through decodeEvent()', () => {
+    const file = path.join(tmp, 'events.jsonl')
+    const sink = new JsonlSink(file)
+    const event = { type: 'run:start', timestamp: 42, sceneCount: 7 }
+    sink.write(event)
+    sink.close()
+
+    const line = fs.readFileSync(file, 'utf-8').trimEnd()
+    expect(decodeEvent(line)).toEqual(event)
+  })
+
+  it('appends across separate sink instances', () => {
+    const file = path.join(tmp, 'events.jsonl')
+    const first = new JsonlSink(file)
+    first.write({ type: 'run:start', timestamp: 1, sceneCount: 1 })
+    first.close()
+
+    const second = new JsonlSink(file)
+    second.write({ type: 'run:start', timestamp: 2, sceneCount: 1 })
+    second.close()
+
+    const lines = fs.readFileSync(file, 'utf-8').trimEnd().split('\n')
+    expect(lines).toHaveLength(2)
+  })
+
+  it('close() is safe to call twice and before any write', () => {
+    const sink = new JsonlSink(path.join(tmp, 'never.jsonl'))
+    sink.close()
+    sink.close()
+    expect(fs.existsSync(path.join(tmp, 'never.jsonl'))).toBe(false)
+  })
+})

--- a/packages/receiver/src/app.ts
+++ b/packages/receiver/src/app.ts
@@ -1,0 +1,65 @@
+import { Hono } from 'hono'
+import { isEventShaped } from '@scenetest/protocol'
+import type { Sink, SinkEvent } from './sink.js'
+
+/**
+ * Create the framework-agnostic receiver core: a Hono app that accepts
+ * protocol events over HTTP and fans them out to the given sinks.
+ *
+ * Routes:
+ * - `POST /events` — one JSON event per request. Validated with
+ *   `isEventShaped()` only (envelope check, NOT strict `decodeEvent`):
+ *   the receiver is a relay and must pass through event types newer
+ *   than itself. On `run:start`, each sink's `clear?.()` runs before
+ *   the event is written.
+ *
+ * Responses are always HTTP 200 — `{"ok":true}` for accepted events,
+ * `{"ok":false}` for malformed or non-event bodies. The CLI's reporter
+ * is fire-and-forget, and old CLIs must never be broken by an error
+ * status.
+ *
+ * Routes are defined with method chaining so the inferred app type
+ * carries the route schema for `hono/client` typed transports.
+ */
+export function createReceiverApp({ sinks }: { sinks: Sink[] }) {
+  const app = new Hono().post('/events', async (c) => {
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ ok: false })
+    }
+
+    if (!isEventShaped(body)) {
+      return c.json({ ok: false })
+    }
+
+    const event = body as SinkEvent
+
+    // New run: let live-state sinks reset before the run:start lands.
+    if (event.type === 'run:start') {
+      for (const sink of sinks) {
+        sink.clear?.()
+      }
+    }
+
+    for (const sink of sinks) {
+      sink.write(event)
+    }
+
+    return c.json({ ok: true })
+  })
+
+  return app
+}
+
+/**
+ * The receiver app's route schema, for `hono/client`:
+ *
+ * ```ts
+ * import { hc } from 'hono/client'
+ * import type { ReceiverAppType } from '@scenetest/receiver'
+ * const client = hc<ReceiverAppType>('http://localhost:5173/__scenetest')
+ * ```
+ */
+export type ReceiverAppType = ReturnType<typeof createReceiverApp>

--- a/packages/receiver/src/index.ts
+++ b/packages/receiver/src/index.ts
@@ -1,0 +1,3 @@
+export { createReceiverApp, type ReceiverAppType } from './app.js'
+export { JsonlSink, type Sink, type SinkEvent } from './sink.js'
+export { toNodeHandler } from './node.js'

--- a/packages/receiver/src/node.ts
+++ b/packages/receiver/src/node.ts
@@ -1,0 +1,14 @@
+import { getRequestListener } from '@hono/node-server'
+import type { Hono } from 'hono'
+
+/**
+ * Adapt a Hono app to a Node `(req, res)` request listener so it can
+ * mount inside a connect-style server (e.g. Vite's dev server
+ * middleware stack). The caller is responsible for routing/prefix
+ * stripping — rewrite `req.url` to the app-relative path before
+ * delegating.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toNodeHandler(app: Hono<any, any, any>): ReturnType<typeof getRequestListener> {
+  return getRequestListener(app.fetch)
+}

--- a/packages/receiver/src/sink.ts
+++ b/packages/receiver/src/sink.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+/**
+ * A protocol event as the receiver sees it: the envelope (`type` +
+ * `timestamp`) is guaranteed by `isEventShaped`, everything else is
+ * passed through untouched. The receiver is a relay — it must not
+ * narrow events to the vocabulary it was compiled against, or a newer
+ * CLI paired with an older receiver would have its events dropped.
+ */
+export type SinkEvent = { type: string; timestamp: number } & Record<string, unknown>
+
+/**
+ * Destination for received protocol events.
+ *
+ * `write()` is called once per accepted event. `clear()`, if present,
+ * is called when a `run:start` event arrives — consumers that hold
+ * live state (ring buffers, dashboards) reset so the new run starts
+ * fresh. `clear()` is invoked before the `run:start` event itself is
+ * written.
+ */
+export interface Sink {
+  write(event: SinkEvent): void
+  clear?(): void
+}
+
+/**
+ * Sink that appends one JSON line per event to a file — ".jsonl =
+ * protocol events, one per line". Lines are `JSON.stringify(event)`
+ * (the `encodeEvent()` wire format) followed by `\n`, so known event
+ * types round-trip through `decodeEvent()`.
+ *
+ * The file is opened lazily on first write (parent directories are
+ * created as needed) and appended to across runs; call `close()` when
+ * done. No `clear()` — the JSONL file is a durable log, not live state.
+ */
+export class JsonlSink implements Sink {
+  private fd: number | null = null
+
+  constructor(private readonly filePath: string) {}
+
+  write(event: SinkEvent): void {
+    if (this.fd === null) {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true })
+      this.fd = fs.openSync(this.filePath, 'a')
+    }
+    fs.writeSync(this.fd, JSON.stringify(event) + '\n')
+  }
+
+  close(): void {
+    if (this.fd !== null) {
+      fs.closeSync(this.fd)
+      this.fd = null
+    }
+  }
+}

--- a/packages/receiver/tsconfig.json
+++ b/packages/receiver/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/__tests__"]
+}

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -45,6 +45,7 @@
     "preact": "^10.22.0",
     "@scenetest/checks": "workspace:*",
     "@scenetest/protocol": "workspace:*",
+    "@scenetest/receiver": "workspace:*",
     "@scenetest/checks-panel": "workspace:*",
     "@scenetest/scenes-panel": "workspace:*"
   },

--- a/packages/vite-plugin/src/__tests__/middleware-events.test.ts
+++ b/packages/vite-plugin/src/__tests__/middleware-events.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'fs'
+import http from 'http'
+import os from 'os'
+import path from 'path'
+import type { AddressInfo } from 'net'
+import { createScenetestMiddleware } from '../middleware.js'
+
+// End-to-end coverage of the events path now that POST /__scenetest/events
+// delegates to @scenetest/receiver: the refactor's acceptance bar is "dev
+// behavior observably unchanged", so exercise it over real HTTP exactly as
+// the CLI's DashboardReporter and the dashboard's EventSource do.
+
+function stubServer(): any {
+  return {
+    ssrLoadModule: async () => ({ assertions: {} }),
+    moduleGraph: { getModuleById: () => null, invalidateModule: () => {} },
+  }
+}
+
+let tmpRoot: string
+let httpServer: http.Server
+let baseUrl: string
+
+function startServer(options: Parameters<typeof createScenetestMiddleware>[2] = {}): Promise<void> {
+  const middleware = createScenetestMiddleware(stubServer(), tmpRoot, options)
+  httpServer = http.createServer((req, res) => {
+    void middleware(req, res, () => {
+      res.statusCode = 404
+      res.end('not handled')
+    })
+  })
+  return new Promise((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => {
+      const { port } = httpServer.address() as AddressInfo
+      baseUrl = `http://127.0.0.1:${port}`
+      resolve()
+    })
+  })
+}
+
+function postEvent(body: string): Promise<Response> {
+  return fetch(`${baseUrl}/__scenetest/events`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+}
+
+/** Connect to the SSE stream and collect `count` replayed events. */
+async function readSseReplay(count: number): Promise<Array<Record<string, unknown>>> {
+  const controller = new AbortController()
+  const res = await fetch(`${baseUrl}/__scenetest/events`, { signal: controller.signal })
+  expect(res.headers.get('content-type')).toBe('text/event-stream')
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  const events: Array<Record<string, unknown>> = []
+  while (events.length < count) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    let idx: number
+    while ((idx = buffer.indexOf('\n\n')) !== -1) {
+      const frame = buffer.slice(0, idx)
+      buffer = buffer.slice(idx + 2)
+      const data = frame.replace(/^data: /, '')
+      events.push(JSON.parse(data))
+    }
+  }
+  controller.abort()
+  return events
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'scenetest-events-'))
+})
+
+afterEach(async () => {
+  httpServer.closeAllConnections()
+  await new Promise((resolve) => httpServer.close(resolve))
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+})
+
+describe('events path through the receiver core', () => {
+  it('accepts protocol events and replays them to a late-joining SSE client', async () => {
+    await startServer()
+    const assertion = { type: 'assertion', timestamp: 1, description: 'works', result: true }
+    const future = { type: 'hologram:flicker', timestamp: 2, intensity: 0.7 }
+
+    expect(await (await postEvent(JSON.stringify(assertion))).json()).toEqual({ ok: true })
+    // Unknown future event types must relay (old plugin + newer CLI).
+    expect(await (await postEvent(JSON.stringify(future))).json()).toEqual({ ok: true })
+
+    expect(await readSseReplay(2)).toEqual([assertion, future])
+  })
+
+  it('rejects malformed and non-event bodies with 200 ok:false and buffers nothing', async () => {
+    await startServer()
+    for (const body of ['{not json', '"just a string"', '{"type":"x"}']) {
+      const res = await postEvent(body)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ ok: false })
+    }
+
+    await postEvent(JSON.stringify({ type: 'assertion', timestamp: 9, result: true }))
+    const replay = await readSseReplay(1)
+    expect(replay).toHaveLength(1)
+    expect(replay[0].timestamp).toBe(9)
+  })
+
+  it('clears the SSE buffer on run:start so the dashboard starts fresh', async () => {
+    await startServer()
+    await postEvent(JSON.stringify({ type: 'assertion', timestamp: 1, result: true }))
+    await postEvent(JSON.stringify({ type: 'run:start', timestamp: 2, sceneCount: 1 }))
+
+    expect(await readSseReplay(1)).toEqual([{ type: 'run:start', timestamp: 2, sceneCount: 1 }])
+  })
+
+  it('does not send Access-Control-Allow-Origin on the SSE stream', async () => {
+    await startServer()
+    // Buffer one event first: SSE headers only flush with the first body
+    // bytes, and fetch() resolves on headers.
+    await postEvent(JSON.stringify({ type: 'assertion', timestamp: 1, result: true }))
+    const controller = new AbortController()
+    const res = await fetch(`${baseUrl}/__scenetest/events`, { signal: controller.signal })
+    expect(res.headers.get('access-control-allow-origin')).toBeNull()
+    controller.abort()
+  })
+
+  it('writes one protocol event per line when the jsonl option is on', async () => {
+    await startServer({ jsonl: true })
+    const events = [
+      { type: 'run:start', timestamp: 1, sceneCount: 1 },
+      { type: 'assertion', timestamp: 2, description: 'ok', result: true },
+    ]
+    for (const event of events) {
+      await postEvent(JSON.stringify(event))
+    }
+
+    const jsonlPath = path.join(tmpRoot, 'scenetest', '.reports', 'events.jsonl')
+    const lines = fs.readFileSync(jsonlPath, 'utf-8').trim().split('\n')
+    expect(lines.map((l) => JSON.parse(l))).toEqual(events)
+  })
+})

--- a/packages/vite-plugin/src/event-hub.ts
+++ b/packages/vite-plugin/src/event-hub.ts
@@ -45,6 +45,14 @@ export class EventHub {
     })
   }
 
+  /**
+   * Sink-compatible alias of `push()` so the hub can be handed to the
+   * `@scenetest/receiver` core as a `Sink` (which also uses `clear()`).
+   */
+  write(event: DashboardEvent): void {
+    this.push(event)
+  }
+
   /** Broadcast an event to all connected clients and buffer it. */
   push(event: DashboardEvent): void {
     // Buffer for late joiners

--- a/packages/vite-plugin/src/middleware.ts
+++ b/packages/vite-plugin/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { Connect, ViteDevServer } from 'vite'
 import type { AssertionRpcPayload, AssertionRpcResponse, AssertionResult, ServerContext } from '@scenetest/checks'
-import { isEventShaped } from '@scenetest/protocol'
+import { createReceiverApp, toNodeHandler, JsonlSink, type Sink } from '@scenetest/receiver'
 import { AsyncLocalStorage } from 'async_hooks'
 import { spawn, type ChildProcess } from 'child_process'
 import fs from 'fs'
@@ -183,7 +183,7 @@ export function failed(description: string, context?: Record<string, unknown>): 
 export function createScenetestMiddleware(
   server: ViteDevServer,
   root: string,
-  options: { reportsDir?: string } = {}
+  options: { reportsDir?: string; jsonl?: boolean | string } = {}
 ): Connect.NextHandleFunction {
   const eventHub = new EventHub()
   let activeReplay: ChildProcess | null = null
@@ -192,6 +192,21 @@ export function createScenetestMiddleware(
   // Where to look for past JSON run reports. Defaults to the same path the
   // CLI writes to. Resolved against the consumer's project root.
   const reportsDir = path.resolve(root, options.reportsDir ?? 'scenetest/.reports')
+
+  // Inbound CLI events go through the framework-agnostic receiver core
+  // (@scenetest/receiver). The EventHub doubles as a Sink: write() relays
+  // to the SSE clients, clear() resets the ring buffer on run:start.
+  // Serving the SSE stream itself stays here — that's a dev-transport
+  // concern, not the receiver's.
+  const sinks: Sink[] = [eventHub]
+  if (options.jsonl) {
+    const jsonlPath =
+      typeof options.jsonl === 'string'
+        ? path.resolve(root, options.jsonl)
+        : path.join(reportsDir, 'events.jsonl')
+    sinks.push(new JsonlSink(jsonlPath))
+  }
+  const receiverHandler = toNodeHandler(createReceiverApp({ sinks }))
 
   return async (req, res, next) => {
     // ── Preact app shell (index + runner) ───────────────────
@@ -294,31 +309,13 @@ export function createScenetestMiddleware(
     }
 
     // ── Receive events from CLI runner ──────────────────────
+    // Delegated to the receiver core: envelope-only validation (relay
+    // semantics — event types newer than this plugin still fan out),
+    // sink clear() on run:start, always 200 so old CLIs never break.
     if (req.method === 'POST' && req.url === '/__scenetest/events') {
-      let body = ''
-      for await (const chunk of req) {
-        body += chunk
-      }
-
-      try {
-        const event = JSON.parse(body)
-        // The hub is a relay, not a consumer: require only the protocol
-        // envelope so event types newer than this plugin still fan out
-        // (a newer CLI paired with an older plugin is the normal case).
-        if (isEventShaped(event)) {
-          // Clear buffer on new run so the dashboard starts fresh
-          if (event.type === 'run:start') {
-            eventHub.clear()
-          }
-          eventHub.push(event)
-        }
-      } catch {
-        // Ignore malformed events
-      }
-
-      res.statusCode = 200
-      res.setHeader('Content-Type', 'application/json')
-      res.end('{"ok":true}')
+      // The receiver app mounts at its own root; strip the prefix.
+      req.url = '/events'
+      await receiverHandler(req, res)
       return
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,28 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@20.19.30)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/receiver:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.14(hono@4.12.25)
+      '@scenetest/protocol':
+        specifier: workspace:*
+        version: link:../protocol
+      hono:
+        specifier: ^4.6.0
+        version: 4.12.25
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.30
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@20.19.30)(vite@7.3.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/scenes:
     dependencies:
       '@scenetest/checks':
@@ -390,6 +412,9 @@ importers:
       '@scenetest/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@scenetest/receiver':
+        specifier: workspace:*
+        version: link:../receiver
       '@scenetest/scenes-panel':
         specifier: workspace:*
         version: link:../scenes-panel
@@ -1081,6 +1106,12 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2342,6 +2373,10 @@ packages:
   highlight.js@11.11.1:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
+
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+    engines: {node: '>=16.9.0'}
 
   htm@3.1.1:
     resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
@@ -3905,6 +3940,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.14(hono@4.12.25)':
+    dependencies:
+      hono: 4.12.25
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5325,6 +5364,8 @@ snapshots:
   he@1.2.0: {}
 
   highlight.js@11.11.1: {}
+
+  hono@4.12.25: {}
 
   htm@3.1.1: {}
 


### PR DESCRIPTION
Closes #200. Part of #199.

New `@scenetest/receiver` package: `createReceiverApp({ sinks })` (Hono, method-chained so `ReceiverAppType` works with `hono/client`), `Sink` interface, `JsonlSink` (one protocol event per line), and `toNodeHandler()` for connect-style mounting. Envelope-only validation (`isEventShaped`) so the relay passes through event types newer than itself; always responds 200 — old CLIs are fire-and-forget.

The Vite middleware's `POST /__scenetest/events` now delegates to the receiver core with `EventHub` as the default sink; SSE serving stays in the middleware. Opt-in `jsonl` option adds a `JsonlSink`, off by default — dev behavior unchanged (verified over real HTTP, including SSE replay).

Tests: receiver 10/10 new, vite-plugin 79/79 untouched; build + typecheck pass.

https://claude.ai/code/session_01DP4jJDPH6TuWwe4EZYfZ9d

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP4jJDPH6TuWwe4EZYfZ9d)_