### PR TITLE
Auto-collapse finished files in runner sidebar with manual override

### DIFF
--- a/packages/dashboard/src/__tests__/tree-collapse.test.tsx
+++ b/packages/dashboard/src/__tests__/tree-collapse.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { Tree } from '../runner.js'
+import type { RunnerScene } from '../select-runner.js'
+
+/**
+ * The Runner sidebar tree folds a file's scenes once the file finishes (none of
+ * its scenes still running), and a click on the file header overrides that.
+ */
+
+function scene(name: string, file: string, status: string): RunnerScene {
+  return {
+    id: `${file}:${name}`,
+    name,
+    file,
+    status,
+    duration: status === 'running' ? null : 5,
+    error: null,
+    team: {},
+    teamIndex: 0,
+    actors: ['a'],
+    assertions: [],
+    timeline: [],
+  }
+}
+
+function mount(scenes: RunnerScene[]): HTMLElement {
+  const root = document.createElement('div')
+  document.body.appendChild(root)
+  act(() => {
+    render(<Tree scenes={scenes} selected={null} onSelect={() => {}} />, root)
+  })
+  return root
+}
+
+function group(root: HTMLElement, file: string): Element {
+  const el = [...root.querySelectorAll('.tree-file')].find((f) => f.getAttribute('title') === file)
+  if (!el) throw new Error(`no tree-file for ${file}`)
+  return el.closest('.tree-group')!
+}
+
+describe('Runner sidebar: files fold when they finish', () => {
+  it('keeps a file with a running scene expanded', () => {
+    const root = mount([scene('a', 'one.spec.md', 'completed'), scene('b', 'one.spec.md', 'running')])
+    const g = group(root, 'one.spec.md')
+    expect(g.classList.contains('collapsed')).toBe(false)
+    expect(g.querySelectorAll('.tree-scene').length).toBe(2)
+  })
+
+  it('auto-folds a file once all its scenes have settled', () => {
+    const root = mount([scene('a', 'done.spec.md', 'completed'), scene('b', 'done.spec.md', 'failed')])
+    const g = group(root, 'done.spec.md')
+    expect(g.classList.contains('collapsed')).toBe(true)
+    expect(g.querySelectorAll('.tree-scene').length).toBe(0)
+  })
+
+  it('folds each file independently', () => {
+    const root = mount([scene('a', 'done.spec.md', 'completed'), scene('b', 'live.spec.md', 'running')])
+    expect(group(root, 'done.spec.md').classList.contains('collapsed')).toBe(true)
+    expect(group(root, 'live.spec.md').classList.contains('collapsed')).toBe(false)
+  })
+
+  it('clicking a finished file header expands it (manual override)', () => {
+    const root = mount([scene('a', 'done.spec.md', 'completed')])
+    const header = group(root, 'done.spec.md').querySelector('.tree-file') as HTMLElement
+    act(() => header.click())
+    const g = group(root, 'done.spec.md')
+    expect(g.classList.contains('collapsed')).toBe(false)
+    expect(g.querySelectorAll('.tree-scene').length).toBe(1)
+  })
+
+  it('clicking a running file header collapses it (manual override)', () => {
+    const root = mount([scene('a', 'live.spec.md', 'running')])
+    const header = group(root, 'live.spec.md').querySelector('.tree-file') as HTMLElement
+    act(() => header.click())
+    expect(group(root, 'live.spec.md').classList.contains('collapsed')).toBe(true)
+  })
+})

