### PR TITLE
Add --report-url flag for streaming protocol events to HTTP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## [0.15.0] — 2026-06-12
+
+**`@scenetest/scenes` gains a pluggable report destination.** The CLI can now stream its protocol events to any HTTP endpoint as a run executes — the "speaking" half of the receiver/sink design — unblocking direct-to-cloud and bring-your-own-runner CI reporting. Only `@scenetest/scenes` bumps (to 0.15.0); other packages are unchanged.
+
+### @scenetest/scenes
+
+* **New `--report-url <url>` flag (and `SCENETEST_REPORT_URL` env var)** — streams protocol events to a caller-supplied HTTP endpoint as the run executes, the "speaking" half of the receiver/sink design. `POST`s batched `{ "events": [{ "seq", "payload" }] }` (protocol events verbatim; `seq` is monotonic per run), flushing every ~250ms or 50 events with a final flush before exit. Fail-soft (an unreachable endpoint warns once and never fails the run) and additive — the dev middleware / `.jsonl` keep working. Optional `SCENETEST_REPORT_TOKEN` is sent as an `Authorization: Bearer` header. New config fields `reportUrl` / `reportToken` mirror the flag and env vars.
+* **Fix: `scenetest --version` now reports the installed package version** instead of a stale hardcoded `0.7.0`. The version is read from `package.json` at runtime, so it no longer drifts between releases.
+
+---
+
 ## [0.14.0] — 2026-06-11
 
 **The recorder panel moves to `@scenetest/scenes/recorder`**, completing what 0.13.0 did for the observer: each panel lives with the package it's a lens/composer for. The recorder composes scenes DSL, so it versions in lockstep with the parser that consumes its output — and like the observer it is pure DOM code with zero Vite coupling (record on any page, export `.spec.md`, run with the CLI). `@scenetest/scenes` and `@scenetest/vite-plugin` bump to 0.14.0; other packages are unchanged.

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -20,6 +20,7 @@ scenetest --swarm              # Run swarm mode (all teams, all scenes)
 | `--config <path>` | Path to config file (default: auto-discovered) |
 | `--report <dir>` | Report output directory (default: `./scenetest-reports`) |
 | `--format <fmt>` | Report format: `html`, `json`, or `both` (default: `html`) |
