### PR TITLE
chore(release): monorepo version marker 0.16.0 + document versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Scenetest are documented here.
 
 ---
 
-## 2026-06-18 — @scenetest/dashboard 0.13.0, @scenetest/vite-plugin 0.16.0
+## 2026-06-18 — monorepo 0.16.0 · @scenetest/dashboard 0.13.0, @scenetest/vite-plugin 0.16.0
 
 **Embedded routing fix.** `<Dashboard>` no longer runs its own router against a hardcoded `/__scenetest` base — it defers to the host's `preact-iso` router, so it embeds correctly inside another app (scenetest-cloud, mounted per-PR at `/repo/:owner/:name/pr/:number`) without rewriting the browser URL. `@scenetest/dashboard` (breaking) bumps to 0.13.0 and `@scenetest/vite-plugin` (which bundles the dev dashboard) to 0.16.0; other packages are unchanged.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,17 @@ pnpm typecheck        # Type check all packages
 pnpm -r test          # Run all unit tests across packages
 ```
 
+## Releasing & Versioning
+
+**Per-package semver, with a monorepo accumulator.** Each published package is versioned by its own change — bump only the packages a release actually touches, in their `package.json`. (Pre-1.0, a breaking change rides the **minor** slot, e.g. `0.12.0 → 0.13.0`; additive changes are also minor; fixes are patch.) Cross-package deps are `workspace:*`, so a bump never forces a range update elsewhere.
+
+The private root `scenetest-monorepo` `version` is a marker (never published) that **bumps by the strongest bump in each release**: any package minor → root minor (`0.16.0 → 0.17.0`); a patch-only release → root patch (`0.16.0 → 0.16.1`). It therefore stays at or ahead of the highest package version by construction — don't compute it as `max(versions)` (a single fast-moving package could outrun that); accumulate it per release.
+
+Per release:
+1. Bump the changed packages' versions (+ the root per the rule above).
+2. Add a dated, per-package entry at the top of `CHANGELOG.md` in the existing form: `## <date> — monorepo <v> · @scenetest/<pkg> <v>, …`, with an `### @scenetest/<pkg> <v>` subsection per bumped package.
+3. Commit as `release: monorepo <v> (@scenetest/<pkg> <v>, …)` — a standalone commit on top of the work it ships. This is a manual convention; nothing tools it.
+
 ## Package Structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.14.0",
+	"version": "0.16.0",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,


### PR DESCRIPTION
Follow-up to the **0.13.0 / 0.16.0** release (already on `main` via #228). That release versioned the packages but left the private root `scenetest-monorepo` stale at `0.14.0`. This gives the root a meaningful value and writes the convention down.

3 files, 13 lines:
- **`package.json`** — root `scenetest-monorepo` `0.14.0 → 0.16.0`. It's a private marker (never published) that bumps by the *strongest* bump in each release (any package minor → root minor; patch-only → root patch), so it stays at or ahead of the highest package version by construction.
- **`CHANGELOG.md`** — prefix the 2026-06-18 header with `monorepo 0.16.0 ·`.
- **`CLAUDE.md`** — new "Releasing & Versioning" section: per-package semver, the root accumulator rule, and the per-release checklist.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRQxWeJqVWHBKWBq27kbFM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRQxWeJqVWHBKWBq27kbFM)_