### PR TITLE
Harden the serverCheck() executor: timeouts, normalized failures, module runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to Scenetest are documented here.
 * **Hardened the `serverCheck()` executor.** Each server function now runs under a per-check timeout (default 5000ms, configurable via the new `serverCheckTimeout` plugin option) and receives an `AbortSignal` as a new `signal` helper (`{ should, failed, signal }`); a hung check is reported as a failed assertion and the RPC response always returns.
 * Middleware-level failures on `POST /__scenetest/run` (virtual-module load error, unknown serverFn id, scenetest config load error) now answer HTTP 200 with a normalized failed check — title-prefixed description, error detail in `context` — instead of an opaque 500 or an empty `success: false` response.
 * serverFns and the scenetest config are loaded through Vite's Environments API module runner (`createServerModuleRunner` against the `ssr` environment) when available, falling back to `server.ssrLoadModule` on vite 5.
+* The SSE stream now flushes its response headers on connect, so a dashboard `EventSource` opened before any run fires `open` immediately instead of waiting for the first event.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to Scenetest are documented here.
 
 * **New package: `@scenetest/receiver`** — the receiver core extracted from the Vite middleware as a framework-agnostic Hono app. `createReceiverApp({ sinks })` accepts protocol events on `POST /events` (envelope-validated with `isEventShaped()` so it relays event types newer than itself, always responding 200 so old CLIs never break) and fans them out to `Sink`s, calling `clear()` on `run:start`. Ships a `JsonlSink` (one protocol event per JSON line) and a `toNodeHandler()` adapter; the Vite middleware now delegates `POST /__scenetest/events` to it with the SSE `EventHub` as a sink, and dev behavior is unchanged.
 
+### @scenetest/vite-plugin
+
+* **Hardened the `serverCheck()` executor.** Each server function now runs under a per-check timeout (default 5000ms, configurable via the new `serverCheckTimeout` plugin option) and receives an `AbortSignal` as a new `signal` helper (`{ should, failed, signal }`); a hung check is reported as a failed assertion and the RPC response always returns.
+* Middleware-level failures on `POST /__scenetest/run` (virtual-module load error, unknown serverFn id, scenetest config load error) now answer HTTP 200 with a normalized failed check — title-prefixed description, error detail in `context` — instead of an opaque 500 or an empty `success: false` response.
+* serverFns and the scenetest config are loaded through Vite's Environments API module runner (`createServerModuleRunner` against the `ssr` environment) when available, falling back to `server.ssrLoadModule` on vite 5.
+
 ### Security
 
 * **Typed values no longer leave the test process.** `typeInto()` and `select()` used to record their target as `selector=value`, which put the literal value — including `[self.password]` from the builtin login macro — into dashboard events (SSE-visible to anything that could reach the dev server) and into the persisted run-report timeline. The target is now the selector only, in both the `test()` and `scene()` models.

--- a/packages/checks/src/index.ts
+++ b/packages/checks/src/index.ts
@@ -10,6 +10,7 @@ export type {
   AssertServerFn,
   AssertDataFn,
   ServerContext,
+  ServerCheckHelpers,
   AssertionRpcPayload,
   AssertionRpcResponse,
 } from './types.js'