+| `--report-url <url>` | POST batched protocol events to an HTTP endpoint as the run executes (see [Live report URL](#live-report-url)) |
 | `--devices` | Enable device rotation (assign rotating mobile/tablet/desktop devices to actors) |
 | `--no-keyboard-actor` | Disable keyboard-only actor rotation (keyboard navigation is ON by default) |
 | `--fuzzy-fingers` | Enable fuzzy-finger touch simulation (imprecise human touch, ~1 in 5 clicks miss) |
@@ -268,6 +269,44 @@ When running against a Vite dev server with the scenetest plugin, a live dashboa
 The URL is printed when the runner starts. You can also open it from the floating dev panel's **dashboard** button.
 
 See [Live Dashboard](/reference/live-dashboard) for full details.
+
+## Live report URL
+
+`--report-url <url>` streams protocol events to a caller-supplied HTTP endpoint
+as the run executes — in addition to the dev middleware / `.jsonl`, not instead
+of them. This is the "speaking" half of the receiver/sink design, useful for
+relaying a run to a remote dashboard (e.g. a cloud runner box) or reporting
+directly from CI.
+
+```sh
+scenetest run --report-url http://127.0.0.1:4999/events/$RUN_ID
+# or via env var:
+SCENETEST_REPORT_URL=http://127.0.0.1:4999/events/$RUN_ID scenetest run
+```
+
+The flag takes precedence over `SCENETEST_REPORT_URL`, which takes precedence
+over `reportUrl` in the config file.
+
+**Wire contract.** The CLI `POST`s to `<url>` with the body:
+
+```json
+{ "events": [{ "seq": 0, "payload": { "type": "run:start", "timestamp": 1, "sceneCount": 3 } }] }
+```
+
+- `payload` is a protocol event, carried verbatim (no new wire format).
+- `seq` is a monotonic counter assigned per run, so the receiver can order and
+  de-duplicate the stream regardless of HTTP arrival order.
+- The URL is opaque — bake the run id into it.
+
+**Behavior.**
+
+- **Batched** — events flush every ~250ms or once 50 are queued, with a final
+  synchronous flush before exit so the tail of the run (including `run:end`) is
+  never lost.
+- **Fail soft** — an unreachable or erroring endpoint logs a single warning and
+  never fails the run. Reporting is observability, not a gate.
+- **Auth** — set `SCENETEST_REPORT_TOKEN` (or `reportToken` in config) to send
+  an `Authorization: Bearer <token>` header, for the direct-to-cloud case.
 
 ## Exit Codes
 

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/src/__tests__/report-url-reporter.test.ts
+++ b/packages/scenes/src/__tests__/report-url-reporter.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ReportUrlReporter } from '../report-url-reporter.js'
+import type { DashboardEvent } from '../types.js'
+
+const URL = 'http://127.0.0.1:4999/events/run-123'
+
+function runStart(sceneCount = 1): DashboardEvent {
+  return { type: 'run:start', timestamp: 1, sceneCount }
+}
+
+/** Decode every POST into a flat list of { seq, payload } envelopes. */
+function postedEnvelopes(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.flatMap((call) => {
+    const body = JSON.parse((call[1] as RequestInit).body as string)
+    return body.events as { seq: number; payload: DashboardEvent }[]
+  })
+}
+
+describe('ReportUrlReporter', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs to the configured URL with the { events: [{ seq, payload }] } shape', async () => {
+    const reporter = new ReportUrlReporter({ url: URL })
+    reporter.send(runStart())
+    reporter.send({ type: 'run:end', timestamp: 2, duration: 5, summary: {
+      scenes: 1, completed: 1, failed: 0,
+      assertions: { total: 0, passed: 0, failed: 0 }, warnings: 0, consoleErrors: 0,
+    } })
+    await reporter.drain()
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(fetchMock.mock.calls[0][0]).toBe(URL)
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(init.method).toBe('POST')
+
+    const envelopes = postedEnvelopes(fetchMock)
+    expect(envelopes.map((e) => e.seq)).toEqual([0, 1])
+    expect(envelopes[0].payload.type).toBe('run:start')
+    expect(envelopes[1].payload.type).toBe('run:end')
+  })
+
+  it('assigns monotonic seq across multiple flushes, in order', async () => {
+    const reporter = new ReportUrlReporter({ url: URL, maxBatchSize: 2 })
+    for (let i = 0; i < 5; i++) {
+      reporter.send({ type: 'assertion', timestamp: i, description: `a${i}`, result: true })
+    }
+    await reporter.drain()
+
+    // maxBatchSize 2 → flushes at 2, 4, then drain flushes the tail.
+    const seqs = postedEnvelopes(fetchMock).map((e) => e.seq)
+    expect(seqs).toEqual([0, 1, 2, 3, 4])
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('sends a bearer Authorization header only when a token is given', async () => {
+    const withToken = new ReportUrlReporter({ url: URL, token: 'sekret' })
+    withToken.send(runStart())
+    await withToken.drain()
+    let headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>
+    expect(headers['Authorization']).toBe('Bearer sekret')
+
+    fetchMock.mockClear()
+    const noToken = new ReportUrlReporter({ url: URL })
+    noToken.send(runStart())
+    await noToken.drain()
+    headers = (fetchMock.mock.calls[0][1] as RequestInit).headers as Record<string, string>
+    expect(headers['Authorization']).toBeUndefined()
+  })
+
+  it('fails soft: a rejected fetch never throws and warns once', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const reporter = new ReportUrlReporter({ url: URL, maxBatchSize: 1 })
+    reporter.send(runStart())
+    reporter.send(runStart())
+    await expect(reporter.drain()).resolves.toBeUndefined()
+
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns once on a non-ok response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const reporter = new ReportUrlReporter({ url: URL })
+    reporter.send(runStart())
+    await reporter.drain()
+
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('drain with no queued events does not POST', async () => {
+    const reporter = new ReportUrlReporter({ url: URL })
+    await reporter.drain()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -3,6 +3,7 @@
 import { Command } from 'commander'
 import path from 'path'
 import fs from 'fs'
+import { fileURLToPath } from 'url'
 import { loadConfig, filterTeamsByName } from './config.js'
 import { SceneRunner, printSummary } from './runner.js'
 import { init } from './init.js'
@@ -20,12 +21,17 @@ import {
 } from './prompt-generator.js'
 import type { CLIOptions, RunReport } from './types.js'
 
+// Read the version from package.json so `scenetest --version` always matches
+// the installed package instead of a hand-maintained literal that drifts.
+const pkgPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'package.json')
+const version = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version as string
+
 const program = new Command()
 
 program
   .name('scenetest')
   .description('Run scenetest scene specs')
-  .version('0.7.0')
+  .version(version)
   .argument('[scenes...]', 'Scene files or directories to run')
   .option('--ui', 'Run in interactive UI mode')
   .option('--headed', 'Run with visible browser')

--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -6,6 +6,11 @@ import fs from 'fs'
 import { loadConfig, filterTeamsByName } from './config.js'
 import { SceneRunner, printSummary } from './runner.js'
 import { init } from './init.js'
+import {
+  ReportUrlReporter,
+  setReportUrlReporter,
+  drainReportUrlReporter,
+} from './report-url-reporter.js'
 import { finish as soundFinish, resolveSoundEnabled } from './sound.js'
 import {
   gatherProjectContext,
@@ -26,6 +31,7 @@ program
   .option('--headed', 'Run with visible browser')
   .option('--report <dir>', 'Report output directory')
   .option('--format <format>', 'Report format (html, json, both)')
+  .option('--report-url <url>', 'POST batched protocol events to this HTTP endpoint as the run executes (also honors SCENETEST_REPORT_URL)')
   .option('--config <path>', 'Path to config file')
   .option('--devices', 'Enable device rotation (assign each actor a rotating mobile/tablet/desktop device)')
   .option('--no-keyboard-actor', 'Disable keyboard-only actor rotation (keyboard navigation is ON by default)')
@@ -75,6 +81,16 @@ program
         config.noPanel = true
       }
       config.sound = { enabled: resolveSoundEnabled(config, options) }
+
+      // Live report-url sink: CLI flag > env var > config. Composes with the
+      // local dev middleware / jsonl — it's an additional sink, not a replacement.
+      const reportUrl =
+        options.reportUrl ?? process.env.SCENETEST_REPORT_URL ?? config.reportUrl
+      if (reportUrl) {
+        const token = process.env.SCENETEST_REPORT_TOKEN ?? config.reportToken
+        setReportUrlReporter(new ReportUrlReporter({ url: reportUrl, token }))
+        console.log(`Reporting events to: ${reportUrl}\n`)
+      }
 
       // Interactive UI mode
       if (options.ui) {
@@ -141,6 +157,9 @@ program
           await new Promise(() => {}) // Wait forever
         }
       } finally {
+        // Final synchronous flush so the tail of the run — including run:end —
+        // is delivered before we exit.
+        await drainReportUrlReporter()
         if (!options.ui) {
           await runner.close()
         }

--- a/packages/scenes/src/dashboard-reporter.ts
+++ b/packages/scenes/src/dashboard-reporter.ts
@@ -1,4 +1,5 @@
 import type { DashboardEvent } from './types.js'
+import { reportUrlSend } from './report-url-reporter.js'
 
 /**
  * Streams dashboard events to the Vite dev server for the live timeline.
@@ -53,5 +54,8 @@ export function setDashboardReporter(reporter: DashboardReporter | null): void {
 }
 
 export function dashboardSend(event: DashboardEvent): void {
+  // Fan out to every configured sink: the dev-server dashboard (SSE/jsonl) and
+  // the optional caller-supplied --report-url endpoint. Both are fire-and-forget.
   _reporter?.send(event)
+  reportUrlSend(event)
 }

--- a/packages/scenes/src/report-url-reporter.ts
+++ b/packages/scenes/src/report-url-reporter.ts
@@ -1,0 +1,149 @@
+import type { DashboardEvent } from './types.js'
+
+/**
+ * A single batched event on the wire. The protocol event is carried verbatim
+ * as `payload`; `seq` is a monotonic counter assigned per run so the receiving
+ * end can order (and de-duplicate) the stream regardless of HTTP arrival order.
+ */
+export interface ReportEnvelope {
+  seq: number
+  payload: DashboardEvent
+}
+
+export interface ReportUrlOptions {
+  /** Caller-supplied HTTP endpoint. Opaque — the run id is baked into it. */
+  url: string
+  /** Optional bearer token, sent as `Authorization: Bearer <token>`. */
+  token?: string
+  /** Flush the queue at least this often (ms). Default 250. */
+  flushIntervalMs?: number
+  /** Flush eagerly once the queue reaches this many events. Default 50. */
+  maxBatchSize?: number
+  /** Per-request timeout (ms). Default 5000. */
+  timeoutMs?: number
+}
+
+/**
+ * Streams protocol events to a caller-supplied HTTP endpoint as the run
+ * executes — the "speaking" half of the receiver/sink design.
+ *
+ * Contract:
+ *   POST <url>  body: { "events": [{ "seq": n, "payload": <protocol event> }] }
+ *
+ * Events are batched (every `flushIntervalMs` or once `maxBatchSize` is
+ * queued) and posted in order. `drain()` performs a final synchronous flush
+ * before process exit so the tail of a run — including `run:end` — is never
+ * lost.
+ *
+ * Fail soft: an unreachable or erroring endpoint logs a single warning and
+ * never throws. Reporting is observability, not a gate on the run.
+ */
+export class ReportUrlReporter {
+  private readonly url: string
+  private readonly headers: Record<string, string>
+  private readonly flushIntervalMs: number
+  private readonly maxBatchSize: number
+  private readonly timeoutMs: number
+
+  private seq = 0
+  private queue: ReportEnvelope[] = []
+  private timer: ReturnType<typeof setTimeout> | null = null
+  /** Serializes POSTs so batches arrive in seq order. */
+  private chain: Promise<void> = Promise.resolve()
+  private warned = false
+
+  constructor(opts: ReportUrlOptions) {
+    this.url = opts.url
+    this.headers = { 'Content-Type': 'application/json' }
+    if (opts.token) this.headers['Authorization'] = `Bearer ${opts.token}`
+    this.flushIntervalMs = opts.flushIntervalMs ?? 250
+    this.maxBatchSize = opts.maxBatchSize ?? 50
+    this.timeoutMs = opts.timeoutMs ?? 5000
+  }
+
+  /** Enqueue an event. Non-blocking, never throws. */
+  send(event: DashboardEvent): void {
+    this.queue.push({ seq: this.seq++, payload: event })
+    if (this.queue.length >= this.maxBatchSize) {
+      void this.flush()
+    } else {
+      this.scheduleFlush()
+    }
+  }
+
+  private scheduleFlush(): void {
+    if (this.timer) return
+    this.timer = setTimeout(() => {
+      this.timer = null
+      void this.flush()
+    }, this.flushIntervalMs)
+    // Don't keep the process alive just for a pending flush.
+    this.timer.unref?.()
+  }
+
+  /**
+   * Hand the currently queued events to the POST chain. Returns once that
+   * batch (and everything queued before it) has been delivered or failed.
+   */
+  flush(): Promise<void> {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+    if (this.queue.length === 0) return this.chain
+    const batch = this.queue
+    this.queue = []
+    this.chain = this.chain.then(() => this.post(batch))
+    return this.chain
+  }
+
+  /** Final flush — drains the queue and waits for all in-flight POSTs. */
+  async drain(): Promise<void> {
+    // flush() returns the tail of the POST chain, so awaiting it waits for
+    // this batch and everything queued before it.
+    await this.flush()
+  }
+
+  private async post(events: ReportEnvelope[]): Promise<void> {
+    try {
+      const res = await fetch(this.url, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({ events }),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+      if (!res.ok) this.warn(`responded ${res.status}`)
+    } catch (err) {
+      this.warn(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  /** Warn once — reporting failures shouldn't spam the run or fail it. */
+  private warn(reason: string): void {
+    if (this.warned) return
+    this.warned = true
+    console.warn(
+      `[scenetest] report-url delivery to ${this.url} failed (${reason}); ` +
+        `continuing without it. Reporting is observability, not a gate.`
+    )
+  }
+}
+
+// ─── Module-level singleton ─────────────────────────────────────────
+// Set by the CLI before execution; fed by dashboardSend() alongside the
+// dev-server dashboard reporter, so every emit site reaches both sinks.
+
+let _reporter: ReportUrlReporter | null = null
+
+export function setReportUrlReporter(reporter: ReportUrlReporter | null): void {
+  _reporter = reporter
+}
+
+export function reportUrlSend(event: DashboardEvent): void {
+  _reporter?.send(event)
+}
+
+/** Final flush before exit. No-op when no report URL was configured. */
+export async function drainReportUrlReporter(): Promise<void> {
+  await _reporter?.drain()
+}

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -179,6 +179,20 @@ export interface ScenetestConfig extends BaseConfig {
   reportFormat?: 'html' | 'json' | 'both'
 
   /**
+   * Live report HTTP endpoint. When set, the CLI POSTs batched protocol events
+   * to this URL as the run executes — in addition to the local dev middleware /
+   * jsonl, not instead of them. The URL is opaque (bake the run id into it).
+   * Overridden by the `--report-url` flag or `SCENETEST_REPORT_URL` env var.
+   */
+  reportUrl?: string
+
+  /**
+   * Bearer token sent as `Authorization: Bearer <token>` to `reportUrl`.
+   * Overridden by the `SCENETEST_REPORT_TOKEN` env var.
+   */
+  reportToken?: string
+
+  /**
    * Device rotation: assign each actor a rotating device profile.
    * When true, uses built-in device pool (mobile, tablet, desktop).
    * When an array of DeviceProfile, uses that as the pool.
@@ -1120,6 +1134,9 @@ export interface CLIOptions {
 
   /** Report format */
   format?: 'html' | 'json' | 'both'
+
+  /** Live report HTTP endpoint — POST batched protocol events as the run executes */
+  reportUrl?: string
 
   /** Config file path */
   config?: string


### PR DESCRIPTION
## Summary

Adds a new `--report-url` CLI flag and supporting infrastructure to stream protocol events to a caller-supplied HTTP endpoint as the run executes. This is the "speaking" half of the receiver/sink design, enabling remote dashboards and cloud runners to receive live run data directly from the CLI.

## Key Changes

- **New `ReportUrlReporter` class** (`packages/scenes/src/report-url-reporter.ts`): Batches and POSTs protocol events to a configured HTTP endpoint with monotonic sequence numbers for ordering/deduplication. Events flush every ~250ms or once 50 are queued, with a final synchronous flush before exit to ensure `run:end` is never lost. Implements fail-soft behavior — unreachable endpoints log a single warning and never fail the run.

- **CLI integration** (`packages/scenes/src/cli.ts`): 
  - Added `--report-url <url>` flag
  - Supports `SCENETEST_REPORT_URL` env var and `reportUrl` config field (flag > env > config precedence)
  - Optional `SCENETEST_REPORT_TOKEN` env var and `reportToken` config field for bearer token auth
  - Calls `drainReportUrlReporter()` in the finally block to ensure tail events are delivered before exit

- **Dashboard reporter fan-out** (`packages/scenes/src/dashboard-reporter.ts`): Modified `dashboardSend()` to fan out events to both the dev-server dashboard (SSE/jsonl) and the optional report-url endpoint, making them composable sinks rather than mutually exclusive.

- **Type definitions** (`packages/scenes/src/types.ts`): Added `reportUrl` and `reportToken` config fields, and `reportUrl` CLI option.

- **Wire contract**: POSTs `{ "events": [{ "seq": n, "payload": <protocol event> }] }` where `payload` is a protocol event verbatim and `seq` is a monotonic counter per run.

- **Comprehensive test suite** (`packages/scenes/src/__tests__/report-url-reporter.test.ts`): Tests batching, sequence ordering across flushes, bearer token handling, fail-soft behavior, and edge cases.

- **Documentation** (`docs/public/reference/cli.md`): Added "Live report URL" section explaining the feature, wire contract, behavior (batching, fail-soft, auth), and usage examples.

- **Changelog**: Documented the new feature in `CHANGELOG.md`.

## Implementation Details

- Events are queued and flushed on a timer (default 250ms) or eagerly when the batch reaches `maxBatchSize` (default 50).
- POSTs are serialized via a promise chain to ensure batches arrive in sequence order regardless of HTTP timing.
- The timer is marked with `.unref()` so it doesn't keep the process alive — the final `drain()` call ensures nothing is lost.
- Authorization header is only sent when a token is provided.
- Fetch timeout defaults to 5000ms and is configurable.
- The reporter is a module-level singleton set by the CLI before execution, allowing any emit site to reach both sinks without coupling.

https://claude.ai/code/session_01HJCqBnesLYaPG9ZNFWbvBu