### PR TITLE
Update CLI invocation from pnpm to npx in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ user:
 **4. Run tests:**
 
 ```bash
-pnpm scenetest
+npx scenetest
 ```
 
 ## Documentation

--- a/docs/public/design/dashboard.md
+++ b/docs/public/design/dashboard.md
@@ -107,7 +107,7 @@ Side-by-side diff showing:
 ```yaml
 # .github/workflows/test.yml
 - name: Run scenetest
-  run: pnpm scenetest --report
+  run: npx scenetest --report
 
 - name: Upload report
   uses: scenetest/upload-report@v1

--- a/docs/public/guides/getting-started.md
+++ b/docs/public/guides/getting-started.md
@@ -129,7 +129,7 @@ A few things to notice:
 Run it:
 
 ```bash
-pnpm scenetest
+npx scenetest
 ```
 
 The runner discovers `.spec.md` files, launches a browser for each actor, and runs through the action queues. If a selector can't be found, the test fails with a clear message about what it was looking for.
@@ -288,7 +288,7 @@ For each file you modify, show the before and after for the changed lines. At th
 1. Paste it into an LLM conversation along with your spec files and component source
 2. Review the suggested changes -- the markers are purely additive, so they won't affect your app's behavior
 3. Apply the changes
-4. Run `pnpm scenetest` and watch specs start passing
+4. Run `npx scenetest` and watch specs start passing
 
 This step gets easier over time. Once you're in the habit of adding `data-testid` to new components as you build them, the specs just work.
 

--- a/docs/public/guides/writing-scene-specs.md
+++ b/docs/public/guides/writing-scene-specs.md
@@ -218,7 +218,7 @@ The short version:
 1. Read your spec files to find every selector token
 2. Find the corresponding element in your source
 3. Add `data-testid` for static elements and list containers, `aria-label` for interactive elements, `data-key` for items inside a container
-4. Run `pnpm scenetest` and watch specs start passing
+4. Run `npx scenetest` and watch specs start passing
 
 ## The Handoff: Reporting to Engineers
 

--- a/docs/public/reference/live-dashboard.md
+++ b/docs/public/reference/live-dashboard.md
@@ -6,7 +6,7 @@ The live dashboard streams scene execution events in real-time to a browser-base
 
 1. Start your dev server (`pnpm dev` or equivalent)
 2. Open `http://localhost:5173/__scenetest/dashboard` in your browser
-3. Run scenes: `pnpm scenetest scenetest/scenes/my-scene.spec.md`
+3. Run scenes: `npx scenetest scenetest/scenes/my-scene.spec.md`
 4. Watch the timeline populate in real-time
 
 The dashboard URL is also printed to the terminal when scenes start:

--- a/packages/scenes/src/init.ts
+++ b/packages/scenes/src/init.ts
@@ -57,5 +57,5 @@ export default [
   }
 
   console.log('Created scenetest/ directory')
-  console.log('Run `pnpm scenetest` to start running scene specs.')
+  console.log('Run `npx scenetest` to start running scene specs.')
 }


### PR DESCRIPTION
## Summary
Updated all documentation and initialization messages to use `npx scenetest` instead of `pnpm scenetest` as the recommended command for running scene tests.

## Changes
- **Documentation updates**: Updated getting started guide, writing scene specs guide, live dashboard reference, and design docs to reflect `npx scenetest` as the primary invocation method
- **README**: Changed the quick-start example to use `npx scenetest`
- **Initialization message**: Updated the console output in `packages/scenes/src/init.ts` to guide users toward `npx scenetest`

## Rationale
Using `npx scenetest` is more accessible to users who may not have `pnpm` installed or configured, and aligns with the standard npm ecosystem convention for running CLI tools. This makes the framework more approachable for new users while maintaining compatibility with any package manager.

https://claude.ai/code/session_01Vr8ewsKdcbjGnGCVhtrHTt