### PR TITLE
Add expectConsoleError() to assert expected console errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ test-results/
 playwright-report/
 playwright/.cache/
 
+# Scenetest run reports
+scenetest/.reports/
+.reports/
+
 # IDE
 .idea/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## Unreleased
+
+### @scenetest/scenes
+
+* **`expectConsoleError(pattern)` — assert an expected console error.** Scenes that deliberately exercise an error path (a wrong-password login, an invalid submit) can now declare the resulting browser console error / uncaught exception as a *success* rather than a problem. The action waits (up to the action timeout) for a captured error matching `pattern` (a case-insensitive substring, or a `RegExp` — `/regex/` in the text DSL), marks it **expected**, and fails the scene if none arrives. Expected errors are reported as `✓ N expected console error(s)` and excluded from the `🔴 browser console error(s)` surface and the run summary's count. Available on the actor handle, `ActionChain`, the reactive `scene()` model, and the text/`.spec.md` DSL. Each call claims a single error (the earliest unclaimed match for that actor).
+
+---
+
 ## 2026-06-22 — monorepo 0.17.0 · @scenetest/scenes 0.16.0, @scenetest/vite-plugin 0.17.0, @scenetest/dashboard 0.14.0, @scenetest/protocol 0.12.0, @scenetest/receiver 0.12.0
 
 **Dashboard control plane.** The dashboard can pause/resume/stop a run and re-run a team. Directions reach the CLI the same way in dev and cloud (receiver → `onCommand` → the run) and their effects come back as events. Commands target the active run; the only protocol change is two events plus a flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Scenetest are documented here.
 ### @scenetest/scenes
 
 * **`expectConsoleError(pattern)` — assert an expected console error.** Scenes that deliberately exercise an error path (a wrong-password login, an invalid submit) can now declare the resulting browser console error / uncaught exception as a *success* rather than a problem. The action waits (up to the action timeout) for a captured error matching `pattern` (a case-insensitive substring, or a `RegExp` — `/regex/` in the text DSL), marks it **expected**, and fails the scene if none arrives. Expected errors are reported as `✓ N expected console error(s)` and excluded from the `🔴 browser console error(s)` surface and the run summary's count. Available on the actor handle, `ActionChain`, the reactive `scene()` model, and the text/`.spec.md` DSL. Each call claims a single error (the earliest unclaimed match for that actor).
+* **`consoleErrorAliases` config — name the errors a suite expects.** Like selector aliases, config can map a domain term to a console-error pattern (`{ 'bad-password': 'Invalid login credentials' }`), so specs say `expectConsoleError bad-password`. A bare name resolves to the alias; a `~name` prefix forces alias resolution and throws on a typo. Exported helpers: `setConsoleErrorAliases` / `getConsoleErrorAliases` / `clearConsoleErrorAliases`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ The dashboard UI was extracted from the Vite plugin's inline HTML string so dev 
 - `config.ts` — `loadConfig()`, `findConfigFile()`, `defineConfig()`, team discovery
 - `types.ts` — All type definitions (`ScenetestConfig`, `SequentialActorHandle`, `ActionChain`, `ConcurrentActorHandle`, `SceneContext`, etc.)
 - `recorder/` — the scene recorder panel (capture, reverse-selector, panel UI), subpath export `./recorder`, auto-initializing on import. Pure DOM code with no Vite coupling; the Vite plugin injects it when `recorder: true`
+- `skills/scene-authoring/SKILL.md` + `skills/team-configuration/SKILL.md` — two shippable Agent Skills (TanStack Intent). `scene-authoring` teaches writing scene specs (the three authoring models, the actor DSL, selectors, multi-actor coordination, `expectConsoleError`, the `.spec.md` format); `team-configuration` teaches `scenetest/actors/**` teams, the `ActorConfig` shape, seed-data mapping, `warmup` auth caching, `cleanup:`/`setup:` directives, and `config.ts`. Shipped in the npm tarball (`files` includes `skills` + `!skills/_artifacts`, `tanstack-intent` keyword). Validate with `pnpm -C packages/scenes skills:validate`. Consumers discover them via `npx @tanstack/intent list` and load `@scenetest/scenes#scene-authoring` / `#team-configuration`. Keep in sync with `docs/public/reference/text-dsl.md`, `docs/public/guides/writing-scene-specs.md`, and `docs/public/guides/building-teams.md`.
 
 ### Vite Plugin (`packages/vite-plugin/src/`)
 - `index.ts` — Main plugin (dev: inject observer + middleware; prod: strip)