--- a/packages/checks/src/types.ts
+++ b/packages/checks/src/types.ts
@@ -74,6 +74,22 @@ export interface ServerContext {
 }
 
 /**
+ * Helpers injected into a `serverCheck()` server function when it executes
+ * in the dev server (the third argument of the generated wrapper, after the
+ * author's `server` and `data` parameters).
+ *
+ * `signal` aborts when the per-check timeout elapses (the Vite plugin's
+ * `serverCheckTimeout` option, default 5000ms). Long-running checks should
+ * observe it to stop early; the middleware enforces the deadline either way
+ * and reports a timed-out check as a failed assertion.
+ */
+export interface ServerCheckHelpers {
+  should: (description: string, condition: boolean, context?: Record<string, unknown>) => void
+  failed: (description: string, context?: Record<string, unknown>) => void
+  signal: AbortSignal
+}
+
+/**
  * Internal RPC payload sent from browser to server
  */
 export interface AssertionRpcPayload {

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -15,4 +15,10 @@ export default defineConfig({
 })
 ```
 
+## Security Considerations
+
+`serverCheck()` server functions are extracted at build time and executed by the dev-server middleware (`POST /__scenetest/run`) with full Node.js privileges. That code is yours, and it only ever runs on infrastructure you control: your own Vite dev server, whether that's your laptop or a disposable runner box you provision. It is never executed in any cloud worker or other hosted service. Don't expose the dev server to untrusted networks or code.
+
+Each `serverCheck()` invocation is subject to a per-check timeout (default 5000ms, configurable via the plugin's `serverCheckTimeout` option); a check that exceeds it is reported as a failed assertion and the RPC response still returns.
+
 See the [monorepo](https://github.com/scenetest/scenetest-js) for full documentation.

--- a/packages/vite-plugin/src/__tests__/middleware-events.test.ts
+++ b/packages/vite-plugin/src/__tests__/middleware-events.test.ts
@@ -117,13 +117,14 @@ describe('events path through the receiver core', () => {
     expect(await readSseReplay(1)).toEqual([{ type: 'run:start', timestamp: 2, sceneCount: 1 }])
   })
 
-  it('does not send Access-Control-Allow-Origin on the SSE stream', async () => {
+  it('flushes SSE headers immediately and sends no Access-Control-Allow-Origin', async () => {
     await startServer()
-    // Buffer one event first: SSE headers only flush with the first body
-    // bytes, and fetch() resolves on headers.
-    await postEvent(JSON.stringify({ type: 'assertion', timestamp: 1, result: true }))
+    // No events posted: headers must arrive even with an empty buffer
+    // (a browser EventSource opened before any run).
     const controller = new AbortController()
     const res = await fetch(`${baseUrl}/__scenetest/events`, { signal: controller.signal })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/event-stream')
     expect(res.headers.get('access-control-allow-origin')).toBeNull()
     controller.abort()
   })

--- a/packages/vite-plugin/src/__tests__/middleware-run.test.ts
+++ b/packages/vite-plugin/src/__tests__/middleware-run.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { Readable } from 'stream'
+import { createServer, type ViteDevServer } from 'vite'
+import { createScenetestMiddleware } from '../middleware.js'
+import { clearConfigCache } from '../config.js'
+import {
+  registerAssertions,
+  clearRegistry,
+  RESOLVED_VIRTUAL_MODULE_ID,
+} from '../virtual-module.js'
+import { scenetest } from '../index.js'
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}))
+
+const VIRTUAL_ID = 'virtual:scenetest-assertions'
+
+type ServerFn = (server: unknown, data: unknown, helpers: Record<string, unknown>) => unknown
+
+/**
+ * Stub dev server without `environments` — exercises the ssrLoadModule
+ * fallback path (what the middleware does on vite 5).
+ */
+function stubServer(
+  assertions: Record<string, ServerFn>,
+  opts: { failVirtual?: boolean; failConfig?: boolean } = {}
+): ViteDevServer {
+  return {
+    ssrLoadModule: async (id: string) => {
+      if (id === VIRTUAL_ID) {
+        if (opts.failVirtual) throw new Error('virtual module exploded')
+        return { assertions }
+      }
+      if (opts.failConfig) throw new Error('config boom')
+      return {}
+    },
+    moduleGraph: { getModuleById: () => null, invalidateModule: () => {} },
+  } as unknown as ViteDevServer
+}
+
+interface MockResponse {
+  statusCode: number
+  headers: Record<string, string>
+  body: string
+  end: (chunk?: string) => void
+  setHeader: (k: string, v: string) => void
+}
+
+function mockRes(): MockResponse {
+  const res: MockResponse = {
+    statusCode: 0,
+    headers: {},
+    body: '',
+    end(chunk) {
+      if (typeof chunk === 'string') res.body += chunk
+    },
+    setHeader(k, v) {
+      res.headers[k.toLowerCase()] = v
+    },
+  }
+  return res
+}
+
+async function callRun(
+  mw: ReturnType<typeof createScenetestMiddleware>,
+  payload: { id: string; title: string; key?: string; data?: unknown }
+): Promise<MockResponse> {
+  const res = mockRes()
+  const req = Readable.from([JSON.stringify(payload)]) as unknown as Record<string, unknown>
+  ;(req as { method: string }).method = 'POST'
+  ;(req as { url: string }).url = '/__scenetest/run'
+  ;(req as { headers: Record<string, string> }).headers = {}
+  await mw(req as never, res as never, () => {})
+  return res
+}
+
+describe('POST /__scenetest/run', () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'scenetest-run-'))
+    clearConfigCache()
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('delivers an AbortSignal to the serverFn via the helpers object', async () => {
+    const seen: { signal?: unknown } = {}
+    const mw = createScenetestMiddleware(
+      stubServer({
+        'check-1': (_server, _data, helpers) => {
+          seen.signal = helpers.signal
+          const should = helpers.should as (d: string, c: boolean) => void
+          should('signal delivered', helpers.signal instanceof AbortSignal)
+        },
+      }),
+      tmp
+    )
+
+    const res = await callRun(mw, { id: 'check-1', title: 'My check', data: null })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0].type).toBe('pass')
+    expect(seen.signal).toBeInstanceOf(AbortSignal)
+    expect((seen.signal as AbortSignal).aborted).toBe(false)
+  })
+
+  it('times out a hung serverFn and responds promptly with a fail result', async () => {
+    const mw = createScenetestMiddleware(
+      stubServer({
+        'check-1': () => new Promise(() => {}), // never resolves, ignores the signal
+      }),
+      tmp,
+      { serverCheckTimeout: 50 }
+    )
+
+    const started = Date.now()
+    const res = await callRun(mw, { id: 'check-1', title: 'Hung check', data: null })
+    const elapsed = Date.now() - started
+
+    expect(elapsed).toBeLessThan(2000)
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0].type).toBe('fail')
+    expect(body.results[0].description).toBe('Hung check: serverCheck timed out after 50ms')
+  })
+
+  it('aborts the signal at the deadline so a well-behaved serverFn can stop early', async () => {
+    let abortFired = false
+    const mw = createScenetestMiddleware(
+      stubServer({
+        'check-1': (_server, _data, helpers) =>
+          new Promise<void>((resolve) => {
+            const signal = helpers.signal as AbortSignal
+            signal.addEventListener('abort', () => {
+              abortFired = true
+              resolve()
+            })
+          }),
+      }),
+      tmp,
+      { serverCheckTimeout: 50 }
+    )
+
+    const started = Date.now()
+    const res = await callRun(mw, { id: 'check-1', title: 'Abortable check', data: null })
+    const elapsed = Date.now() - started
+
+    expect(elapsed).toBeLessThan(2000)
+    expect(res.statusCode).toBe(200)
+    expect(JSON.parse(res.body).success).toBe(true)
+    expect(abortFired).toBe(true)
+  })
+
+  it('does not crash on a serverFn that rejects after the timeout', async () => {
+    let rejectLate: ((err: Error) => void) | undefined
+    const mw = createScenetestMiddleware(
+      stubServer({
+        'check-1': () =>
+          new Promise((_resolve, reject) => {
+            rejectLate = reject
+          }),
+      }),
+      tmp,
+      { serverCheckTimeout: 50 }
+    )
+
+    const res = await callRun(mw, { id: 'check-1', title: 'Late reject', data: null })
+    expect(JSON.parse(res.body).results[0].description).toContain('timed out')
+
+    // Reject after the response was already sent — must not become an
+    // unhandled rejection (vitest would fail the test run if it did).
+    rejectLate?.(new Error('too late'))
+    await new Promise((r) => setTimeout(r, 10))
+  })
+
+  it('returns 200 with a fail result when the virtual module fails to load', async () => {
+    const mw = createScenetestMiddleware(stubServer({}, { failVirtual: true }), tmp)
+
+    const res = await callRun(mw, { id: 'check-1', title: 'Broken module', data: null })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0].type).toBe('fail')
+    expect(body.results[0].description).toBe('Broken module: failed to load server assertions')
+    expect(body.results[0].context.error).toContain('virtual module exploded')
+  })
+
+  it('returns 200 with a fail result when no serverFn matches the id', async () => {
+    const mw = createScenetestMiddleware(stubServer({}), tmp)
+
+    const res = await callRun(mw, { id: 'missing-id', title: 'Orphan check', data: null })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0].type).toBe('fail')
+    expect(body.results[0].description).toContain('Orphan check')
+    expect(body.results[0].description).toContain('missing-id')
+  })
+
+  it('returns 200 with a fail result when the scenetest config fails to load', async () => {
+    // A config file must exist for loadConfig() to attempt loading it
+    fs.mkdirSync(path.join(tmp, 'scenetest'), { recursive: true })
+    fs.writeFileSync(path.join(tmp, 'scenetest', 'config.ts'), 'export default {}')
+
+    const mw = createScenetestMiddleware(
+      stubServer({ 'check-1': () => {} }, { failConfig: true }),
+      tmp
+    )
+
+    const res = await callRun(mw, { id: 'check-1', title: 'Config check', data: null })
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0].type).toBe('fail')
+    expect(body.results[0].description).toBe('Config check: failed to load scenetest config')
+    expect(body.results[0].context.error).toContain('config boom')
+  })
+
+  it('keeps serverFn throws as a normalized fail result', async () => {
+    const mw = createScenetestMiddleware(
+      stubServer({
+        'check-1': () => {
+          throw new Error('kaboom')
+        },
+      }),
+      tmp
+    )
+
+    const res = await callRun(mw, { id: 'check-1', title: 'Thrower', data: null })
+    const body = JSON.parse(res.body)
+    expect(body.success).toBe(true)
+    expect(body.results[0].type).toBe('fail')
+    expect(body.results[0].description).toBe('Thrower: serverFn threw an error')
+    expect(body.results[0].context.error).toBe('kaboom')
+  })
+})
+
+describe('POST /__scenetest/run via the Environments API module runner', () => {
+  let tmp: string
+  let vite: ViteDevServer | undefined
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'scenetest-runner-'))
+    clearConfigCache()
+  })
+
+  afterEach(async () => {
+    clearRegistry()
+    if (vite) {
+      await vite.close()
+      vite = undefined
+    }
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('loads the virtual module through the module runner, including after invalidation', async () => {
+    vite = await createServer({
+      root: tmp,
+      configFile: false,
+      logLevel: 'silent',
+      server: { middlewareMode: true },
+      optimizeDeps: { noDiscovery: true },
+      plugins: [scenetest()],
+    })
+
+    // The devDep vite is 6.x, so the Environments API must be present —
+    // otherwise this test silently stops covering the runner path.
+    expect((vite as unknown as { environments?: { ssr?: unknown } }).environments?.ssr).toBeTruthy()
+
+    // Prove the runner is used: the legacy path must never be hit.
+    const ssrLoadSpy = vi
+      .spyOn(vite, 'ssrLoadModule')
+      .mockImplementation(async () => {
+        throw new Error('ssrLoadModule should not be called when the module runner is available')
+      })
+
+    // Register after createServer — the plugin's buildStart clears the registry
+    registerAssertions([
+      {
+        id: 'check-1',
+        title: 'check-1',
+        location: { file: path.join(tmp, 'app.tsx'), line: 1, column: 1 },
+        serverFnBodyCode: 'should("data is 42", data === 42)',
+        params: 'server, data',
+      },
+    ])
+
+    const mw = createScenetestMiddleware(vite, tmp)
+
+    const res1 = await callRun(mw, { id: 'check-1', title: 'Runner check', data: 42 })
+    expect(res1.statusCode).toBe(200)
+    const body1 = JSON.parse(res1.body)
+    expect(body1.success).toBe(true)
+    expect(body1.results).toHaveLength(1)
+    expect(body1.results[0].type).toBe('pass')
+
+    // Register a new assertion and invalidate the virtual module the same
+    // way the plugin's transform hook does — the runner must pick up the
+    // regenerated module, not serve a stale one.
+    registerAssertions([
+      {
+        id: 'check-2',
+        title: 'check-2',
+        location: { file: path.join(tmp, 'app.tsx'), line: 2, column: 1 },
+        serverFnBodyCode: 'should("signal helper exists", signal instanceof AbortSignal)',
+        params: 'server, data',
+      },
+    ])
+    const virtualMod = vite.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID)
+    expect(virtualMod).toBeTruthy()
+    vite.moduleGraph.invalidateModule(virtualMod!)
+
+    const res2 = await callRun(mw, { id: 'check-2', title: 'Runner check 2', data: null })
+    const body2 = JSON.parse(res2.body)
+    expect(body2.success).toBe(true)
+    expect(body2.results).toHaveLength(1)
+    expect(body2.results[0].type).toBe('pass')
+
+    expect(ssrLoadSpy).not.toHaveBeenCalled()
+  }, 30000)
+})

--- a/packages/vite-plugin/src/__tests__/transform.test.ts
+++ b/packages/vite-plugin/src/__tests__/transform.test.ts
@@ -124,7 +124,7 @@ serverCheck('row matches', async (server, { id, status }) => {
     registerAssertions(result!.extractedAssertions)
 
     const moduleCode = generateVirtualModuleCode()
-    expect(moduleCode).toContain('async (server, { id, status }, { should, failed })')
+    expect(moduleCode).toContain('async (server, { id, status }, { should, failed, signal })')
     // Regression: an `await` body inside a non-async wrapper fails to parse.
     expect(() => parse(moduleCode, { sourceType: 'module' })).not.toThrow()
   })

--- a/packages/vite-plugin/src/__tests__/virtual-module.test.ts
+++ b/packages/vite-plugin/src/__tests__/virtual-module.test.ts
@@ -16,7 +16,7 @@ describe('generateVirtualModuleCode', () => {
     expect(code).toBe('export const assertions = {}')
   })
 
-  it('should generate serverFn with { should, failed } parameters', () => {
+  it('should generate serverFn with { should, failed, signal } parameters', () => {
     registerAssertions([
       {
         id: 'test-id',
@@ -29,10 +29,10 @@ describe('generateVirtualModuleCode', () => {
 
     const code = generateVirtualModuleCode()
 
-    // The generated code MUST use { should, failed } so that:
+    // The generated code MUST use { should, failed, signal } so that:
     // 1. User code can call should() and failed() in serverFn
-    // 2. The middleware can pass { should, failed } helpers
-    expect(code).toContain('{ should, failed }')
+    // 2. The middleware can pass { should, failed, signal } helpers
+    expect(code).toContain('{ should, failed, signal }')
     expect(code).not.toContain('{ pass, fail }')
   })
 
@@ -93,7 +93,7 @@ describe('generateVirtualModuleCode', () => {
 
     const code = generateVirtualModuleCode()
 
-    expect(code).toContain('async (server, data, { should, failed })')
+    expect(code).toContain('async (server, data, { should, failed, signal })')
     // The whole module must be valid JS — `await` outside async would throw.
     expect(() => parse(code, { sourceType: 'module' })).not.toThrow()
   })
@@ -113,7 +113,7 @@ describe('generateVirtualModuleCode', () => {
 
     // Author destructured `data` — the wrapper must keep that pattern so the
     // body references (`id`, `status`) still resolve.
-    expect(code).toContain('async (server, { id, status }, { should, failed })')
+    expect(code).toContain('async (server, { id, status }, { should, failed, signal })')
     expect(() => parse(code, { sourceType: 'module' })).not.toThrow()
   })
 
@@ -130,6 +130,6 @@ describe('generateVirtualModuleCode', () => {
 
     const code = generateVirtualModuleCode()
 
-    expect(code).toContain('async (server, data, { should, failed })')
+    expect(code).toContain('async (server, data, { should, failed, signal })')
   })
 })

--- a/packages/vite-plugin/src/event-hub.ts
+++ b/packages/vite-plugin/src/event-hub.ts
@@ -31,6 +31,10 @@ export class EventHub {
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
     })
+    // Node buffers the response head until the first body write, so with
+    // an empty buffer the EventSource would sit pending (no `open` event)
+    // until the first run produces an event. Flush immediately.
+    res.flushHeaders()
 
     // Send buffered events so late joiners catch up
     for (const event of this.buffer) {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -158,6 +158,15 @@ export interface ScenetestPluginOptions {
   recorder?: boolean
 
   /**
+   * Maximum time in milliseconds a single serverCheck() server function may
+   * run in the dev server before it is reported as a failed check. The
+   * deadline is also handed to the server function as an AbortSignal
+   * (the `signal` helper) so well-behaved checks can stop early.
+   * Defaults to 5000.
+   */
+  serverCheckTimeout?: number
+
+  /**
    * Content Security Policy configuration for dev mode.
    * Adds CSP headers to protect against XSS and other injection attacks.
    * Defaults to disabled — opt in with `csp: true` or `csp: { enabled: true }`.
@@ -270,7 +279,9 @@ export function scenetest(options: ScenetestPluginOptions = {}): Plugin {
       }
 
       // Install the scenetest middleware for handling RPC requests
-      server.middlewares.use(createScenetestMiddleware(server, root))
+      server.middlewares.use(
+        createScenetestMiddleware(server, root, { serverCheckTimeout: options.serverCheckTimeout })
+      )
     },
 
     resolveId(id) {

--- a/packages/vite-plugin/src/middleware.ts
+++ b/packages/vite-plugin/src/middleware.ts
@@ -1,12 +1,18 @@
 import type { Connect, ViteDevServer } from 'vite'
-import type { AssertionRpcPayload, AssertionRpcResponse, AssertionResult, ServerContext } from '@scenetest/checks'
+import type {
+  AssertionRpcPayload,
+  AssertionRpcResponse,
+  AssertionResult,
+  ServerCheckHelpers,
+  ServerContext,
+} from '@scenetest/checks'
 import { createReceiverApp, toNodeHandler, JsonlSink, type Sink } from '@scenetest/receiver'
 import { AsyncLocalStorage } from 'async_hooks'
 import { spawn, type ChildProcess } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 import { createRequire } from 'module'
-import { RESOLVED_VIRTUAL_MODULE_ID } from './virtual-module.js'
+import { VIRTUAL_MODULE_ID } from './virtual-module.js'
 import { loadConfig } from './config.js'
 import { EventHub } from './event-hub.js'
 import { generateDashboardHtml } from './dashboard.js'
@@ -169,6 +175,52 @@ export function failed(description: string, context?: Record<string, unknown>): 
 }
 
 /**
+ * Loads and evaluates a module through the dev server's plugin pipeline
+ * (so the scenetest plugin's resolveId/load hooks apply).
+ */
+type ServerModuleLoader = (id: string) => Promise<Record<string, unknown>>
+
+/**
+ * Default per-serverCheck() execution timeout (ms). Overridable via the
+ * middleware's `serverCheckTimeout` option (threaded from the plugin option
+ * of the same name).
+ */
+const DEFAULT_SERVER_CHECK_TIMEOUT_MS = 5000
+
+/**
+ * Build the module loader used to evaluate the virtual assertions module and
+ * the user's scenetest config.
+ *
+ * On vite 6+ the Environments API is available: we create a server module
+ * runner against the `ssr` environment (once per middleware instance, reused
+ * across requests) and import through it. On vite 5 — or any vite build that
+ * doesn't export `createServerModuleRunner` — we fall back to the legacy
+ * `server.ssrLoadModule`, which the wide peer range still requires.
+ */
+async function createServerModuleLoader(server: ViteDevServer): Promise<ServerModuleLoader> {
+  const ssrEnvironment = (server as { environments?: Record<string, unknown> }).environments?.ssr
+  if (ssrEnvironment) {
+    try {
+      // Dynamic import + existence check: on vite 5 the import succeeds but
+      // the export is absent, so we must not reference it statically.
+      const vite = (await import('vite')) as unknown as {
+        createServerModuleRunner?: (
+          environment: unknown,
+          options?: { hmr?: false }
+        ) => { import: (id: string) => Promise<Record<string, unknown>> }
+      }
+      if (typeof vite.createServerModuleRunner === 'function') {
+        const runner = vite.createServerModuleRunner(ssrEnvironment, { hmr: false })
+        return (id) => runner.import(id)
+      }
+    } catch {
+      // Fall through to ssrLoadModule
+    }
+  }
+  return (id) => server.ssrLoadModule(id)
+}
+
+/**
  * Create the scenetest middleware for handling RPC requests.
  *
  * Observer and recorder modules are served via Vite's resolveId hook
@@ -183,7 +235,7 @@ export function failed(description: string, context?: Record<string, unknown>): 
 export function createScenetestMiddleware(
   server: ViteDevServer,
   root: string,
-  options: { reportsDir?: string; jsonl?: boolean | string } = {}
+  options: { reportsDir?: string; jsonl?: boolean | string; serverCheckTimeout?: number } = {}
 ): Connect.NextHandleFunction {
   const eventHub = new EventHub()
   let activeReplay: ChildProcess | null = null
@@ -207,6 +259,17 @@ export function createScenetestMiddleware(
     sinks.push(new JsonlSink(jsonlPath))
   }
   const receiverHandler = toNodeHandler(createReceiverApp({ sinks }))
+
+  // Per-serverCheck() execution deadline for /__scenetest/run.
+  const serverCheckTimeoutMs = options.serverCheckTimeout ?? DEFAULT_SERVER_CHECK_TIMEOUT_MS
+
+  // Module loader for serverFns + config: created lazily on the first RPC,
+  // then reused for every request (the module runner keeps its own cache).
+  let moduleLoaderPromise: Promise<ServerModuleLoader> | null = null
+  const getModuleLoader = (): Promise<ServerModuleLoader> => {
+    if (!moduleLoaderPromise) moduleLoaderPromise = createServerModuleLoader(server)
+    return moduleLoaderPromise
+  }
 
   return async (req, res, next) => {
     // ── Preact app shell (index + runner) ───────────────────
@@ -422,71 +485,129 @@ export function createScenetestMiddleware(
 
     const { id, title, data } = payload
 
-    try {
-      // Load the virtual module containing all serverFns
-      const virtualModule = await server.ssrLoadModule(RESOLVED_VIRTUAL_MODULE_ID)
-      const assertions = virtualModule.assertions as Record<string, (server: ServerContext, data: unknown) => void | Promise<void>>
+    const errorDetail = (err: unknown): string => (err instanceof Error ? err.message : String(err))
 
-      // Get the serverFn for this ID
-      const serverFn = assertions[id] as (
-        server: ServerContext,
-        data: unknown,
-        helpers: { should: typeof should; failed: typeof failed }
-      ) => void | Promise<void>
+    const failResult = (description: string, context?: Record<string, unknown>): AssertionResult => ({
+      type: 'fail',
+      description,
+      result: false,
+      timestamp: Date.now(),
+      context,
+    })
 
-      if (!serverFn) {
-        const response: AssertionRpcResponse = {
-          success: false,
-          results: [],
-          error: `No serverFn found for id: ${id}`,
-        }
-        res.statusCode = 200
-        res.setHeader('Content-Type', 'application/json')
-        res.end(JSON.stringify(response))
-        return
+    // Always answer HTTP 200 with a well-formed AssertionRpcResponse:
+    // middleware-level failures surface as a normalized fail result so the
+    // observer panel shows a failed check instead of an opaque 500.
+    const respond = (response: AssertionRpcResponse): void => {
+      let body: string
+      try {
+        body = JSON.stringify(response)
+      } catch (err) {
+        // Non-serializable assertion context (circular refs, BigInt, …)
+        body = JSON.stringify({
+          success: true,
+          results: [failResult(`${title}: failed to serialize results`, { error: errorDetail(err) })],
+        } satisfies AssertionRpcResponse)
       }
-
-      // Load config to get server functions
-      const config = await loadConfig(root, (id) => server.ssrLoadModule(id))
-      const serverContext = (config.server || {}) as ServerContext
-
-      // Execute serverFn with AsyncLocalStorage for result collection
-      const results: AssertionResult[] = []
-
-      await assertionStorage.run(results, async () => {
-        try {
-          // Pass the should/failed helpers directly to the serverFn
-          await serverFn(serverContext, data, { should, failed })
-        } catch (err) {
-          results.push({
-            type: 'fail',
-            description: `${title}: serverFn threw an error`,
-            result: false,
-            timestamp: Date.now(),
-            context: { error: err instanceof Error ? err.message : String(err) },
-          })
-        }
-      })
-
-      const response: AssertionRpcResponse = {
-        success: true,
-        results,
-      }
-
       res.statusCode = 200
       res.setHeader('Content-Type', 'application/json')
-      res.end(JSON.stringify(response))
-    } catch (err) {
-      console.error('[vite-plugin-scenetest] Middleware error:', err)
-      const response: AssertionRpcResponse = {
-        success: false,
-        results: [],
-        error: err instanceof Error ? err.message : String(err),
-      }
-      res.statusCode = 500
-      res.setHeader('Content-Type', 'application/json')
-      res.end(JSON.stringify(response))
+      res.end(body)
     }
+
+    type ServerCheckFn = (
+      server: ServerContext,
+      data: unknown,
+      helpers: ServerCheckHelpers
+    ) => void | Promise<void>
+
+    // Load the virtual module containing all serverFns
+    let serverFn: ServerCheckFn | undefined
+    try {
+      const loadModule = await getModuleLoader()
+      const virtualModule = await loadModule(VIRTUAL_MODULE_ID)
+      const assertions = virtualModule.assertions as Record<string, ServerCheckFn>
+      serverFn = assertions[id]
+    } catch (err) {
+      console.error('[vite-plugin-scenetest] Failed to load server assertions:', err)
+      respond({
+        success: true,
+        results: [failResult(`${title}: failed to load server assertions`, { error: errorDetail(err) })],
+      })
+      return
+    }
+
+    if (!serverFn) {
+      respond({
+        success: true,
+        results: [failResult(`${title}: no serverCheck() registered for id ${id}`, { id })],
+      })
+      return
+    }
+    const checkFn: ServerCheckFn = serverFn
+
+    // Load config to get server resources. loadConfig() swallows load errors
+    // (warn + empty config), so capture the underlying error here to surface
+    // it as a failed check instead of silently running the serverFn against
+    // an unexpectedly empty server context.
+    let serverContext: ServerContext
+    try {
+      let configLoadFailed = false
+      let configLoadError: unknown
+      const loadModule = await getModuleLoader()
+      const config = await loadConfig(root, async (configId) => {
+        try {
+          return await loadModule(configId)
+        } catch (err) {
+          configLoadFailed = true
+          configLoadError = err
+          throw err
+        }
+      })
+      if (configLoadFailed) throw configLoadError
+      serverContext = (config.server || {}) as ServerContext
+    } catch (err) {
+      respond({
+        success: true,
+        results: [failResult(`${title}: failed to load scenetest config`, { error: errorDetail(err) })],
+      })
+      return
+    }
+
+    // Execute the serverFn with AsyncLocalStorage for result collection.
+    // Each invocation gets an AbortSignal that fires at the deadline; since
+    // user code is free to ignore it, the invocation is also raced against
+    // the same deadline so the HTTP response always returns.
+    const results: AssertionResult[] = []
+    const signal = AbortSignal.timeout(serverCheckTimeoutMs)
+    let timedOut = false
+
+    await assertionStorage.run(results, async () => {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const deadline = new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          timedOut = true
+          resolve()
+        }, serverCheckTimeoutMs)
+      })
+      // Pass the should/failed helpers (and the abort signal) to the serverFn
+      const invocation = Promise.resolve().then(() => checkFn(serverContext, data, { should, failed, signal }))
+      // A serverFn that rejects after the deadline must not crash the dev
+      // server with an unhandled rejection.
+      invocation.catch(() => {})
+      try {
+        await Promise.race([invocation, deadline])
+      } catch (err) {
+        results.push(failResult(`${title}: serverFn threw an error`, { error: errorDetail(err) }))
+      } finally {
+        clearTimeout(timer)
+      }
+    })
+
+    if (timedOut) {
+      results.push(failResult(`${title}: serverCheck timed out after ${serverCheckTimeoutMs}ms`))
+    }
+
+    respond({ success: true, results })
   }
 }
 

--- a/packages/vite-plugin/src/virtual-module.ts
+++ b/packages/vite-plugin/src/virtual-module.ts
@@ -59,8 +59,9 @@ export function removeAssertionsForFile(filename: string): void {
  * Each serverFn is wrapped as an `async` arrow so that bodies using `await`
  * (the common case — serverCheck exists to do async server work) parse and
  * run. It receives the author's first two parameters followed by an injected
- * `{ should, failed }` argument, making those helpers available in scope for
- * the inlined body code.
+ * `{ should, failed, signal }` argument, making those helpers available in
+ * scope for the inlined body code. `signal` is an AbortSignal that fires when
+ * the middleware's per-check timeout elapses (see `serverCheckTimeout`).
  *
  * SECURITY NOTE: This function embeds user-provided assertion code directly
  * into the generated module. The code runs in the Vite dev server context
@@ -81,7 +82,7 @@ export function generateVirtualModuleCode(): string {
   // own parameters are kept so destructured patterns keep resolving.
   const entries = assertions.map((assertion) => {
     const params = assertion.params || 'server, data'
-    return `  ${JSON.stringify(assertion.id)}: async (${params}, { should, failed }) => {
+    return `  ${JSON.stringify(assertion.id)}: async (${params}, { should, failed, signal }) => {
     ${assertion.serverFnBodyCode}
   }`
   })