--- a/packages/dashboard/src/runner.tsx
+++ b/packages/dashboard/src/runner.tsx
@@ -179,7 +179,14 @@ function RunnerHeader({
 }
 
 // ── Tree (scenes grouped by file) ─────────────────────────────────
-function Tree({
+// A file is "done" once none of its scenes are still running; finished files
+// auto-fold so the sidebar stays focused on what's still in flight. Clicking a
+// file header sets a manual override that wins over the auto rule.
+export function fileIsDone(group: RunnerScene[]): boolean {
+  return group.length > 0 && group.every((s) => s.status !== 'running')
+}
+
+export function Tree({
   scenes,
   selected,
   onSelect,
@@ -198,25 +205,39 @@ function Tree({
     return m
   }, [scenes])
 
+  // Per-file manual collapse overrides. A file not present here follows the
+  // auto rule (fold once finished); a click pins it open or closed.
+  const [overrides, setOverrides] = useState<Record<string, boolean>>({})
+  const toggle = useCallback(
+    (file: string, collapsed: boolean) => setOverrides((o) => ({ ...o, [file]: !collapsed })),
+    []
+  )
+
   return (
     <aside class="tree">
       {[...byFile.entries()].map(([file, group]) => {
         const fails = group.filter((s) => s.status !== 'completed' && s.status !== 'running').length
+        const collapsed = file in overrides ? overrides[file] : fileIsDone(group)
         return (
-          <div key={file}>
-            <div class="tree-file" title={file}>
-              <span>{shortFile(file)}</span>
+          <div key={file} class={'tree-group' + (collapsed ? ' collapsed' : '')}>
+            <div class="tree-file" title={file} onClick={() => toggle(file, collapsed)}>
+              <span class="tree-caret" aria-hidden="true">
+                {collapsed ? '▸' : '▾'}
+              </span>
+              <span class="tree-name">{shortFile(file)}</span>
               {fails ? <span class="fail">{fails}</span> : null}
             </div>
-            {group.map((s) => (
-              <div
-                key={s.id}
-                class={'tree-scene ' + s.status + (s.id === selected ? ' selected' : '')}
-                onClick={() => onSelect(s.id)}
-              >
-                {s.name}
-              </div>
-            ))}
+            {collapsed
+              ? null
+              : group.map((s) => (
+                  <div
+                    key={s.id}
+                    class={'tree-scene ' + s.status + (s.id === selected ? ' selected' : '')}
+                    onClick={() => onSelect(s.id)}
+                  >
+                    {s.name}
+                  </div>
+                ))}
           </div>
         )
       })}

--- a/packages/dashboard/src/style.css
+++ b/packages/dashboard/src/style.css
@@ -354,10 +354,28 @@
     padding: 4px 14px;
     color: var(--text2);
     display: flex;
-    justify-content: space-between;
-    gap: 8px;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .tree-file:hover {
+    background: rgba(255, 255, 255, 0.03);
+  }
+  .tree-caret {
+    flex: none;
+    width: 10px;
+    font-size: 9px;
+    color: var(--text2);
+  }
+  .tree-file .tree-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
   .tree-file .fail {
+    flex: none;
     color: var(--red);
   }
   .tree-scene {


### PR DESCRIPTION
## Summary
Adds automatic collapsing of file groups in the runner sidebar once all their scenes have finished running, with a click-to-override mechanism for manual control.

## Changes
- **New test suite** (`tree-collapse.test.tsx`): Comprehensive tests covering auto-collapse behavior, per-file independence, and manual override interactions
- **Tree component logic**: 
  - Exported `fileIsDone()` helper to determine when a file group has no running scenes
  - Added `overrides` state to track manual collapse/expand clicks per file
  - Implemented toggle handler that pins a file open or closed, overriding the auto rule
- **Tree UI updates**:
  - Added collapsible file headers with visual caret indicator (▸/▾)
  - Made file headers clickable with hover feedback
  - Conditionally render scene list based on collapsed state
  - Improved layout with flexbox for better alignment and text truncation

## Implementation Details
- A file is considered "done" when it has scenes and none are in `'running'` status
- Manual overrides (stored in `overrides` state) take precedence over the auto-collapse rule
- Clicking a file header toggles its collapsed state, pinning it until the next click
- The sidebar stays focused on in-flight tests by auto-folding completed files, while preserving user intent through manual overrides

https://claude.ai/code/session_01UyKPFXSrQkModuWyFb3yo3