--- a/docs/app/lib/hljs-scenetest.ts
+++ b/docs/app/lib/hljs-scenetest.ts
@@ -9,7 +9,7 @@ import type { HLJSApi, Language, Mode } from 'highlight.js'
 
 export default function scenetestSpec(_hljs: HLJSApi): Language {
   const ACTIONS_RE =
-    /(?:openTo|seeInView|seeText|seeToast|notSee|see|click|typeInto|check|select|wait|emit|waitFor|warnIf|up|prev|scrollToBottom|if)\b/
+    /(?:openTo|seeInView|seeText|seeToast|expectConsoleError|notSee|see|click|typeInto|check|select|wait|emit|waitFor|warnIf|up|prev|scrollToBottom|if)\b/
 
   const INTERPOLATION: Mode = {
     scope: 'template-variable',

--- a/docs/public/design/cli-v2.md
+++ b/docs/public/design/cli-v2.md
@@ -292,6 +292,12 @@ defineConfig({
   // Fuzzy-finger touch simulation (OFF by default)
   fuzzyFingers: false,    // Set true to enable imprecise touch (~1 in 5 clicks miss)
 
+  // Named console errors — claim expected errors by domain term with
+  // `expectConsoleError <name>` (pattern is a substring or RegExp)
+  consoleErrorAliases: {
+    'bad-password': 'Invalid login credentials',
+  },
+
   // Actor teams are auto-discovered from actors.ts or actors/*.ts
   // (not defined in config)
 

--- a/docs/public/design/writing-tests.md
+++ b/docs/public/design/writing-tests.md
@@ -136,6 +136,11 @@ export default defineConfig({
     modal: '[role=dialog]',
     nav: '[role=navigation]',
   },
+  // Name the console errors scenes deliberately trigger, so specs can
+  // claim them by domain term: `expectConsoleError bad-password`.
+  consoleErrorAliases: {
+    'bad-password': 'Invalid login credentials',
+  },
   reportDir: './scenetest-reports',
   reportFormat: 'html',
 

--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -61,6 +61,15 @@ learner:
 
 It waits for a browser console error (or uncaught exception) matching the pattern — a case-insensitive substring, or a `/regex/` — and **fails the scene if none appears**. Matched errors are reported as `✓ expected console error(s)` and kept out of the run's error surface. Each call claims one error, so add one line per console message the failure emits.
 
+You can also name expected errors in `scenetest/config.ts` and reference them by domain term — handy when several specs expect the same error:
+
+```ts
+consoleErrorAliases: {
+  'bad-password': 'Invalid login credentials',
+}
+// then in a spec:  - expectConsoleError bad-password
+```
+
 ## Scope Navigation
 
 `scope` narrows the actor's **current scope** — subsequent actions search within the matched element. `see` is a pure assertion that checks visibility but does **not** change scope.

--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -47,6 +47,20 @@ user:
 
 `seeToast` waits for the element to appear _and then disappear_ — perfect for toast notifications that auto-dismiss.
 
+## Expecting Console Errors
+
+Some scenes deliberately exercise an error path — logging in with the wrong password, submitting an invalid form. The server *should* return an error there, and Scenetest would otherwise flag the resulting console error as a problem. Use `expectConsoleError` to declare it a success instead:
+
+```scenetest
+learner:
+- typeInto password wrong-password
+- click sign-in
+- expectConsoleError Invalid login credentials
+- seeText Wrong email or password
+```
+
+It waits for a browser console error (or uncaught exception) matching the pattern — a case-insensitive substring, or a `/regex/` — and **fails the scene if none appears**. Matched errors are reported as `✓ expected console error(s)` and kept out of the run's error surface. Each call claims one error, so add one line per console message the failure emits.
+
 ## Scope Navigation
 
 `scope` narrows the actor's **current scope** — subsequent actions search within the matched element. `see` is a pure assertion that checks visibility but does **not** change scope.
@@ -288,6 +302,7 @@ For the full syntax, see the [Markdown Spec Reference](/reference/text-dsl#clean
 - Use `seeInView` to check viewport visibility without scrolling
 - Use bare `click` to click the current scope element
 - Use `seeToast` for transient notifications
+- Use `expectConsoleError` when a scene deliberately triggers a server/console error (e.g. a wrong-password login)
 - Use `pressKey` to send raw keyboard events (`Escape`, `Enter`, `Tab`, etc.)
 - Use `cleanup:` and `setup:` directives in markdown specs for database state management
 - Use `if` for conditional handling, `ifClick` to dismiss optional elements, and `warnIf` for flagging unexpected paths

--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -80,6 +80,27 @@ learner:
 
 The pattern is a **case-insensitive substring** by default, or a `/regex/flags` literal for finer control. Each call claims a **single** error (the earliest unclaimed match for that actor), so write one `expectConsoleError` per console message a failure emits — a failed request that logs both a resource error and an uncaught exception needs two.
 
+#### Named aliases
+
+Like selector aliases, you can name the console errors a suite expects in config, so specs read in domain terms instead of repeating brittle message fragments:
+
+```ts
+// scenetest/config.ts
+export default defineConfig({
+  consoleErrorAliases: {
+    'bad-password': 'Invalid login credentials',
+    'not-found': /status of 404/,
+  },
+})
+```
+
+```scenetest
+- expectConsoleError bad-password     # bare name resolves to the alias
+- expectConsoleError ~bad-password    # explicit ~ form — errors on a typo
+```
+
+A bare argument that exactly matches an alias name resolves to its pattern; otherwise it's treated as a literal substring. Prefix with `~` to force alias resolution (a `~typo` that names no alias throws, catching mistakes early).
+
 **Selector resolution is strict.** Selectors resolve against the current scope only; if nothing matches, you get a diagnostic error naming the action, the selector, and the scope rather than a silent fallback. If you need to reach an element outside the current scope, widen with `up` or `prev` first. If multiple elements match in scope, resolution is also strict — disambiguate with an Nth-element token (`#1`, `#2`, `#3`…) appended to the selector.
 
 ### Nested selectors

--- a/docs/public/reference/text-dsl.md
+++ b/docs/public/reference/text-dsl.md
@@ -22,6 +22,9 @@ Assertions (do NOT change scope):
   notSee <selector>               Wait for element hidden
   seeText <text>                  Wait for text visible
   seeToast <selector>             Wait for element appear then disappear
+  expectConsoleError <pattern>    Wait for an expected console error / uncaught
+                                  exception (substring or /regex/) — a success,
+                                  and kept out of the run's error surface
 
 Scope:
   scope <selector>                Wait for element visible and SET it as scope
@@ -54,9 +57,28 @@ Control:
 |----------|---------|--------------|
 | **Changes scope** | `scope`, `up`, `prev` | `scope` pushes onto the scope stack and narrows. `up` widens — bare `up` resets to page root, `up <selector>` climbs to a matching ancestor. `prev` pops the stack, returning to the previous scope. |
 | **Resets scope** | `openTo`, `reload`, `goBack`, `goForward`, `switchDevice` | Clears scope entirely — back to page root. |
-| **Leaves scope alone** | `click`, `ifClick`, `see`, `seeInView`, `notSee`, `seeText`, `seeToast`, `typeInto`, `check`, `select`, `wait`, `emit`, `waitFor`, `pressKey`, `warnIf`, `scrollToBottom` | Scope stays where it is. Even when `click` causes navigation, the scope stack is left intact; the runtime walks up to the nearest surviving ancestor before the next action. |
+| **Leaves scope alone** | `click`, `ifClick`, `see`, `seeInView`, `notSee`, `seeText`, `seeToast`, `expectConsoleError`, `typeInto`, `check`, `select`, `wait`, `emit`, `waitFor`, `pressKey`, `warnIf`, `scrollToBottom` | Scope stays where it is. Even when `click` causes navigation, the scope stack is left intact; the runtime walks up to the nearest surviving ancestor before the next action. |
 
 **`see` vs `scope`:** `see` is a pure assertion — it checks that an element is visible but does not narrow scope. Use `scope` when you need subsequent actions (like `typeInto` or `check`) to resolve within a specific container.
+
+### Expecting console errors
+
+Scenetest captures browser console errors and uncaught exceptions and surfaces them at the end of a run. But sometimes a scene *wants* one — logging in with the wrong password should make the server return a `400`, and it would be a bug if it didn't. `expectConsoleError <pattern>` asserts that such an error happens: it waits (up to the action timeout) for a captured error matching `<pattern>`, marks it **expected**, and fails the scene if none arrives.
+
+Expected errors are reported as a success (`✓ N expected console error(s)`) and are excluded from the `🔴 browser console error(s)` surface and the run summary's error count.
+
+```scenetest
+learner:
+- openTo /login
+- typeInto email learner@test.com
+- typeInto password wrong-password
+- click sign-in
+- expectConsoleError Invalid login credentials
+- expectConsoleError /status of 4\d\d/
+- seeText Wrong email or password
+```
+
+The pattern is a **case-insensitive substring** by default, or a `/regex/flags` literal for finer control. Each call claims a **single** error (the earliest unclaimed match for that actor), so write one `expectConsoleError` per console message a failure emits — a failed request that logs both a resource error and an uncaught exception needs two.
 
 **Selector resolution is strict.** Selectors resolve against the current scope only; if nothing matches, you get a diagnostic error naming the action, the selector, and the scope rather than a silent fallback. If you need to reach an element outside the current scope, widen with `up` or `prev` first. If multiple elements match in scope, resolution is also strict — disambiguate with an Nth-element token (`#1`, `#2`, `#3`…) appended to the selector.
 

--- a/examples/react/scenetest/config.ts
+++ b/examples/react/scenetest/config.ts
@@ -19,6 +19,12 @@ export default defineConfig({
   timeout: 30000,
   actionTimeout: 5000,
 
+  // Name the console errors our scenes deliberately trigger, so specs can
+  // claim them by domain term: `expectConsoleError name-taken`.
+  consoleErrorAliases: {
+    'name-taken': 'already in use',
+  },
+
   server: {
     validateEmail: (email: string): boolean => {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/

--- a/examples/react/scenetest/scenes/basic.spec.ts
+++ b/examples/react/scenetest/scenes/basic.spec.ts
@@ -25,3 +25,23 @@ test('user can update their name', async ({ actor }) => {
   // Should see the updated display
   await user.seeText('New Name')
 })
+
+test('saving a reserved name triggers an expected console error', async ({ actor }) => {
+  const user = await actor('user')
+
+  await user.openTo('/')
+
+  // The server rejects the reserved name "taken" with a 409, which the app
+  // logs to the console. expectConsoleError asserts that error happened (and
+  // fails the scene if it didn't), instead of it surfacing as a problem.
+  // "name-taken" resolves to the alias defined in scenetest/config.ts; you can
+  // also pass a raw substring or a RegExp.
+  await user
+    .see('name-input')
+    .typeInto('name-input', 'taken')
+    .click('submit-button')
+    .expectConsoleError('name-taken')
+    .see('error')
+
+  await user.seeText('already in use')
+})

--- a/examples/react/scenetest/scenes/expected-errors.spec.md
+++ b/examples/react/scenetest/scenes/expected-errors.spec.md
@@ -1,0 +1,20 @@
+# Expected Errors
+
+A scene can deliberately exercise an error path and assert the resulting
+browser console error with `expectConsoleError`. The error is then reported as
+a success — and the scene *fails* if it doesn't happen.
+
+Saving a reserved name makes the (simulated) server reject the update with a
+409, which the app logs to the console. The `name-taken` alias is defined in
+`scenetest/config.ts`, so the spec reads in domain terms.
+
+## saving a reserved name surfaces a friendly error
+
+user:
+- openTo /
+- see name-input
+- typeInto name-input taken
+- click submit-button
+- expectConsoleError name-taken
+- see error
+- seeText already in use

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -142,8 +142,12 @@ function ProfileForm() {
           setTimeout(() => runAssertions('settled'), 100)
         },
         onError: (err) => {
-          setError(err instanceof Error ? err.message : 'Update failed')
-          failed('mutation failed with error', { error: err instanceof Error ? err.message : String(err) })
+          const message = err instanceof Error ? err.message : 'Update failed'
+          setError(message)
+          // Surface the failure to the browser console, like a real app would.
+          // A scene exercising this path asserts it with expectConsoleError
+          // rather than seeing it flagged as an unexpected error.
+          console.error('Profile update failed:', message)
         },
       }
     )

--- a/examples/react/src/hooks.ts
+++ b/examples/react/src/hooks.ts
@@ -39,6 +39,12 @@ export function useUpdateProfile() {
       // Simulate network delay
       await new Promise((resolve) => setTimeout(resolve, 200))
 
+      // Simulate a server-side rejection for a reserved name. This is a
+      // deliberate error path — a scene can assert it with expectConsoleError.
+      if (updates.name?.toLowerCase() === 'taken') {
+        throw new Error('the name "taken" is already in use (409)')
+      }
+
       const current = getProfileFromDb()
       const updated = saveProfileToDb({ ...current, ...updates })
       return updated

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -14,7 +14,10 @@
     "e2e",
     "playwright",
     "cli",
-    "assertions"
+    "assertions",
+    "scene-authoring",
+    "team-configuration",
+    "tanstack-intent"
   ],
   "bin": {
     "scenetest": "./dist/cli.js"
@@ -30,7 +33,9 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "skills",
+    "!skills/_artifacts"
   ],
   "publishConfig": {
     "access": "public"
@@ -40,7 +45,8 @@
     "typecheck": "tsc --noEmit",
     "dev": "tsc --watch",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "skills:validate": "intent validate"
   },
   "dependencies": {
     "@scenetest/checks": "workspace:*",
@@ -54,7 +60,8 @@
     "typescript": "^5.3.0",
     "@types/node": "^20.10.0",
     "vite": "^6.4.2",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "@tanstack/intent": "^0.0.41"
   },
   "peerDependencies": {
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/packages/scenes/skills/scene-authoring/SKILL.md
+++ b/packages/scenes/skills/scene-authoring/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: scene-authoring
+description: >-
+  Use when writing, reviewing, or generating Scenetest scene specs — the
+  orchestration scripts that simulate user journeys (open a page, fill a form,
+  click, assert what's on screen) with one or more concurrent actors. Covers the
+  three authoring models (`.spec.md` markdown, `scene()` reactive TypeScript,
+  and `test()` classic await-driven), the full actor DSL (navigation,
+  observation, scope, interaction, coordination, conditionals), selector
+  resolution and aliases, multi-actor coordination with emit/waitFor,
+  `expectConsoleError` for deliberate error paths, and the `.spec.md` format
+  (interpolation, cleanup/setup, macros). Apply whenever a task adds or edits
+  files under `scenetest/scenes/` (`*.spec.md` or `*.spec.ts`). For actor teams
+  and seed data, see the team-configuration skill; for `should()`/`failed()`
+  inside app code, see @scenetest/checks#inline-assertions.
+---
+
+# Writing Scenetest Scenes
+
+A **scene** orchestrates a user journey through the app under test: it drives one
+or more **actors** (each a real browser context) to navigate, interact, and
+observe. Scenes live in `scenetest/scenes/**/*.spec.md` or `**/*.spec.ts` and are
+run by the `scenetest` CLI. They test *journeys*; `should()`/`failed()` inside
+app code test *internal invariants* (a separate skill).
+
+Actors are referenced by **role name** (`actor('learner')`), resolved from the
+configured teams — see the team-configuration skill. Roles are story-driven
+(`primary-learner`, `existing-friend`), never generic (`user`).
+
+## Three authoring models
+
+All three share the same DSL, selectors, config, and teams — they differ only in
+syntax and execution model.
+
+| Model | File | Entry | Execution |
+| --- | --- | --- | --- |
+| **Markdown** | `.spec.md` | compiles to `scene()` | reactive, concurrent |
+| **TypeScript scene** | `.spec.ts` | `scene()` | reactive, concurrent — **not awaited** |
+| **Playwright spec** | `.spec.ts` | `test()` | classic — **`await` every step** |
+
+```ts
+// scene() — reactive. Calls QUEUE actions; the runner drains all actors
+// concurrently. actor() is synchronous, DSL calls are NOT awaited.
+import { scene } from '@scenetest/scenes'
+
+scene('user completes onboarding', ({ actor }) => {
+  const user = actor('new-user')
+  user.openTo('/').see('welcome-box').click('continue-button')
+  user.see('onboarding-step')
+})
+```
+
+```ts
+// test() — classic. actor() is awaited; every step is awaited, top to bottom.
+import { test } from '@scenetest/scenes'
+
+test('user completes onboarding', async ({ actor }) => {
+  const user = await actor('new-user')
+  await user.openTo('/')
+  await user.see('welcome-box').click('continue-button')
+  await user.see('onboarding-step')
+})
+```
+
+```scenetest
+# user completes onboarding
+new-user:
+- openTo /
+- see welcome-box
+- click continue-button
+- see onboarding-step
+```
+
+**Pick markdown by default** — it's the simplest way to write a multi-actor spec.
+Use `scene()` when you need TypeScript (loops, computed values). Use `test()`
+when you want the familiar sequential `await` model.
+
+## Actor DSL
+
+Methods are chainable. The same set is available in all three models (in the text
+DSL, the method name is the verb and its arguments follow).
+
+**Navigation** — reset scope to page root:
+- `openTo(url)` — navigate to a URL
+- `reload()` / `goBack()` / `goForward()` — history
+- `switchDevice(name?)` — new browser context with different device emulation (drops cookies/localStorage; tests server-state pickup)
+
+**Observation** — assert only, never change scope:
+- `see(selector)` — wait for element visible (falls back to page root)
+- `seeInView(selector)` — visible **and** in the viewport (no scroll)
+- `notSee(selector)` — wait for element hidden/detached
+- `seeText(text)` — wait for text visible
+- `seeToast(selector)` — wait for element to appear **then disappear** (toasts)
+- `expectConsoleError(pattern)` — assert an expected console error (see below)
+
+**Scope** — narrow where selectors resolve:
+- `scope(selector)` — wait for element and set it as the current scope
+- `up(selector?)` — widen: bare `up` → page root, `up <selector>` → matching ancestor
+- `prev()` — pop back to the previous scope
+
+**Interaction** — resolve within the current scope (strict — no root fallback):
+- `click(selector?)` — bare `click` clicks the current scope
+- `ifClick(selector)` — click if visible, else skip silently
+- `typeInto(selector, value)` — fill an input (replaces content)
+- `check(selector)` — check a checkbox
+- `select(selector, value)` — choose a dropdown option
+- `pressKey(key)` — raw keyboard event (Playwright key name: `Escape`, `Enter`, `Tab`)
+
+**Coordination & control:**
+- `emit(message)` — publish a message on the shared bus (sticky)
+- `waitFor(message)` — block this actor until the message arrives
+- `wait(ms)` — fixed delay (prefer `see`/`waitFor` over `wait`)
+- `warnIf(selector, message)` — record a script warning if the selector appears
+- `scrollToBottom()` — scroll the current scope to the bottom
+
+**TypeScript-only** (`scene()` / `test()`, not the text DSL):
+- `do(async (page) => { … })` — run arbitrary Playwright code inline in the queue
+- `if(selector, actor => { … })` — run sub-actions only if the selector is present
+- `dsl(text)` — parse and queue a multiline text-DSL string
+
+### Scope, briefly
+
+`see` checks visibility but leaves scope alone; `scope` narrows it. `click`,
+`typeInto`, etc. resolve **strictly** within the current scope — if nothing
+matches you get a diagnostic naming the action, selector, and scope, not a silent
+pass. Widen with `up`/`prev` to reach outside the current scope.
+
+## Selectors
+
+A bare token resolves against these attributes, in order:
+`aria-label` → `id` → `data-testid` → `data-name` → `data-key` → `name`.
+
+- **Nested:** space-separated tokens descend — `modal search-input` = `search-input` within `modal`.
+- **Key selector:** `['playlist-row', '12345']` (JSON in the text DSL) targets a `data-key`.
+- **`@label`** — force an exact `aria-label` match: `@Confirm`.
+- **`~name`** — a selector alias defined in config's `aliases` map: `~modal`.
+- **Nth match:** append `#1`/`#2`/… to disambiguate when several elements match in scope.
+
+Prefer `aria-label` for interactive elements (accessible **and** a stable selector).
+
+## Multi-actor coordination
+
+Actors run concurrently. Synchronize them with `emit`/`waitFor` on the shared
+message bus — messages are sticky, so order between actors doesn't matter:
+
+```scenetest
+## sender and receiver exchange a message
+
+sender:
+- openTo /compose
+- typeInto body Hello!
+- click send
+- emit message-sent
+
+receiver:
+- waitFor message-sent
+- openTo /inbox
+- seeText New message
+```
+
+In `.spec.md`, each `role:` block under a `##` scene declares that actor's
+timeline; blocks run concurrently and re-referencing a role continues its script.
+
+## Expecting console errors
+
+When a scene deliberately triggers an error (wrong-password login, invalid
+submit), the server *should* return an error — and Scenetest would otherwise flag
+the resulting console error as a problem. `expectConsoleError(pattern)` declares
+it a success: it waits (up to the action timeout) for a captured browser console
+error / uncaught exception matching `pattern`, marks it **expected**, and **fails
+the scene if none appears**.
+
+```scenetest
+learner:
+- typeInto password wrong-password
+- click sign-in
+- expectConsoleError bad-password        # a config alias (recommended)
+- expectConsoleError /status of 4\d\d/   # or a /regex/
+- seeText Wrong email or password
+```
+
+- `pattern` is a **case-insensitive substring**, a `/regex/` (text DSL) or a
+  `RegExp` (TypeScript), or the name of a `consoleErrorAliases` entry from config
+  (`~name` forces alias resolution and throws on a typo).
+- Each call claims **one** error (the earliest unclaimed match for that actor), so
+  add one line per console message a failure emits — a failed request that logs
+  both a resource error and an uncaught exception needs two.
+
+Expected errors report as `✓ N expected console error(s)`, kept out of the
+`🔴 browser console error(s)` surface. Define aliases once in config — see the
+team-configuration skill.
+
+## `.spec.md` format
+
+- `#` heading → **scene group**; `##` heading → **scene name**. (A single-level
+  file where each `#`/`##` is a scene also works.)
+- `role:` on its own line opens that actor's block; actions follow as `- ` list
+  items (ordered `1.` lists and bare lines work too). `role: openTo /` puts the
+  first action inline.
+- `//` lines are comments (they echo into the run log). Note `#`/`##` are
+  **headings**, not comments.
+- **Interpolation:** `[role.field]` injects an actor's config field —
+  `typeInto email [learner.email]`, `see deck-[learner.key]`. `[self.field]`
+  refers to the current actor (inside a macro), `[team.field]` to team metadata.
+- **`cleanup:` / `setup:`** directives (before the actor cues) run DB
+  setup/teardown for that scene — see the team-configuration skill.
+- **Macros:** any first word that isn't a known verb is a macro call, e.g.
+  `login() [learner.email] [learner.password]`. Define macros in a `.ts` file
+  with `defineMacro('login', ['openTo /login', 'typeInto email [self.email]', …])`.
+  Built-ins (`login`, `logout`, `accept-cookies`, `refresh-and-retry`) are
+  enabled with `builtinMacros: true` in config.
+
+```scenetest
+## learner reviews a deck
+
+cleanup: db.from('reviews').delete().eq('uid', '[learner.key]')
+
+learner:
+- login() [learner.email] [learner.password]
+- openTo /decks
+- click deck-[learner.key]
+- see ~modal review-panel
+- seeToast saved
+```
+
+## Best practices
+
+- **Wait on state, not time.** Prefer `see` / `seeText` / `waitFor` over `wait <ms>`.
+- **Assert what the user perceives** — `seeText`, `see`, `seeToast` — not internals.
+- **Name roles by story**, and only reference roles your teams actually provide.
+- **`scope` before a burst** of actions inside one container; `prev`/`up` to leave.
+- **Deliberate error paths** use `expectConsoleError`, not a bare console error.
+- **Coordinate** cross-actor ordering with `emit`/`waitFor`, never `wait`.
+
+## Quick reference
+
+| Category | Verbs |
+| --- | --- |
+| Navigation | `openTo` `reload` `goBack` `goForward` `switchDevice` |
+| Observation | `see` `seeInView` `notSee` `seeText` `seeToast` `expectConsoleError` |
+| Scope | `scope` `up` `prev` |
+| Interaction | `click` `ifClick` `typeInto` `check` `select` `pressKey` |
+| Coordination | `emit` `waitFor` `wait` `warnIf` `scrollToBottom` |
+| Code-only | `do(fn)` `if(sel, cb)` `dsl(text)` |

--- a/packages/scenes/skills/team-configuration/SKILL.md
+++ b/packages/scenes/skills/team-configuration/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: team-configuration
+description: >-
+  Use when setting up or auditing Scenetest actor teams, credentials, seed data,
+  auth warmup, and run configuration — everything under `scenetest/` that a
+  scene depends on but isn't the scene itself. Covers the `scenetest/actors/`
+  team files (`TeamConfig` / `defineTeam`), the `ActorConfig` shape (key,
+  credentials, localStorage, warmup), how teams map 1:1 to seed data, how N
+  teams give N parallel scenes, warmup-based auth caching, per-scene DB
+  `cleanup:`/`setup:` directives, config hooks (beforeAll/beforeEach), and the
+  `scenetest/config.ts` fields (baseUrl, aliases, consoleErrorAliases,
+  errorSelectors, server). Apply whenever a task touches `scenetest/config.ts`,
+  `scenetest/actors/**`, seed data, or asks "add a role / team / login".
+  For writing the scenes themselves, see the scene-authoring skill.
+---
+
+# Configuring Scenetest Teams & Seed Data
+
+A **team** is a complete, internally-consistent set of actors — one self-contained
+"world" a scene runs in. Scenes reference actors by **role** (`actor('learner')`);
+teams supply the credentials and identity behind each role. Get teams right and
+scenes run reliably, concurrently, and without shared-state bugs.
+
+```
+scenetest/
+├── config.ts          # run config (baseUrl, aliases, hooks, server) — NO actors
+├── actors/            # one team per file (auto-discovered)
+│   ├── team-maria.ts
+│   └── team-john.ts
+└── scenes/            # *.spec.md / *.spec.ts
+```
+
+## Actor teams live in `scenetest/actors/`
+
+The `actors/` directory is **required**. Each `.ts`/`.js`/`.mjs` file's default
+export is a team (or an array of teams). The config file itself defines **no**
+actors.
+
+```ts
+// scenetest/actors/team-maria.ts
+import type { TeamConfig } from '@scenetest/scenes'
+
+export default {
+  'primary-learner': {
+    key: 'maria',                 // stable per-actor id (reports + [role.key])
+    email: 'maria@test.com',
+    password: 'test123',
+    targetLanguage: 'spanish',    // arbitrary extra fields are allowed
+  },
+  'existing-friend': {
+    key: 'carlos',
+    email: 'carlos@test.com',
+    password: 'test123',
+  },
+} satisfies TeamConfig
+```
+
+`TeamConfig` is `Record<roleName, ActorConfig>`. Alternatives:
+
+- **Array export** — several teams in one file: `export default [ {...}, {...} ] satisfies TeamConfig[]`.
+- **`defineTeam`** — attach metadata: `export default defineTeam({ actors: {...}, name: 'maria', tags: { plan: 'pro' } })`. `name` backs the `--team` filter; `tags` are readable in specs via `[team.field]`.
+
+### `ActorConfig` fields
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `key` | `string` (**required**) | Stable identifier — appears in reports and `[role.key]` interpolation. Keep it unique per real user. |
+| `username` / `email` / `password` | `string?` | Login credentials — whatever your app authenticates with. |
+| `localStorage` | `Record<string,string>?` | Entries injected into the actor's browser **before each scene**. |
+| `warmup` | `string \| (page, actor) => Promise<void>` | Runs **once at run start** to capture auth state — see below. |
+| *(any extra)* | `unknown` | Pre-existing knowledge the actor "knows" (language, country…), readable via `[role.field]`. |
+
+**What goes in actor config:** credentials + pre-existing knowledge. **Not**
+database IDs or internal state — the actor discovers everything else through the
+app. Passwords are **fixtures, not secrets** — use one obviously-fake value like
+`test123` everywhere and assume it's public.
+
+## Teams mirror your seed data
+
+Every relationship a scene relies on must already exist in the database. The
+actor files only provide credentials; **your seed data is the source of truth**
+for what relationships exist.
+
+```
+seed: users(maria), users(carlos), friendships(maria, carlos)
+team: 'primary-learner' → maria,  'existing-friend' → carlos
+```
+
+If a scene calls `actor('existing-friend')` expecting a friendship with
+`primary-learner`, that friendship must be seeded. Name roles by their **story**
+(`primary-learner`, `existing-friend`, `random-stranger`, `new-signup`), never
+generically (`user`, `admin`).
+
+- **Every role** referenced by any scene must exist in **every** team.
+- **Each team is self-contained** — no actor (real user) appears in two teams.
+- **Anonymous actors** (logged-out / signup flows) can have empty or partial
+  credentials: `'visitor': { key: 'visitor' }`.
+
+## N teams = N parallel scenes
+
+Concurrency is team-based: each scene acquires **exclusive** use of one team, so
+N teams run N scenes in parallel with no shared state or races. To add
+concurrency, add more team files with different real users who have the **same**
+relationships seeded (`pierre` is to `john` as `carlos` is to `maria`).
+
+- **1 team** — scenes run sequentially. Fine to start.
+- **2–3 teams** — good for most projects.
+- **N teams** — match CI parallelism; more teams = more seed data to maintain.
+
+A scene that needs specific roles waits for a team that provides them, so teams
+may be heterogeneous — but keeping every team role-complete is simplest.
+
+## Seeding auth state with `warmup`
+
+`warmup` performs a login (or any setup) **once per actor at run start**, captures
+the resulting `storageState` (cookies + localStorage), and reuses it for every
+scene that actor appears in — so scenes start already authenticated instead of
+logging in each time. Results are cached and deduplicated by the actor's `key`.
+
+```ts
+'primary-learner': {
+  key: 'maria',
+  email: 'maria@test.com',
+  password: 'test123',
+  // Function form — full control:
+  warmup: async (page, actor) => {
+    await page.goto('/login')
+    await page.getByLabel('Email').fill(actor.email!)
+    await page.getByLabel('Password').fill(actor.password!)
+    await page.getByRole('button', { name: 'Sign in' }).click()
+    await page.waitForURL('**/dashboard')
+  },
+  // Or the macro form — `warmup: 'login'` runs a named macro
+  // (supports openTo, see, seeText, click, typeInto, wait; interpolates [self.field]).
+},
+```
+
+For non-auth client state, `localStorage` is merged into each scene's context
+(actor entries override warmup entries), letting you preset flags without a login.
+
+## Per-scene DB state: `cleanup:` / `setup:`
+
+Inside a `.spec.md`, directives before the actor cues run **server-side**
+expressions (with the config `server` object in scope) to prepare and clean up
+that scene's data. Execution order per scene: **`cleanup` (before) → `setup` →
+scene steps → `cleanup` (after)**. The `[testStart]` token and `[role.key]`
+interpolate into these expressions.
+
+```scenetest
+## learner creates a deck
+
+cleanup: db.from('decks').delete().eq('uid', '[learner.key]')
+setup:   db.from('decks').insert({ uid: '[learner.key]', name: 'starter' })
+
+learner:
+- openTo /decks
+- see deck-[learner.key]
+```
+
+## Run-wide setup: config hooks
+
+For setup that isn't per-scene, use the lifecycle hooks in `scenetest/config.ts`:
+
+```ts
+export default defineConfig({
+  baseUrl: 'http://localhost:5173',
+  beforeAll: async () => { /* migrate + seed the test DB */ },
+  afterAll:  async () => { /* drop / reset */ },
+  beforeEach: async (scene) => { /* scene.name, scene.file */ },
+  afterEach:  async (scene, report) => { /* inspect report */ },
+})
+```
+
+## `scenetest/config.ts` reference
+
+`defineConfig({ … })`. Fields most relevant to teams, seeding, and scenes:
+
+| Field | Purpose |
+| --- | --- |
+| `baseUrl` | App URL (required for the CLI). Actor `localStorage` seeds under this origin. |
+| `server` | Object exposed to `serverCheck()` and `cleanup:`/`setup:` expressions. Type it with `declare module '@scenetest/checks' { interface ServerContext {…} }`. |
+| `aliases` | Selector aliases (`~name` in scenes) → CSS/`aria-label`. |
+| `consoleErrorAliases` | Named console errors for `expectConsoleError <name>` — `{ 'bad-password': 'Invalid login credentials' }` (value: substring or RegExp). |
+| `errorSelectors` | `{ selector, message }[]` watched across all scenes; a match records a console error. |
+| `consoleErrors` | `true`/`'error'`/`'warn'`/`false` — which console output to capture (default: errors). |
+| `timeout` / `actionTimeout` / `warnAfter` | Scene timeout (30000), per-action timeout (5000), slow-action warning (500). |
+| `browser` / `headed` / `devices` | `'chromium'\|'firefox'\|'webkit'`; visible browser; device rotation. |
+| `builtinMacros` | `true` or a name list — enable built-in macros (`login`, `logout`, …). |
+| `reportDir` / `reportFormat` | Where/how run reports are written (`'json'` default, `./scenetest/.reports`). |
+| Hooks | `beforeAll` / `afterAll` / `beforeEach(scene)` / `afterEach(scene, report)`. |
+
+## Checklist
+
+- Every `actor('role')` referenced by a scene exists in **every** team.
+- Every actor's credentials match a user in **seed data**; relationships are seeded.
+- Each team is self-contained (no shared real users across teams).
+- Roles are story-driven; anonymous actors only appear in no-login scenes.
+- `key` is set, stable, and unique per real user.
+- Auth-heavy suites use `warmup` so scenes start logged in.
+- Per-scene data churn uses `cleanup:`/`setup:`; run-wide setup uses `beforeAll`.

--- a/packages/scenes/src/__tests__/console-errors.test.ts
+++ b/packages/scenes/src/__tests__/console-errors.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import {
   consoleErrorMatches,
   claimConsoleError,
   waitForConsoleError,
   parseConsoleErrorPattern,
   describeMissingConsoleError,
+  setConsoleErrorAliases,
+  clearConsoleErrorAliases,
+  resolveConsoleErrorPattern,
 } from '../console-errors.js'
 import type { ConsoleError } from '../types.js'
 
@@ -96,6 +99,41 @@ describe('parseConsoleErrorPattern', () => {
 
   it('falls back to a literal when the regex body is invalid', () => {
     expect(parseConsoleErrorPattern('/(/')).toBe('/(/')
+  })
+})
+
+describe('resolveConsoleErrorPattern (aliases)', () => {
+  afterEach(() => clearConsoleErrorAliases())
+
+  it('resolves a bare name that matches a defined alias', () => {
+    setConsoleErrorAliases({ 'bad-password': 'Invalid login credentials' })
+    expect(resolveConsoleErrorPattern('bad-password')).toBe('Invalid login credentials')
+  })
+
+  it('resolves a RegExp alias', () => {
+    const re = /status of 4\d\d/
+    setConsoleErrorAliases({ 'client-error': re })
+    expect(resolveConsoleErrorPattern('client-error')).toBe(re)
+  })
+
+  it('resolves an explicit ~name reference', () => {
+    setConsoleErrorAliases({ 'bad-password': 'Invalid login credentials' })
+    expect(resolveConsoleErrorPattern('~bad-password')).toBe('Invalid login credentials')
+  })
+
+  it('throws on an unknown ~name reference', () => {
+    setConsoleErrorAliases({ 'bad-password': 'Invalid login credentials' })
+    expect(() => resolveConsoleErrorPattern('~typo')).toThrow(/Unknown console-error alias: typo/)
+  })
+
+  it('passes through a literal substring that is not an alias', () => {
+    setConsoleErrorAliases({ 'bad-password': 'Invalid login credentials' })
+    expect(resolveConsoleErrorPattern('Failed to load resource')).toBe('Failed to load resource')
+  })
+
+  it('passes a RegExp argument through unchanged', () => {
+    const re = /4\d\d/
+    expect(resolveConsoleErrorPattern(re)).toBe(re)
   })
 })
 

--- a/packages/scenes/src/__tests__/console-errors.test.ts
+++ b/packages/scenes/src/__tests__/console-errors.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import {
+  consoleErrorMatches,
+  claimConsoleError,
+  waitForConsoleError,
+  parseConsoleErrorPattern,
+  describeMissingConsoleError,
+} from '../console-errors.js'
+import type { ConsoleError } from '../types.js'
+
+function err(partial: Partial<ConsoleError> & { message: string }): ConsoleError {
+  return {
+    actor: 'learner',
+    timestamp: 0,
+    type: 'error',
+    source: 'console',
+    ...partial,
+  }
+}
+
+describe('consoleErrorMatches', () => {
+  it('matches strings as case-insensitive substrings', () => {
+    expect(consoleErrorMatches('Invalid login credentials', 'invalid LOGIN')).toBe(true)
+    expect(consoleErrorMatches('all good', 'invalid')).toBe(false)
+  })
+
+  it('matches RegExp patterns as given', () => {
+    expect(consoleErrorMatches('status of 400 (Bad Request)', /status of 4\d\d/)).toBe(true)
+    expect(consoleErrorMatches('status of 200', /status of 4\d\d/)).toBe(false)
+  })
+})
+
+describe('claimConsoleError', () => {
+  it('claims the earliest unclaimed matching error for the actor', () => {
+    const errors = [
+      err({ message: 'status of 400', timestamp: 20 }),
+      err({ message: 'status of 400', timestamp: 10 }),
+    ]
+    const claimed = claimConsoleError(errors, 'learner', '400')
+    expect(claimed?.timestamp).toBe(10)
+    expect(errors[1].expected).toBe(true)
+    expect(errors[0].expected).toBeUndefined()
+  })
+
+  it('claims only one error per call (first match only)', () => {
+    const errors = [
+      err({ message: 'status of 400', timestamp: 10 }),
+      err({ message: 'status of 400', timestamp: 20 }),
+    ]
+    claimConsoleError(errors, 'learner', '400')
+    const second = claimConsoleError(errors, 'learner', '400')
+    expect(second?.timestamp).toBe(20)
+    expect(errors.every((e) => e.expected)).toBe(true)
+  })
+
+  it('does not claim errors from a different actor', () => {
+    const errors = [err({ message: 'status of 400', actor: 'teacher' })]
+    expect(claimConsoleError(errors, 'learner', '400')).toBeNull()
+    expect(errors[0].expected).toBeUndefined()
+  })
+
+  it('returns null when nothing matches', () => {
+    const errors = [err({ message: 'all good' })]
+    expect(claimConsoleError(errors, 'learner', '400')).toBeNull()
+  })
+})
+
+describe('waitForConsoleError', () => {
+  it('resolves once a matching error arrives in the shared buffer', async () => {
+    const errors: ConsoleError[] = []
+    const pending = waitForConsoleError(errors, 'learner', 'Invalid login', 1000, 5)
+    setTimeout(() => errors.push(err({ message: 'Invalid login credentials' })), 15)
+    const claimed = await pending
+    expect(claimed?.message).toBe('Invalid login credentials')
+    expect(errors[0].expected).toBe(true)
+  })
+
+  it('resolves null when no matching error arrives before the timeout', async () => {
+    const errors: ConsoleError[] = [err({ message: 'unrelated' })]
+    const claimed = await waitForConsoleError(errors, 'learner', '400', 30, 5)
+    expect(claimed).toBeNull()
+  })
+})
+
+describe('parseConsoleErrorPattern', () => {
+  it('returns a literal string for plain text', () => {
+    expect(parseConsoleErrorPattern('Invalid login credentials')).toBe('Invalid login credentials')
+  })
+
+  it('parses /pattern/flags into a RegExp', () => {
+    const p = parseConsoleErrorPattern('/status of 4\\d\\d/i')
+    expect(p).toBeInstanceOf(RegExp)
+    expect((p as RegExp).source).toBe('status of 4\\d\\d')
+    expect((p as RegExp).flags).toBe('i')
+  })
+
+  it('falls back to a literal when the regex body is invalid', () => {
+    expect(parseConsoleErrorPattern('/(/')).toBe('/(/')
+  })
+})
+
+describe('describeMissingConsoleError', () => {
+  it('lists the unclaimed errors actually seen for the actor', () => {
+    const errors = [
+      err({ message: 'something else happened' }),
+      err({ message: 'claimed already', expected: true }),
+    ]
+    const msg = describeMissingConsoleError(errors, 'learner', '400', 5000)
+    expect(msg).toContain('no console error matching "400"')
+    expect(msg).toContain('something else happened')
+    expect(msg).not.toContain('claimed already')
+  })
+
+  it('notes when nothing was captured', () => {
+    const msg = describeMissingConsoleError([], 'learner', /4\d\d/, 5000)
+    expect(msg).toContain('No unclaimed console errors were captured')
+  })
+})

--- a/packages/scenes/src/__tests__/dsl.test.ts
+++ b/packages/scenes/src/__tests__/dsl.test.ts
@@ -73,6 +73,7 @@ function createSpyTarget(): DslTarget & { calls: string[] } {
     notSee(s: string) { calls.push(`notSee:${s}`); return this },
     seeText(t: string) { calls.push(`seeText:${t}`); return this },
     seeToast(s: string) { calls.push(`seeToast:${s}`); return this },
+    expectConsoleError(p: string | RegExp) { calls.push(`expectConsoleError:${String(p)}`); return this },
     scope(s: string) { calls.push(`scope:${s}`); return this },
     click(s?: string) { calls.push(`click:${s ?? '(scope)'}`); return this },
     typeInto(s: string, v: string) { calls.push(`typeInto:${s}=${v}`); return this },
@@ -100,6 +101,15 @@ describe('parseAction', () => {
     expect(parseAction('seeText Hello World')).toEqual({ action: 'seeText', value: 'Hello World' })
     expect(parseAction('wait 500')).toEqual({ action: 'wait', value: '500' })
     expect(parseAction('emit user-ready')).toEqual({ action: 'emit', value: 'user-ready' })
+  })
+
+  it('parses expectConsoleError with a multi-word pattern', () => {
+    expect(parseAction('expectConsoleError Invalid login credentials')).toEqual({
+      action: 'expectConsoleError', value: 'Invalid login credentials',
+    })
+    expect(parseAction('expectConsoleError /status of 4\\d\\d/i')).toEqual({
+      action: 'expectConsoleError', value: '/status of 4\\d\\d/i',
+    })
   })
 
   it('parses selector-only actions (see, seeInView, notSee, click, check, seeToast, up, ifClick)', () => {
@@ -317,6 +327,21 @@ describe('applyDslAction', () => {
   it('throws when ifClick is missing selector', () => {
     const target = createSpyTarget()
     expect(() => applyDslAction(target, { action: 'ifClick' })).toThrow('ifClick requires a selector')
+  })
+
+  it('dispatches expectConsoleError, parsing literal and /regex/ patterns', () => {
+    const target = createSpyTarget()
+    applyDslAction(target, { action: 'expectConsoleError', value: 'Invalid login credentials' })
+    applyDslAction(target, { action: 'expectConsoleError', value: '/status of 4\\d\\d/i' })
+    expect(target.calls).toEqual([
+      'expectConsoleError:Invalid login credentials',
+      `expectConsoleError:${String(/status of 4\d\d/i)}`,
+    ])
+  })
+
+  it('throws when expectConsoleError is missing a pattern', () => {
+    const target = createSpyTarget()
+    expect(() => applyDslAction(target, { action: 'expectConsoleError' })).toThrow('expectConsoleError requires a pattern')
   })
 
   it('throws on unknown action', () => {

--- a/packages/scenes/src/__tests__/markdown-scene.test.ts
+++ b/packages/scenes/src/__tests__/markdown-scene.test.ts
@@ -592,6 +592,25 @@ see login-form
     expect(scenes[1].blocks[0].role).toBe('returning-user')
   })
 
+  it('parses expectConsoleError as a DSL action, not a macro', () => {
+    const content = `
+## wrong password shows an error
+
+learner:
+- click sign-in
+- expectConsoleError bad-password
+- seeText Wrong password
+`
+    const scenes = parseMarkdownScenes(content, '/test/expect-error.spec.md')
+    const actions = scenes[0].blocks[0].actions
+    const expectAction = actions.find(
+      (a) => a.type === 'action' && a.line.startsWith('expectConsoleError')
+    )
+    expect(expectAction).toBeDefined()
+    // It must NOT be misclassified as a macro invocation.
+    expect(actions.some((a) => a.type === 'macro')).toBe(false)
+  })
+
   it('parses cleanup: directive before actor cues', () => {
     const content = `
 ## learner creates a new deck

--- a/packages/scenes/src/__tests__/reactive.test.ts
+++ b/packages/scenes/src/__tests__/reactive.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ConcurrentActorHandleImpl, drainAll } from '../reactive.js'
 import { MessageBus } from '../message-bus.js'
-import type { TimelineEntry, ScriptWarning } from '../types.js'
+import type { TimelineEntry, ScriptWarning, ConsoleError } from '../types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers — minimal Playwright mocks
@@ -48,6 +48,7 @@ function createTestActor(
   const bus = overrides?.bus ?? new MessageBus()
   const timeline: TimelineEntry[] = []
   const warnings: ScriptWarning[] = []
+  const consoleErrors: ConsoleError[] = []
   const page = overrides?.page ?? mockPage()
 
   const actor = new ConcurrentActorHandleImpl(
@@ -57,12 +58,12 @@ function createTestActor(
     bus,
     timeline,
     warnings,
-    /* consoleErrors */ [],
+    consoleErrors,
     /* actionTimeout */ 5000,
     /* warnAfter */ 60000 // high so warnings don't fire during tests
   )
 
-  return { actor, bus, timeline, warnings, page }
+  return { actor, bus, timeline, warnings, consoleErrors, page }
 }
 
 /**
@@ -596,6 +597,59 @@ describe('drainAll', () => {
     expect(events.indexOf('alice-work')).toBeLessThan(
       events.indexOf('bob-after-alice')
     )
+  })
+})
+
+describe('expectConsoleError()', () => {
+  it('claims a matching error already in the buffer, marking it expected', async () => {
+    const { actor, consoleErrors } = createTestActor('learner')
+    consoleErrors.push({
+      message: 'Invalid login credentials',
+      actor: 'learner',
+      timestamp: Date.now(),
+      type: 'error',
+      source: 'pageerror',
+    })
+
+    actor.expectConsoleError('Invalid login credentials')
+    await drainAll([actor])
+
+    expect(consoleErrors[0].expected).toBe(true)
+  })
+
+  it('waits for an error that arrives after the action starts', async () => {
+    const { actor, consoleErrors } = createTestActor('learner')
+
+    actor.expectConsoleError(/status of 4\d\d/)
+    setTimeout(() => {
+      consoleErrors.push({
+        message: 'Failed to load resource: the server responded with a status of 400',
+        actor: 'learner',
+        timestamp: Date.now(),
+        type: 'error',
+        source: 'console',
+      })
+    }, 20)
+
+    await drainAll([actor])
+    expect(consoleErrors[0].expected).toBe(true)
+  })
+
+  it('aborts the scene when no matching error appears', async () => {
+    // Tiny action timeout so the wait fails fast.
+    const fast = new ConcurrentActorHandleImpl(
+      'learner',
+      { key: 'learner-1' },
+      mockPage() as any,
+      new MessageBus(),
+      [],
+      [],
+      [],
+      30,
+      60000
+    )
+    fast.expectConsoleError('never happens')
+    await expect(drainAll([fast])).rejects.toThrow(/no console error matching "never happens"/)
   })
 })
 

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -5,7 +5,7 @@ import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOptio
 import { MessageBus } from './message-bus.js'
 import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
-import { waitForConsoleError, describeMissingConsoleError } from './console-errors.js'
+import { waitForConsoleError, describeMissingConsoleError, resolveConsoleErrorPattern } from './console-errors.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
 import { settle } from './settle.js'
@@ -316,10 +316,11 @@ class ActionChainImpl implements ActionChain {
   expectConsoleError(pattern: string | RegExp): ActionChain {
     const target = typeof pattern === 'string' ? pattern : String(pattern)
     return this.addAction('expectConsoleError', target, async () => {
+      const resolved = resolveConsoleErrorPattern(pattern)
       const errors = this.actor.getConsoleErrors()
-      const claimed = await waitForConsoleError(errors, this.actor.role, pattern, this.actionTimeout)
+      const claimed = await waitForConsoleError(errors, this.actor.role, resolved, this.actionTimeout)
       if (!claimed) {
-        throw new Error(describeMissingConsoleError(errors, this.actor.role, pattern, this.actionTimeout))
+        throw new Error(describeMissingConsoleError(errors, this.actor.role, resolved, this.actionTimeout))
       }
     })
   }

--- a/packages/scenes/src/actor.ts
+++ b/packages/scenes/src/actor.ts
@@ -5,6 +5,7 @@ import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOptio
 import { MessageBus } from './message-bus.js'
 import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
+import { waitForConsoleError, describeMissingConsoleError } from './console-errors.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
 import { settle } from './settle.js'
@@ -309,6 +310,17 @@ class ActionChainImpl implements ActionChain {
       await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
       await locator.waitFor({ state: 'hidden', timeout: this.actionTimeout })
       // Don't update scope for toasts since they disappear
+    })
+  }
+
+  expectConsoleError(pattern: string | RegExp): ActionChain {
+    const target = typeof pattern === 'string' ? pattern : String(pattern)
+    return this.addAction('expectConsoleError', target, async () => {
+      const errors = this.actor.getConsoleErrors()
+      const claimed = await waitForConsoleError(errors, this.actor.role, pattern, this.actionTimeout)
+      if (!claimed) {
+        throw new Error(describeMissingConsoleError(errors, this.actor.role, pattern, this.actionTimeout))
+      }
     })
   }
 
@@ -872,6 +884,14 @@ export class SequentialActorHandleImpl implements SequentialActorHandle {
   }
 
   /**
+   * The session's shared console-error buffer (used by ActionChainImpl for
+   * `expectConsoleError()` to find and claim a matching error).
+   */
+  getConsoleErrors(): ConsoleError[] {
+    return this.consoleErrors
+  }
+
+  /**
    * Clear all registered watchers (called after each await)
    * Note: Warning triggers persist across the entire scene
    */
@@ -921,6 +941,10 @@ export class SequentialActorHandleImpl implements SequentialActorHandle {
 
   seeToast(selector: Selector): ActionChain {
     return this.createChain().seeToast(selector)
+  }
+
+  expectConsoleError(pattern: string | RegExp): ActionChain {
+    return this.createChain().expectConsoleError(pattern)
   }
 
   scope(selector: Selector): ActionChain {

--- a/packages/scenes/src/console-errors.ts
+++ b/packages/scenes/src/console-errors.ts
@@ -84,6 +84,65 @@ export function parseConsoleErrorPattern(text: string): string | RegExp {
   return text
 }
 
+// ─── Alias registry ──────────────────────────────────────────────────
+//
+// Like selector aliases, a scene config can name the console errors a suite
+// expects up front, so specs read in domain terms instead of repeating brittle
+// message fragments:
+//
+//   defineConfig({
+//     consoleErrorAliases: {
+//       'bad-password': 'Invalid login credentials',
+//       'not-found': /status of 404/,
+//     },
+//   })
+//
+//   - expectConsoleError bad-password     # bare name resolves to the alias
+//   - expectConsoleError ~bad-password    # explicit ~ form (errors on a typo)
+
+/** Map of alias name → console-error pattern (substring or RegExp). */
+export type ConsoleErrorAliases = Record<string, string | RegExp>
+
+let globalConsoleErrorAliases: ConsoleErrorAliases = {}
+
+/** Replace the global console-error alias registry (called from config). */
+export function setConsoleErrorAliases(aliases: ConsoleErrorAliases): void {
+  globalConsoleErrorAliases = aliases
+}
+
+/** Read the current console-error alias registry. */
+export function getConsoleErrorAliases(): ConsoleErrorAliases {
+  return globalConsoleErrorAliases
+}
+
+/** Clear all console-error aliases. */
+export function clearConsoleErrorAliases(): void {
+  globalConsoleErrorAliases = {}
+}
+
+/**
+ * Resolve an `expectConsoleError` argument against the alias registry:
+ * - a `RegExp` passes through unchanged;
+ * - a `~name` string is an explicit alias reference (throws if undefined);
+ * - a bare string that exactly names an alias resolves to its pattern;
+ * - anything else is returned as-is (a literal substring).
+ */
+export function resolveConsoleErrorPattern(pattern: string | RegExp): string | RegExp {
+  if (typeof pattern !== 'string') return pattern
+  if (pattern.startsWith('~')) {
+    const name = pattern.slice(1)
+    const resolved = globalConsoleErrorAliases[name]
+    if (resolved === undefined) {
+      const known = Object.keys(globalConsoleErrorAliases)
+      const hint = known.length ? ` Known aliases: ${known.join(', ')}.` : ''
+      throw new Error(`Unknown console-error alias: ${name}.${hint}`)
+    }
+    return resolved
+  }
+  const alias = globalConsoleErrorAliases[pattern]
+  return alias !== undefined ? alias : pattern
+}
+
 /**
  * Build the error thrown when an expected console error never arrives. Lists
  * the unclaimed errors actually seen for the actor, so the mismatch is obvious.

--- a/packages/scenes/src/console-errors.ts
+++ b/packages/scenes/src/console-errors.ts
@@ -1,0 +1,105 @@
+import type { ConsoleError } from './types.js'
+
+/**
+ * Console-error expectation matching.
+ *
+ * Browser console errors and uncaught exceptions are captured per scene (see
+ * `team-manager.ts`). Most of the time an error is a problem, but sometimes a
+ * scene *wants* one — "log in with the wrong password" should make the server
+ * return a 400, and it would be a bug if it didn't. `expectConsoleError()` lets
+ * a scene claim such an error: the matched entry is marked `expected`, so the
+ * reporter counts it as a success instead of surfacing it as a problem.
+ */
+
+/**
+ * Does a captured console-error message satisfy the expectation pattern?
+ * Strings match as case-insensitive substrings (forgiving for hand-written
+ * specs); RegExps are tested as given.
+ */
+export function consoleErrorMatches(message: string, pattern: string | RegExp): boolean {
+  return typeof pattern === 'string'
+    ? message.toLowerCase().includes(pattern.toLowerCase())
+    : pattern.test(message)
+}
+
+/**
+ * Claim the earliest still-unclaimed console error produced by `actor` that
+ * matches `pattern`, marking it `expected` so the reporter treats it as a
+ * success rather than a problem. Returns the claimed error, or `null` when none
+ * match. "First match only": one call claims at most one error.
+ */
+export function claimConsoleError(
+  errors: readonly ConsoleError[],
+  actor: string,
+  pattern: string | RegExp
+): ConsoleError | null {
+  let earliest: ConsoleError | null = null
+  for (const e of errors) {
+    if (e.expected) continue
+    if (e.actor !== actor) continue
+    if (!consoleErrorMatches(e.message, pattern)) continue
+    if (!earliest || e.timestamp < earliest.timestamp) earliest = e
+  }
+  if (earliest) earliest.expected = true
+  return earliest
+}
+
+/**
+ * Poll the shared console-error buffer until an error matching `pattern`
+ * appears for `actor`, claiming it. The triggering action (a click that hits a
+ * failing endpoint, say) usually lands the error a beat after it resolves, so
+ * we wait up to `timeout`. Resolves the claimed error, or `null` if none
+ * arrived in time.
+ */
+export async function waitForConsoleError(
+  errors: readonly ConsoleError[],
+  actor: string,
+  pattern: string | RegExp,
+  timeout: number,
+  pollInterval = 50
+): Promise<ConsoleError | null> {
+  const deadline = Date.now() + timeout
+  for (;;) {
+    const claimed = claimConsoleError(errors, actor, pattern)
+    if (claimed) return claimed
+    if (Date.now() >= deadline) return null
+    await new Promise((r) => setTimeout(r, pollInterval))
+  }
+}
+
+/**
+ * Parse a text-DSL / `.spec.md` `expectConsoleError` argument. A
+ * `/pattern/flags` form becomes a RegExp; anything else is a literal
+ * (case-insensitive) substring.
+ */
+export function parseConsoleErrorPattern(text: string): string | RegExp {
+  const m = text.match(/^\/(.*)\/([a-z]*)$/)
+  if (m) {
+    try {
+      return new RegExp(m[1], m[2])
+    } catch {
+      // Not a valid RegExp — fall back to literal substring matching.
+    }
+  }
+  return text
+}
+
+/**
+ * Build the error thrown when an expected console error never arrives. Lists
+ * the unclaimed errors actually seen for the actor, so the mismatch is obvious.
+ */
+export function describeMissingConsoleError(
+  errors: readonly ConsoleError[],
+  actor: string,
+  pattern: string | RegExp,
+  timeout: number
+): string {
+  const patternStr = typeof pattern === 'string' ? `"${pattern}"` : String(pattern)
+  const seen = errors
+    .filter((e) => e.actor === actor && !e.expected)
+    .map((e) => `  - ${e.message}`)
+  const tail = seen.length
+    ? `\nUnclaimed console errors seen for [${actor}]:\n${seen.join('\n')}`
+    : `\nNo unclaimed console errors were captured for [${actor}].`
+  return `expectConsoleError: no console error matching ${patternStr} appeared within ${timeout}ms.${tail}`
+}

--- a/packages/scenes/src/dsl.ts
+++ b/packages/scenes/src/dsl.ts
@@ -1,4 +1,5 @@
 import type { DslTarget, Selector } from './types.js'
+import { parseConsoleErrorPattern } from './console-errors.js'
 
 /**
  * Text DSL Grammar:
@@ -18,6 +19,9 @@ import type { DslTarget, Selector } from './types.js'
  *   notSee <selector>               - Wait for element hidden
  *   seeText <text>                  - Wait for text visible
  *   seeToast <selector>             - Wait for element appear then disappear
+ *   expectConsoleError <pattern>    - Expect a console error/uncaught exception
+ *                                     matching <pattern> (substring or /regex/),
+ *                                     marking it a success not a problem
  *
  * Scope (changes current scope):
  *   scope <selector>                - Wait for element visible and SET as current scope
@@ -134,7 +138,7 @@ export function parseAction(line: string): ParsedAction {
   const selectorOnlyActions = ['see', 'seeInView', 'notSee', 'click', 'check', 'seeToast', 'up', 'ifClick', 'scope']
 
   // Actions that take a value only (no selector)
-  const valueOnlyActions = ['openTo', 'seeText', 'wait', 'emit', 'waitFor', 'switchDevice', 'pressKey']
+  const valueOnlyActions = ['openTo', 'seeText', 'wait', 'emit', 'waitFor', 'switchDevice', 'pressKey', 'expectConsoleError']
 
   // Actions that take selector + value (everything after first selector word is value)
   const selectorValueActions = ['typeInto', 'select', 'warnIf']
@@ -237,6 +241,11 @@ export function applyDslAction(target: DslTarget, parsed: ParsedAction): void {
     case 'seeToast':
       if (!selector) throw new Error('seeToast requires a selector')
       target.seeToast(selector)
+      break
+
+    case 'expectConsoleError':
+      if (!value) throw new Error('expectConsoleError requires a pattern')
+      target.expectConsoleError(parseConsoleErrorPattern(value))
       break
 
     case 'scope':

--- a/packages/scenes/src/index.ts
+++ b/packages/scenes/src/index.ts
@@ -18,6 +18,14 @@ export type { MarkdownScene, ActorBlock, SceneAction } from './markdown-scene.js
 // Selector utilities
 export { setAliases, getAliases, clearAliases, explainSelector } from './selectors.js'
 
+// Console-error expectation utilities
+export {
+  setConsoleErrorAliases,
+  getConsoleErrorAliases,
+  clearConsoleErrorAliases,
+} from './console-errors.js'
+export type { ConsoleErrorAliases } from './console-errors.js'
+
 // Device rotation
 export { DeviceRotation, builtinDevices, findDevice } from './devices.js'
 export type { DeviceProfile } from './devices.js'

--- a/packages/scenes/src/markdown-scene.ts
+++ b/packages/scenes/src/markdown-scene.ts
@@ -308,7 +308,7 @@ const KNOWN_ACTIONS = [
   'openTo', 'see', 'seeInView', 'notSee', 'seeText', 'seeToast', 'click',
   'typeInto', 'check', 'select', 'wait', 'emit', 'waitFor',
   'warnIf', 'up', 'prev', 'scrollToBottom', 'if', 'pressKey', 'ifClick',
-  'scope',
+  'scope', 'expectConsoleError',
 ]
 
 /** Check if a line looks like a DSL action or macro invocation */

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -69,6 +69,7 @@ import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOptio
 import { MessageBus } from './message-bus.js'
 import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
+import { waitForConsoleError, describeMissingConsoleError } from './console-errors.js'
 import { registerScene, getCurrentSession } from './scene.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
@@ -547,6 +548,16 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
       const locator = resolveSelector(this.page, selector)
       await locator.waitFor({ state: 'visible', timeout: this.actionTimeout })
       await locator.waitFor({ state: 'hidden', timeout: this.actionTimeout })
+    })
+  }
+
+  expectConsoleError(pattern: string | RegExp): this {
+    const target = typeof pattern === 'string' ? pattern : String(pattern)
+    return this.push('expectConsoleError', target, async () => {
+      const claimed = await waitForConsoleError(this.consoleErrors, this.role, pattern, this.actionTimeout)
+      if (!claimed) {
+        throw new Error(describeMissingConsoleError(this.consoleErrors, this.role, pattern, this.actionTimeout))
+      }
     })
   }
 

--- a/packages/scenes/src/reactive.ts
+++ b/packages/scenes/src/reactive.ts
@@ -69,7 +69,7 @@ import { tabToElement, pressEnter, pressSpace, clearAndType, keyboardSelectOptio
 import { MessageBus } from './message-bus.js'
 import { resolveSelector, buildSelectorMissError } from './selectors.js'
 import { parseDslLines, parseAction, applyDslAction } from './dsl.js'
-import { waitForConsoleError, describeMissingConsoleError } from './console-errors.js'
+import { waitForConsoleError, describeMissingConsoleError, resolveConsoleErrorPattern } from './console-errors.js'
 import { registerScene, getCurrentSession } from './scene.js'
 import { findDevice } from './devices.js'
 import { dashboardSend } from './dashboard-reporter.js'
@@ -554,9 +554,10 @@ export class ConcurrentActorHandleImpl implements ConcurrentActorHandle {
   expectConsoleError(pattern: string | RegExp): this {
     const target = typeof pattern === 'string' ? pattern : String(pattern)
     return this.push('expectConsoleError', target, async () => {
-      const claimed = await waitForConsoleError(this.consoleErrors, this.role, pattern, this.actionTimeout)
+      const resolved = resolveConsoleErrorPattern(pattern)
+      const claimed = await waitForConsoleError(this.consoleErrors, this.role, resolved, this.actionTimeout)
       if (!claimed) {
-        throw new Error(describeMissingConsoleError(this.consoleErrors, this.role, pattern, this.actionTimeout))
+        throw new Error(describeMissingConsoleError(this.consoleErrors, this.role, resolved, this.actionTimeout))
       }
     })
   }

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -10,6 +10,7 @@ import { NavigationModeRotation } from './keyboard.js'
 import type { NavigationMode } from './keyboard.js'
 import { sceneRegistry, setCurrentFile, runScene } from './scene.js'
 import { setAliases } from './selectors.js'
+import { setConsoleErrorAliases } from './console-errors.js'
 import { importFile } from './loader.js'
 import { loadMarkdownScene } from './markdown-scene.js'
 import { SwarmTrigger, runSwarm } from './swarm.js'
@@ -135,6 +136,11 @@ export class SceneRunner {
     // Apply aliases from config
     if (config.aliases) {
       setAliases(config.aliases)
+    }
+
+    // Apply console-error aliases from config (named, expectable errors)
+    if (config.consoleErrorAliases) {
+      setConsoleErrorAliases(config.consoleErrorAliases)
     }
 
     // Register built-in macros if configured

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -404,14 +404,19 @@ export class SceneRunner {
             else soundFail()
           }
 
-          if (report.consoleErrors.length > 0) {
-            console.log(`    ⚠ ${report.consoleErrors.length} console error(s)`)
-            for (const ce of report.consoleErrors.slice(0, 5)) {
+          const unexpectedErrors = report.consoleErrors.filter((ce) => !ce.expected)
+          const expectedErrors = report.consoleErrors.filter((ce) => ce.expected)
+          if (expectedErrors.length > 0) {
+            console.log(`    ✓ ${expectedErrors.length} expected console error(s)`)
+          }
+          if (unexpectedErrors.length > 0) {
+            console.log(`    ⚠ ${unexpectedErrors.length} console error(s)`)
+            for (const ce of unexpectedErrors.slice(0, 5)) {
               const label = ce.source === 'selector' ? `error-selector(${ce.selector})` : ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
               console.log(formatConsoleEntry(ce.actor, label, ce.message, 200))
             }
-            if (report.consoleErrors.length > 5) {
-              console.log(`      └─ ... and ${report.consoleErrors.length - 5} more`)
+            if (unexpectedErrors.length > 5) {
+              console.log(`      └─ ... and ${unexpectedErrors.length - 5} more`)
             }
           }
         } finally {
@@ -437,7 +442,12 @@ export class SceneRunner {
     )
     const failedAssertions = totalAssertions - passedAssertions
     const totalWarnings = sceneReports.reduce((sum, r) => sum + r.warnings.length, 0)
-    const totalConsoleErrors = sceneReports.reduce((sum, r) => sum + r.consoleErrors.length, 0)
+    // Expected errors (claimed via expectConsoleError) are successes, not
+    // problems — keep them out of the summary's console-error count.
+    const totalConsoleErrors = sceneReports.reduce(
+      (sum, r) => sum + r.consoleErrors.filter((ce) => !ce.expected).length,
+      0
+    )
 
     const report: RunReport = {
       timestamp: new Date().toISOString(),
@@ -796,17 +806,26 @@ export function printSummary(report: RunReport): void {
     console.log(`\n  ⚠ ${report.summary.assertions.failed} assertion(s) failed`)
   }
 
+  const totalExpectedErrors = report.scenes.reduce(
+    (sum, s) => sum + s.consoleErrors.filter((ce) => ce.expected).length,
+    0
+  )
+  if (totalExpectedErrors > 0) {
+    console.log(`\n  ✓ ${totalExpectedErrors} expected console error(s)`)
+  }
+
   if (report.summary.consoleErrors > 0) {
     console.log(`\n  🔴 ${report.summary.consoleErrors} browser console error(s)`)
     for (const scene of report.scenes) {
-      if (scene.consoleErrors.length > 0) {
-        console.log(`    ${scene.name}: ${scene.consoleErrors.length} error(s)`)
-        for (const ce of scene.consoleErrors.slice(0, 3)) {
+      const unexpected = scene.consoleErrors.filter((ce) => !ce.expected)
+      if (unexpected.length > 0) {
+        console.log(`    ${scene.name}: ${unexpected.length} error(s)`)
+        for (const ce of unexpected.slice(0, 3)) {
           const label = ce.source === 'selector' ? `error-selector(${ce.selector})` : ce.source === 'pageerror' ? 'uncaught' : ce.type === 'warning' ? 'console.warn' : 'console.error'
           console.log(formatConsoleEntry(ce.actor, label, ce.message, 150))
         }
-        if (scene.consoleErrors.length > 3) {
-          console.log(`      └─ ... and ${scene.consoleErrors.length - 3} more`)
+        if (unexpected.length > 3) {
+          console.log(`      └─ ... and ${unexpected.length - 3} more`)
         }
       }
     }

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -172,6 +172,23 @@ export interface ScenetestConfig extends BaseConfig {
    */
   aliases?: Record<string, string>
 
+  /**
+   * Console-error aliases — name the browser console errors a suite expects,
+   * so specs can claim them by domain term with `expectConsoleError`. A pattern
+   * is a case-insensitive substring or a `RegExp`. Reference an alias by bare
+   * name, or with a `~` prefix to fail loudly on a typo.
+   *
+   * @example
+   * ```ts
+   * consoleErrorAliases: {
+   *   'bad-password': 'Invalid login credentials',
+   *   'not-found': /status of 404/,
+   * }
+   * // in a scene:  - expectConsoleError bad-password
+   * ```
+   */
+  consoleErrorAliases?: Record<string, string | RegExp>
+
   /** Report output directory */
   reportDir?: string
 

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -349,6 +349,13 @@ export interface ConsoleError {
   url?: string
   /** The CSS selector that matched (only present when source is 'selector') */
   selector?: string
+  /**
+   * Set when a scene claimed this error via `expectConsoleError()`. Expected
+   * errors are a success — the scene asserted the error *should* happen — so
+   * the reporter excludes them from the "browser console error(s)" surface and
+   * the run summary's error count.
+   */
+  expected?: boolean
 }
 
 /**
@@ -671,6 +678,19 @@ export interface SequentialActorHandle extends ActorConfig {
   seeToast(selector: Selector): ActionChain
 
   /**
+   * Wait for a browser console error (or uncaught exception) matching
+   * `pattern` to occur, and mark it as expected so it is reported as a success
+   * rather than a problem. Fails the scene if no matching error appears within
+   * the action timeout. Use when a scene deliberately exercises an error path —
+   * e.g. logging in with a wrong password, where a missing 400 would be a bug.
+   *
+   * `pattern` is a case-insensitive substring, or a `RegExp` for finer control.
+   * Claims a single error (the earliest unclaimed match); call it once per
+   * console message you expect.
+   */
+  expectConsoleError(pattern: string | RegExp): ActionChain
+
+  /**
    * Wait for element to be visible and set it as the current scope.
    * Subsequent actions (click, typeInto, etc.) resolve within this scope.
    */
@@ -823,6 +843,14 @@ export interface ActionChain extends PromiseLike<void> {
   /** Wait for element to appear AND disappear (for toasts/notifications) */
   seeToast(selector: Selector): ActionChain
 
+  /**
+   * Wait for a browser console error (or uncaught exception) matching
+   * `pattern`, marking it expected so it reports as a success rather than a
+   * problem. Fails the scene if no matching error appears within the action
+   * timeout. For deliberate error paths (e.g. a wrong-password login).
+   */
+  expectConsoleError(pattern: string | RegExp): ActionChain
+
   /** Wait for element to be visible and set it as the current scope */
   scope(selector: Selector): ActionChain
 
@@ -959,6 +987,7 @@ export interface DslTarget {
   notSee(selector: Selector): unknown
   seeText(text: string): unknown
   seeToast(selector: Selector): unknown
+  expectConsoleError(pattern: string | RegExp): unknown
   scope(selector: Selector): unknown
   click(selector?: Selector): unknown
   typeInto(selector: Selector, value: string): unknown
@@ -1033,6 +1062,13 @@ export interface ConcurrentActorHandle {
   notSee(selector: Selector): ConcurrentActorHandle
   seeText(text: string): ConcurrentActorHandle
   seeToast(selector: Selector): ConcurrentActorHandle
+  /**
+   * Wait for a browser console error (or uncaught exception) matching
+   * `pattern`, marking it expected so it reports as a success rather than a
+   * problem. Aborts the scene if no matching error appears within the action
+   * timeout. For deliberate error paths (e.g. a wrong-password login).
+   */
+  expectConsoleError(pattern: string | RegExp): ConcurrentActorHandle
 
   // -- Scope --
   /** Wait for element to be visible and set it as the current scope */

--- a/packages/vscode-scenetest/syntaxes/scenetest-spec.tmLanguage.json
+++ b/packages/vscode-scenetest/syntaxes/scenetest-spec.tmLanguage.json
@@ -32,7 +32,7 @@
       "patterns": [
         {
           "comment": "Actor cue with inline action: user: openTo /login",
-          "match": "^\\s*(?:-\\s*|\\d+\\.\\s*)?([a-zA-Z][a-zA-Z0-9_-]*):\\s+(openTo|see|seeInView|notSee|seeText|seeToast|click|typeInto|check|select|wait|emit|waitFor|warnIf|up|prev|scrollToBottom|if)(?:\\s+(.*))?$",
+          "match": "^\\s*(?:-\\s*|\\d+\\.\\s*)?([a-zA-Z][a-zA-Z0-9_-]*):\\s+(openTo|see|seeInView|notSee|seeText|seeToast|expectConsoleError|click|typeInto|check|select|wait|emit|waitFor|warnIf|up|prev|scrollToBottom|if)(?:\\s+(.*))?$",
           "captures": {
             "1": { "name": "variable.other.actor.scenetest" },
             "2": { "name": "entity.name.function.action.scenetest" },
@@ -112,6 +112,14 @@
         {
           "comment": "Text assertion: seeText",
           "match": "^\\s*(?:-\\s*|\\d+\\.\\s*)?(seeText)\\s+(.*)$",
+          "captures": {
+            "1": { "name": "entity.name.function.action.scenetest" },
+            "2": { "patterns": [{ "include": "#value-with-interpolation" }] }
+          }
+        },
+        {
+          "comment": "Console-error expectation: expectConsoleError <pattern>",
+          "match": "^\\s*(?:-\\s*|\\d+\\.\\s*)?(expectConsoleError)\\s+(.*)$",
           "captures": {
             "1": { "name": "entity.name.function.action.scenetest" },
             "2": { "patterns": [{ "include": "#value-with-interpolation" }] }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
         specifier: 1.56.1
         version: 1.56.1
     devDependencies:
+      '@tanstack/intent':
+        specifier: ^0.0.41
+        version: 0.0.41
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.30


### PR DESCRIPTION
## Summary

Adds `expectConsoleError(pattern)` action to allow scenes to declare expected console errors and uncaught exceptions as successes rather than problems. This is essential for testing error paths — e.g., logging in with the wrong password should produce a 400 error, and it would be a bug if it didn't.

## Key Changes

- **New module `console-errors.ts`** with utilities for matching, claiming, and waiting for console errors:
  - `consoleErrorMatches()` — case-insensitive substring or RegExp matching
  - `claimConsoleError()` — mark the earliest unclaimed matching error as `expected`
  - `waitForConsoleError()` — poll the shared buffer until a match arrives (up to timeout)
  - `parseConsoleErrorPattern()` — parse text DSL `/regex/flags` or literal substring
  - `describeMissingConsoleError()` — build helpful error messages listing unclaimed errors seen

- **Updated `ConsoleError` type** with optional `expected?: boolean` field to mark claimed errors

- **New `expectConsoleError(pattern)` action** in both `SequentialActorHandle` and `ConcurrentActorHandle`:
  - Waits (up to action timeout) for a browser console error matching the pattern
  - Marks the matched error as `expected` so it reports as a success
  - Fails the scene if no matching error appears
  - Pattern is a case-insensitive substring or `/regex/` (with flags)

- **DSL support** in `dsl.ts`:
  - Parses `expectConsoleError <pattern>` in `.spec.md` files
  - Handles both literal strings and `/regex/flags` syntax

- **Reporter updates** in `runner.ts`:
  - Separates expected vs. unexpected console errors in output
  - Shows `✓ N expected console error(s)` for claimed errors
  - Excludes expected errors from the run summary's error count
  - Displays unclaimed errors as `⚠ N console error(s)`

- **Documentation**:
  - Added guide section in `writing-scene-specs.md` with examples
  - Updated text DSL reference in `text-dsl.md`
  - Updated VS Code syntax highlighting for the new action

- **Tests** in `console-errors.test.ts` and `reactive.test.ts`:
  - Full coverage of matching, claiming, and waiting logic
  - Integration tests for both sequential and concurrent actors
  - Validates error message formatting

## Implementation Details

- Errors are claimed from a shared buffer (`ConsoleError[]`) per session, allowing multiple actors to coordinate expectations
- "First match only" semantics: each `expectConsoleError()` call claims at most one error, so multiple expected errors require multiple calls
- The action timeout controls how long to wait for an error to arrive (useful since errors often land a beat after the triggering action resolves)
- Expected errors are excluded from the run summary's console-error count and the reporter's error surface, but are still captured and reported as a success

https://claude.ai/code/session_01Dq6S3YHLQwFjkdQRf4vdd4