### PR DESCRIPTION
Closes #202.

- **Per-check timeout + AbortSignal**: each `/__scenetest/run` invocation gets `AbortSignal.timeout()` passed as `helpers.signal` (new `ServerCheckHelpers` type in @scenetest/checks) and is raced against the same deadline, so a hung serverFn can no longer hang the RPC. Timed-out checks surface as failed assertions. Default 5s, configurable via `serverCheckTimeout` (plugin + middleware option). Late rejections from abandoned serverFns are swallowed.
- **Normalized middleware failures**: virtual-module load errors, missing serverFn ids, and config load errors now return 200 with a fail `AssertionResult` (error detail in `context`) instead of a 500 — the observer panel shows a failed check rather than an opaque error. `success: true` + results chosen because the client ignores `results` on `success: false`.
- **Module runner**: serverFns and config load through the Environments API module runner on vite 6+ (feature-detected, created once, HMR invalidation verified by an integration test against a real dev server), falling back to `ssrLoadModule` on vite 5.
- **Docs**: README Security Considerations section now states the invariant — user server code only ever executes in the user's own dev server, never in a cloud worker.

Tests: 9 new in `middleware-run.test.ts` (timeout promptness, signal delivery, all failure normalizations, module-runner integration); 88/88 vite-plugin, full workspace build/typecheck/test pass.

https://claude.ai/code/session_01DP4jJDPH6TuWwe4EZYfZ9d

---
_Generated by [Claude Code](https://claude.ai/code/session_01DP4jJDPH6TuWwe4EZYfZ9d)_