### PR TITLE
Fix dashboard button URL and add demo mode for docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to Scenetest are documented here.
 
 ---
 
-## 2026-06-22 — monorepo 0.16.1 · @scenetest/checks 0.13.1
+## 2026-06-22 — monorepo 0.17.0 · @scenetest/checks 0.14.0
 
-### @scenetest/checks 0.13.1
+### @scenetest/checks 0.14.0
 
-**Fix the observer panel's "dashboard" button.** The button linked to `/__scenetest/dashboard`, a path that stopped existing when the dashboard's views were renamed — the live dashboard (Home) now mounts at the base `/__scenetest`, with `/__scenetest/runner` and `/__scenetest/waterfall` for the other views. The button now points at `/__scenetest` so it opens the live dashboard again instead of 404'ing. (Reference docs that pointed at the old URL are corrected too.)
+**Fix the observer panel's "dashboard" button + add a demo mode.** The button linked to `/__scenetest/dashboard`, a path that stopped existing when the dashboard's views were renamed — the live dashboard (Home) now mounts at the base `/__scenetest`, with `/__scenetest/runner` and `/__scenetest/waterfall` for the other views. The button now points at `/__scenetest`, so under a dev server it opens the live dashboard again instead of 404'ing. (Reference docs that pointed at the old URL are corrected too.)
+
+For standalone hosts with no dev server behind them (the docs site), set `window.__scenetest_demo = true` and the "dashboard" button pops the fullscreen assertion viewer — the same window an assertion click opens — instead of following the dead link. The flag is read at click time, so it can be set any time after the panel mounts.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to Scenetest are documented here.
 
 ---
 
-## 2026-06-22 — monorepo 0.17.0 · @scenetest/checks 0.14.0
+## 2026-06-22 — monorepo 0.16.1 · @scenetest/checks 0.13.1
 
-### @scenetest/checks 0.14.0
+### @scenetest/checks 0.13.1
 
 **Fix the observer panel's "dashboard" button + add a demo mode.** The button linked to `/__scenetest/dashboard`, a path that stopped existing when the dashboard's views were renamed — the live dashboard (Home) now mounts at the base `/__scenetest`, with `/__scenetest/runner` and `/__scenetest/waterfall` for the other views. The button now points at `/__scenetest`, so under a dev server it opens the live dashboard again instead of 404'ing. (Reference docs that pointed at the old URL are corrected too.)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## 2026-06-22 — monorepo 0.16.1 · @scenetest/checks 0.13.1
+
+### @scenetest/checks 0.13.1
+
+**Fix the observer panel's "dashboard" button.** The button linked to `/__scenetest/dashboard`, a path that stopped existing when the dashboard's views were renamed — the live dashboard (Home) now mounts at the base `/__scenetest`, with `/__scenetest/runner` and `/__scenetest/waterfall` for the other views. The button now points at `/__scenetest` so it opens the live dashboard again instead of 404'ing. (Reference docs that pointed at the old URL are corrected too.)
+
+---
+
 ## 2026-06-18 — monorepo 0.16.0 · @scenetest/dashboard 0.13.0, @scenetest/vite-plugin 0.16.0
 
 **Embedded routing fix.** `<Dashboard>` no longer runs its own router against a hardcoded `/__scenetest` base — it defers to the host's `preact-iso` router, so it embeds correctly inside another app (scenetest-cloud, mounted per-PR at `/repo/:owner/:name/pr/:number`) without rewriting the browser URL. `@scenetest/dashboard` (breaking) bumps to 0.13.0 and `@scenetest/vite-plugin` (which bundles the dev dashboard) to 0.16.0; other packages are unchanged.

--- a/docs/app/routes/__root.tsx
+++ b/docs/app/routes/__root.tsx
@@ -6,6 +6,11 @@ import {
   createRootRoute,
 } from '@tanstack/react-router'
 import '@scenetest/checks/panel'
+
+// The docs site has no dev server behind it, so the panel's live-dashboard
+// link (/__scenetest) has nothing to point at. Demo mode makes the panel's
+// "dashboard" button pop the fullscreen assertion viewer instead.
+if (typeof window !== 'undefined') window.__scenetest_demo = true
 import { SectionNav } from '../components/SectionNav'
 import { LinkCard } from '../components/LinkCard'
 import { Footer } from '../components/Footer'

--- a/docs/app/sections.ts
+++ b/docs/app/sections.ts
@@ -68,7 +68,7 @@ export const reference: SectionItem[] = [
     slug: 'live-dashboard',
     title: 'Live Dashboard',
     description:
-      'Real-time swim-lane timeline at /__scenetest/dashboard showing actor actions, assertions, and timing as scenes run.',
+      'Real-time swim-lane timeline at /__scenetest showing actor actions, assertions, and timing as scenes run.',
   },
 ]
 

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -264,7 +264,7 @@ scenetest-reports/
 
 ## Live Dashboard
 
-When running against a Vite dev server with the scenetest plugin, a live dashboard is available at `/__scenetest/dashboard`. It shows a real-time swim-lane timeline with per-actor action bars, assertion markers, and timing data as scenes execute.
+When running against a Vite dev server with the scenetest plugin, a live dashboard is available at `/__scenetest`. It shows a real-time swim-lane timeline with per-actor action bars, assertion markers, and timing data as scenes execute.
 
 The URL is printed when the runner starts. You can also open it from the floating dev panel's **dashboard** button.
 

--- a/docs/public/reference/live-dashboard.md
+++ b/docs/public/reference/live-dashboard.md
@@ -1,11 +1,11 @@
 # Live Dashboard
 
