### PR TITLE
Fix scene test runner URL path in CLI output

### DIFF
--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -213,7 +213,7 @@ async function writeReport(
   fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2))
   const id = path.basename(jsonPath, '.json')
   console.log(`Report written to: ${jsonPath}`)
-  console.log(`Open in browser:    /__scenetest/?run=${id}`)
+  console.log(`Open in browser:    /__scenetest/runner?run=${id}`)
 
   if (format === 'html') {
     console.log(


### PR DESCRIPTION
Updated the browser URL path in `writeReport()` from `/__scenetest/?run=${id}` to `/__scenetest/runner?run=${id}` to match the actual route where the scene test runner is served