### PR TITLE
Remove `run` subcommand from CLI examples

### DIFF
--- a/docs/public/design/dashboard.md
+++ b/docs/public/design/dashboard.md
@@ -107,7 +107,7 @@ Side-by-side diff showing:
 ```yaml
 # .github/workflows/test.yml
 - name: Run scenetest
-  run: pnpm scenetest run --report
+  run: pnpm scenetest --report
 
 - name: Upload report
   uses: scenetest/upload-report@v1

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -279,9 +279,9 @@ relaying a run to a remote dashboard (e.g. a cloud runner box) or reporting
 directly from CI.
 
 ```sh
-scenetest run --report-url http://127.0.0.1:4999/events/$RUN_ID
+scenetest --report-url http://127.0.0.1:4999/events/$RUN_ID
 # or via env var:
-SCENETEST_REPORT_URL=http://127.0.0.1:4999/events/$RUN_ID scenetest run
+SCENETEST_REPORT_URL=http://127.0.0.1:4999/events/$RUN_ID scenetest
 ```
 
 The flag takes precedence over `SCENETEST_REPORT_URL`, which takes precedence

--- a/packages/scenes/README.md
+++ b/packages/scenes/README.md
@@ -7,7 +7,7 @@ npm install -D @scenetest/scenes
 ```
 
 ```bash
-npx scenetest run
+npx scenetest
 ```
 
 See the [monorepo](https://github.com/scenetest/scenetest-js) for full documentation.


### PR DESCRIPTION
## Summary
Updates documentation and README examples to reflect the current CLI interface by removing the `run` subcommand. The `scenetest` command now invokes the runner directly without requiring an intermediate `run` subcommand.

## Changes
- **docs/public/reference/cli.md**: Updated `--report-url` flag examples to use `scenetest --report-url` instead of `scenetest run --report-url`, and updated the corresponding environment variable example
- **docs/public/design/dashboard.md**: Updated GitHub Actions workflow example to use `pnpm scenetest --report` instead of `pnpm scenetest run --report`
- **packages/scenes/README.md**: Updated quick-start example to use `npx scenetest` instead of `npx scenetest run`

## Details
These changes align the documentation with the actual CLI behavior, ensuring users follow the correct command syntax when getting started or configuring reporting features.

https://claude.ai/code/session_01HJCqBnesLYaPG9ZNFWbvBu