-The live dashboard streams scene execution events in real-time to a browser-based timeline at `/__scenetest/dashboard`. It shows swim lanes per actor with action bars, assertion markers, and timing data as scenes run.
+The live dashboard streams scene execution events in real-time to a browser-based timeline at `/__scenetest`. It shows swim lanes per actor with action bars, assertion markers, and timing data as scenes run.
 
 ## Quick Start
 
 1. Start your dev server (`pnpm dev` or equivalent)
-2. Open `http://localhost:5173/__scenetest/dashboard` in your browser
+2. Open `http://localhost:5173/__scenetest` in your browser
 3. Run scenes: `pnpm scenetest scenetest/scenes/my-scene.spec.md`
 4. Watch the timeline populate in real-time
 
@@ -16,7 +16,7 @@ Running 2 scene file(s)...
 
 Found 2 scene(s)
 
-Dashboard: http://localhost:5173/__scenetest/dashboard
+Dashboard: http://localhost:5173/__scenetest
 ```
 
 You can also open it from the floating dev panel — click the **dashboard** button in the action bar.
@@ -117,7 +117,7 @@ export default defineConfig({
 })
 ```
 
-The dashboard routes (`/__scenetest/dashboard` and `/__scenetest/events`) are registered automatically in dev mode. They are not included in production builds.
+The dashboard routes (`/__scenetest` and `/__scenetest/events`) are registered automatically in dev mode. They are not included in production builds.
 
 ## Relationship to Reports
 
@@ -126,7 +126,7 @@ The live dashboard and static HTML reports serve different purposes:
 | | Live Dashboard | HTML Reports |
 |---|---|---|
 | **When** | During test execution | After run completes |
-| **Where** | `/__scenetest/dashboard` in browser | `scenetest/.reports/report-*.html` on disk |
+| **Where** | `/__scenetest` in browser | `scenetest/.reports/report-*.html` on disk |
 | **Data** | Real-time event stream | Complete run summary |
 | **Use case** | Watching test progress, debugging slow actions | Sharing results, CI artifacts, historical comparison |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.17.0",
+	"version": "0.16.1",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.16.1",
+	"version": "0.17.0",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/package.json
+++ b/packages/checks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/checks",
-  "version": "0.14.0",
+  "version": "0.13.1",
   "description": "Inline assertions for end-to-end testing",
   "type": "module",
   "license": "MIT",

--- a/packages/checks/src/panel/index.ts
+++ b/packages/checks/src/panel/index.ts
@@ -44,6 +44,11 @@ declare global {
     __scenetest_panel?: boolean
     __scenetest_no_panel?: boolean
     __scenetest_force_panel?: boolean
+    // When set, the panel's "dashboard" button opens the fullscreen assertion
+    // viewer instead of linking to the live dashboard at /__scenetest (which
+    // only exists under a dev server). Used by the docs demo. Read at click
+    // time, so it can be set any time after the panel mounts.
+    __scenetest_demo?: boolean
     // __scenetest_report is declared in ../types.ts (ScenetestReporter)
     __scenetest_openInEditor?: typeof openInEditor
     __scenetest_openFullscreenToGroup?: typeof openFullscreenToGroup

--- a/packages/checks/src/panel/panel.ts
+++ b/packages/checks/src/panel/panel.ts
@@ -57,7 +57,7 @@ function getPanelHTML(): string {
         <button class="scenetest-btn scenetest-audio-btn" id="scenetest-play" title="Play symphony">\u25B6</button>
       </div>
       <span class="scenetest-separator"></span>
-      <a class="scenetest-btn" id="scenetest-dashboard" href="/__scenetest/dashboard" target="_blank" title="Live dashboard">dashboard</a>
+      <a class="scenetest-btn" id="scenetest-dashboard" href="/__scenetest" target="_blank" title="Live dashboard">dashboard</a>
       <button class="scenetest-btn" id="scenetest-fullscreen">fullscreen</button>
       <button class="scenetest-btn" id="scenetest-clear">clear</button>
     </div>

--- a/packages/checks/src/panel/panel.ts
+++ b/packages/checks/src/panel/panel.ts
@@ -447,6 +447,17 @@ export function createPanel(): void {
     openFullscreen()
   })
 
+  // Dashboard button: normally an <a> to the live dashboard (/__scenetest),
+  // served only under a dev server. In demo mode (e.g. the docs site, where
+  // there is no dev server) there's nothing at that URL, so pop the fullscreen
+  // assertion viewer instead — the same window an assertion click opens.
+  panelEl.querySelector('#scenetest-dashboard')?.addEventListener('click', (e) => {
+    if (typeof window !== 'undefined' && window.__scenetest_demo) {
+      e.preventDefault()
+      openFullscreen()
+    }
+  })
+
   // Audio: Mute toggle
   panelEl.querySelector('#scenetest-mute')?.addEventListener('click', (e) => {
     e.stopPropagation()

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -438,7 +438,7 @@ export interface ErrorSelector {
 
 /**
  * Events streamed from the CLI runner to the Vite dev server
- * for the live dashboard at /__scenetest/dashboard.
+ * for the live dashboard at /__scenetest.
  *
  * The vocabulary is defined by `@scenetest/protocol` (where it is named
  * `RunEvent`); this alias is kept for backwards compatibility.


### PR DESCRIPTION
The panel's "dashboard" button linked to `/__scenetest/dashboard`, a path that no longer exists after the dashboard's views were reorganized. This fixes the URL to point to `/__scenetest` (where the live dashboard now mounts) and adds a demo mode for standalone hosts like the docs site that have no dev server behind them.
