### PR TITLE
feat(scenes): make playwright a peer dependency, add `scenetest install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Scenetest are documented here.
 
 ---
 
+## 2026-08-25 — monorepo 0.18.0 · @scenetest/scenes 0.17.0
+
+**playwright is a peer dependency.** Your project supplies playwright, so its bin is linked in `node_modules/.bin` and one copy backs both the browser download and the run. `scenetest install` downloads the browser builds through the playwright scenetest itself resolves.
+
+### @scenetest/scenes 0.17.0
+* **Breaking:** `playwright` moved from `dependencies` to `peerDependencies` (`>=1.40.0`, not optional). Add it to your project: `pnpm add -D playwright`. Under pnpm's default isolated layout a nested playwright never linked its bin, so `pnpm exec playwright install` failed once a project stopped depending on playwright directly.
+* New `scenetest install [args...]` subcommand — runs `playwright install` against scenetest's own resolved playwright, so the browser builds match the library that launches them. Arguments pass straight through (`scenetest install chromium --with-deps`).
+* A missing playwright or a missing browser build now prints the command that fixes it instead of a module-resolution or launch stack trace.
+
+---
+
 ## 2026-08-25 — monorepo 0.17.1 · @scenetest/scenes 0.16.1, vscode-scenetest 0.10.1
 
 **Markdown scenes can navigate.** `reload`, `goBack`, `goForward`, and `switchDevice` were documented DSL actions that `.spec.md` files could not reach.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,9 +156,11 @@ Design doc: `docs/public/design/unified-console.md`.
 - `keyboard.ts` — `NavigationModeRotation`, `tabToElement()`, `pressEnter()`, `clearAndType()`, fuzzy-finger helpers, `FuzzyFingerError`
 - `config.ts` — `loadConfig()`, `findConfigFile()`, `defineConfig()`, team discovery
 - `types.ts` — all type definitions (`ScenetestConfig`, `SequentialActorHandle`, `ActionChain`, `ConcurrentActorHandle`, `SceneContext`)
+- `playwright-install.ts` — `resolvePlaywrightCli()`, `installBrowsers()`, and the two setup-failure predicates behind `scenetest install`
 - `recorder/` — the scene recorder panel (capture, reverse-selector, panel UI), subpath export `./recorder`, auto-initializing on import. Pure DOM code with no Vite coupling
 
 Constraints:
+- **playwright is a peer dependency.** The consumer supplies it, so its bin is linked and one copy backs both the browser download and the run. `cli.ts` therefore imports `runner.js` lazily — the runner imports playwright at module scope, and `scenetest install` has to stay reachable on a project that has not installed it yet.
 - Stop is cooperative. `isStopped` breaks the run loop, so the CLI emits a graceful `run:end` with a partial summary; `gate()` parks the loop while paused.
 - `RunController` is run-agnostic. There is no run id, and `meta.runId` is logged but never gates the action.
 - `run:replay` is a no-op inside `RunController`. Relaunching is the supervisor's job — the CLI in dev, the driver in cloud.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@ _Evaluate your product, not your tests. A Javascript testing framework with inli
 ## Installation
 
 ```bash
-pnpm add @scenetest/checks @scenetest/vite-plugin @scenetest/scenes
+pnpm add @scenetest/checks @scenetest/vite-plugin @scenetest/scenes playwright
+pnpm exec scenetest install
 ```
+
+Scenetest drives the browser through playwright, and declares it as a peer
+dependency: your project supplies it, so one copy backs both the browser
+download and the run. `scenetest install` downloads the browser builds.
 
 Framework bindings ship as subpaths of `@scenetest/checks` — import from
 `@scenetest/checks/react`, `/vue`, `/solid`, or `/svelte`.

--- a/docs/public/guides/getting-started.md
+++ b/docs/public/guides/getting-started.md
@@ -4,10 +4,18 @@ This guide walks you through adding Scenetest to an existing Vite project. By th
 
 ## 1. Install and Set Up
 
-Install the three Scenetest packages:
+Install the three Scenetest packages, plus playwright:
 
 ```bash
-pnpm add -D @scenetest/checks @scenetest/vite-plugin @scenetest/scenes
+pnpm add -D @scenetest/checks @scenetest/vite-plugin @scenetest/scenes playwright
+```
+
+Scenetest drives the browser through playwright, and declares it as a peer
+dependency: your project supplies it, so one copy backs both the browser
+download and the run. Download the browser builds:
+
+```bash
+pnpm exec scenetest install
 ```
 
 Framework bindings are subpaths of `@scenetest/checks`: import from

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -11,6 +11,41 @@ scenetest --headed             # Run with visible browser
 scenetest --swarm              # Run swarm mode (all teams, all scenes)
 ```
 
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `scenetest install [args...]` | Install the browser builds scenes run in (see [Browsers](#browsers)) |
+| `scenetest init` | Create the `scenetest/` folder structure (`--force` overwrites) |
+| `scenetest prompt <type>` | Generate an LLM prompt for teams or seed data (`teams`, `seeds`, `both`) |
+| `scenetest teams` | List the configured actor teams (`--json` for machine output) |
+
+## Browsers
+
+Scenetest drives the browser through playwright, and declares it as a **peer
+dependency**:
+
+```bash
+pnpm add -D playwright
+```
+
+Your project supplies playwright, so its `playwright` bin is linked and one copy
+backs both the browser download and the run. Two copies — one nested under
+scenetest, one your own — download browsers for one version and launch scenes
+with the other.
+
+Download the browser builds with:
+
+```bash
+scenetest install                 # Every browser playwright supports
+scenetest install chromium        # One browser
+scenetest install --with-deps     # Also the OS packages the browsers need (CI)
+```
+
+`scenetest install` forwards its arguments to the playwright that scenetest
+itself resolves, so the builds it downloads are the ones your scenes launch.
+`pnpm exec playwright install` does the same job through your own copy.
+
 ## Command-Line Options
 
 | Flag | Description |

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.3.3",
     "vite": "^6.4.2",
     "@scenetest/vite-plugin": "workspace:*",
-    "@scenetest/scenes": "workspace:*"
+    "@scenetest/scenes": "workspace:*",
+    "playwright": "^1.40.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "scenetest-monorepo",
-	"version": "0.17.1",
+	"version": "0.18.0",
 	"description": "A local-first testing framework for the Vite ecosystem",
 	"license": "MIT",
 	"private": true,

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scenetest/scenes",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "CLI tool for running scenetest scene specs",
   "type": "module",
   "license": "MIT",

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@scenetest/checks": "workspace:*",
     "@scenetest/protocol": "workspace:*",
-    "playwright": "^1.40.0",
     "commander": "^12.0.0",
     "glob": "^11.1.0",
     "jiti": "^2.4.0"
@@ -53,13 +52,18 @@
   "devDependencies": {
     "typescript": "^5.3.0",
     "@types/node": "^20.10.0",
+    "playwright": "^1.40.0",
     "vite": "^6.4.2",
     "vitest": "^4.1.4"
   },
   "peerDependencies": {
+    "playwright": ">=1.40.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
+    "playwright": {
+      "optional": false
+    },
     "vite": {
       "optional": true
     }

--- a/packages/scenes/src/__tests__/playwright-install.test.ts
+++ b/packages/scenes/src/__tests__/playwright-install.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  installBrowsers,
+  isMissingBrowserError,
+  isMissingPlaywrightError,
+  resolvePlaywrightCli,
+  MISSING_BROWSER_MESSAGE,
+  MISSING_PLAYWRIGHT_MESSAGE,
+} from '../playwright-install.js'
+
+describe('resolvePlaywrightCli', () => {
+  it('points at the cli.js of the playwright scenetest itself loads', () => {
+    const cli = resolvePlaywrightCli()
+    expect(path.basename(cli)).toBe('cli.js')
+    expect(fs.existsSync(cli)).toBe(true)
+    // Same package root as the library the runner imports, so the browsers it
+    // downloads are the ones the run will launch.
+    const root = path.dirname(cli)
+    const version = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')).version
+    expect(version).toMatch(/^\d+\.\d+\.\d+/)
+  })
+})
+
+describe('installBrowsers', () => {
+  it('forwards its arguments to `playwright install` and reports the exit code', async () => {
+    // `--dry-run` exercises the spawn path without downloading a browser.
+    const code = await installBrowsers(['chromium', '--dry-run'], { stdio: 'ignore' })
+    expect(code).toBe(0)
+  })
+
+  it('reports a non-zero exit code from the installer', async () => {
+    const code = await installBrowsers(['no-such-browser'], { stdio: 'ignore' })
+    expect(code).not.toBe(0)
+  })
+})
+
+describe('isMissingPlaywrightError', () => {
+  it('recognizes an unresolvable playwright import', () => {
+    const err = Object.assign(new Error("Cannot find package 'playwright' imported from /app/runner.js"), {
+      code: 'ERR_MODULE_NOT_FOUND',
+    })
+    expect(isMissingPlaywrightError(err)).toBe(true)
+  })
+
+  it('ignores an unresolvable import of some other package', () => {
+    const err = Object.assign(new Error("Cannot find package 'jiti' imported from /app/loader.js"), {
+      code: 'ERR_MODULE_NOT_FOUND',
+    })
+    expect(isMissingPlaywrightError(err)).toBe(false)
+  })
+
+  it('ignores an error without a module-resolution code', () => {
+    expect(isMissingPlaywrightError(new Error("Cannot find package 'playwright'"))).toBe(false)
+    expect(isMissingPlaywrightError(null)).toBe(false)
+  })
+})
+
+describe('isMissingBrowserError', () => {
+  it("recognizes playwright's missing-executable error", () => {
+    const err = new Error(
+      "browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1200/chrome-linux/chrome"
+    )
+    expect(isMissingBrowserError(err)).toBe(true)
+  })
+
+  it('ignores an unrelated launch failure', () => {
+    expect(isMissingBrowserError(new Error('browserType.launch: Timeout 30000ms exceeded'))).toBe(false)
+    expect(isMissingBrowserError(null)).toBe(false)
+  })
+})
+
+describe('setup messages', () => {
+  it('name the command that fixes each failure', () => {
+    expect(MISSING_PLAYWRIGHT_MESSAGE).toContain('pnpm add -D playwright')
+    expect(MISSING_PLAYWRIGHT_MESSAGE).toContain('scenetest install')
+    expect(MISSING_BROWSER_MESSAGE).toContain('scenetest install')
+  })
+})

--- a/packages/scenes/src/cli.ts
+++ b/packages/scenes/src/cli.ts
@@ -5,7 +5,13 @@ import path from 'path'
 import fs from 'fs'
 import { fileURLToPath } from 'url'
 import { loadConfig, filterTeamsByName } from './config.js'
-import { SceneRunner, printSummary } from './runner.js'
+import {
+  installBrowsers,
+  isMissingBrowserError,
+  isMissingPlaywrightError,
+  MISSING_BROWSER_MESSAGE,
+  MISSING_PLAYWRIGHT_MESSAGE,
+} from './playwright-install.js'
 import { init } from './init.js'
 import {
   ReportUrlReporter,
@@ -28,6 +34,32 @@ import type { CLIOptions, RunReport } from './types.js'
 // the installed package instead of a hand-maintained literal that drifts.
 const pkgPath = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'package.json')
 const version = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version as string
+
+/**
+ * The runner imports playwright at module scope, and playwright is a peer
+ * dependency. Loading the runner lazily keeps the rest of the CLI — above all
+ * `scenetest install` — reachable on a project that has not installed it yet.
+ */
+function loadRunner(): Promise<typeof import('./runner.js')> {
+  return import('./runner.js')
+}
+
+/**
+ * Report a broken playwright setup as the instruction that fixes it. Both
+ * failures reach the user through the CLI: a missing peer while the run loads
+ * playwright, a missing browser build while it launches one.
+ */
+function reportSetupError(err: unknown): boolean {
+  if (isMissingPlaywrightError(err)) {
+    console.error(MISSING_PLAYWRIGHT_MESSAGE)
+    return true
+  }
+  if (isMissingBrowserError(err)) {
+    console.error(MISSING_BROWSER_MESSAGE)
+    return true
+  }
+  return false
+}
 
 const program = new Command()
 
@@ -110,6 +142,7 @@ program
       }
 
       // Create runner
+      const { SceneRunner, printSummary } = await loadRunner()
       const runner = new SceneRunner(config, teams)
 
       // Initialize browser
@@ -206,7 +239,9 @@ program
         process.exit(exitCode)
       }
     } catch (err) {
-      console.error('Error:', err instanceof Error ? err.message : err)
+      if (!reportSetupError(err)) {
+        console.error('Error:', err instanceof Error ? err.message : err)
+      }
       process.exit(1)
     }
   })
@@ -254,6 +289,23 @@ async function writeReport(
   }
 }
 
+
+program
+  .command('install')
+  .description('Install the browser builds scenetest runs scenes in')
+  .argument('[args...]', 'Passed through to `playwright install` (e.g. chromium, --with-deps, --force)')
+  .allowUnknownOption()
+  .action(async (args: string[]) => {
+    // Forward to the playwright scenetest itself resolves, so the browser
+    // builds match the library that will drive them.
+    try {
+      const code = await installBrowsers(args)
+      if (code !== 0) process.exit(code)
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : err)
+      process.exit(1)
+    }
+  })
 
 program
   .command('init')

--- a/packages/scenes/src/init.ts
+++ b/packages/scenes/src/init.ts
@@ -57,5 +57,6 @@ export default [
   }
 
   console.log('Created scenetest/ directory')
-  console.log('Run `npx scenetest` to start running scene specs.')
+  console.log('Run `npx scenetest install` to download the browser builds.')
+  console.log('Then run `npx scenetest` to start running scene specs.')
 }

--- a/packages/scenes/src/playwright-install.ts
+++ b/packages/scenes/src/playwright-install.ts
@@ -1,0 +1,92 @@
+import path from 'path'
+import { spawn } from 'child_process'
+import { createRequire } from 'module'
+import { fileURLToPath } from 'url'
+
+/**
+ * Playwright is a peer dependency of @scenetest/scenes: the consumer declares
+ * it, so its bin is linked and exactly one copy backs both the browser
+ * download and the run. This module turns the two ways that contract breaks —
+ * no playwright, no browser binaries — into instructions instead of a stack
+ * trace, and backs `scenetest install`.
+ */
+
+export const MISSING_PLAYWRIGHT_MESSAGE = [
+  'playwright is not installed.',
+  '',
+  'Scenetest drives the browser through playwright, and declares it as a peer',
+  'dependency so your project keeps exactly one copy of it. Install it, then',
+  'install the browser builds:',
+  '',
+  '  pnpm add -D playwright',
+  '  pnpm exec scenetest install',
+].join('\n')
+
+export const MISSING_BROWSER_MESSAGE = [
+  'The browser build is not installed.',
+  '',
+  'Install the browsers playwright needs:',
+  '',
+  '  pnpm exec scenetest install',
+].join('\n')
+
+/** True if `err` is Node failing to resolve the playwright package. */
+export function isMissingPlaywrightError(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code
+  if (code !== 'ERR_MODULE_NOT_FOUND' && code !== 'MODULE_NOT_FOUND') return false
+  return /'playwright'|"playwright"/.test((err as Error).message ?? '')
+}
+
+/** True if `err` is playwright reporting that a browser build is missing. */
+export function isMissingBrowserError(err: unknown): boolean {
+  const message = (err as Error | null)?.message ?? ''
+  return /Executable doesn't exist|please run the following command to download new browsers/i.test(
+    message
+  )
+}
+
+/**
+ * Absolute path to the `cli.js` of the playwright copy scenetest itself loads.
+ * Resolving through `playwright/package.json` (an exported path) finds the
+ * package root without depending on playwright exporting its CLI.
+ *
+ * Throws with MISSING_PLAYWRIGHT_MESSAGE if playwright is not installed.
+ */
+export function resolvePlaywrightCli(): string {
+  let packageJson: string
+  try {
+    // `playwright/package.json` is an unconditional export, so require
+    // resolution reaches it. `import.meta.resolve` covers the loaders that
+    // give us no CJS resolver.
+    packageJson = createRequire(import.meta.url).resolve('playwright/package.json')
+  } catch {
+    try {
+      packageJson = fileURLToPath(import.meta.resolve('playwright/package.json'))
+    } catch {
+      throw new Error(MISSING_PLAYWRIGHT_MESSAGE)
+    }
+  }
+  return path.join(path.dirname(packageJson), 'cli.js')
+}
+
+/**
+ * Run `playwright install <args>` against scenetest's own resolved playwright,
+ * so the browser builds match the library that will drive them. Resolves with
+ * the child's exit code.
+ *
+ * The download reports its progress on the CLI's own streams. `stdio` is here
+ * for tests, which capture that output instead of printing it.
+ */
+export function installBrowsers(
+  args: string[] = [],
+  options: { stdio?: 'inherit' | 'ignore' } = {}
+): Promise<number> {
+  const cli = resolvePlaywrightCli()
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cli, 'install', ...args], {
+      stdio: options.stdio ?? 'inherit',
+    })
+    child.on('error', reject)
+    child.on('close', (code) => resolve(code ?? 1))
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.2(@types/node@20.19.30)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      playwright:
+        specifier: 1.56.1
+        version: 1.56.1
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -358,13 +361,13 @@ importers:
       jiti:
         specifier: ^2.4.0
         version: 2.6.1
-      playwright:
-        specifier: 1.56.1
-        version: 1.56.1
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.30
+      playwright:
+        specifier: 1.56.1
+        version: 1.56.1
       typescript:
         specifier: ^5.3.0
         version: 5.9.3


### PR DESCRIPTION
Closes #245.

**Stacked on `claude/issue-244-3y9pls`** — retarget to the default branch once that one merges.

## The problem

Under pnpm's default isolated layout, a playwright nested inside `@scenetest/scenes` never linked its bin into the consuming project. Once a project stopped depending on playwright directly, the documented way to get the browsers failed:

```
$ pnpm exec playwright install chromium
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "playwright" not found
```

Nothing in the scenetest CLI covered browser installation either.

## The change

Both halves of the issue, because they fix different failures.

**playwright is now a peer dependency** (`>=1.40.0`, `optional: false`). The consumer supplies it, so the bin is linked and one copy backs both the browser download and the run. A project that carried its own playwright alongside the nested one could otherwise download browsers for one version and launch scenes with another.

**New `scenetest install [args...]`** — resolves the playwright scenetest itself loads (through `playwright/package.json` → `cli.js`) and spawns `playwright install`, so the builds it downloads are the ones the run launches. Arguments pass straight through: `scenetest install chromium --with-deps`.

**Supporting:**

- `cli.ts` imports `runner.js` lazily. The runner imports playwright at module scope, so without this `scenetest install` would be unreachable on exactly the project that needs it.
- A missing peer or a missing browser build prints the command that fixes it, not `ERR_MODULE_NOT_FOUND` or a launch stack trace. Both predicates were checked against the real errors.
- `scenetest init` points at `scenetest install` as the next step.
- Docs: README install block, getting-started step 1, and new **Subcommands** + **Browsers** sections in the CLI reference. CLAUDE.md records the peer contract and the lazy-import constraint.
- Release commit on top: monorepo 0.18.0 · `@scenetest/scenes` 0.17.0 (breaking rides the minor slot pre-1.0).

## Breaking change

Consumers must add `playwright` to their own `package.json`:

```bash
pnpm add -D playwright
pnpm exec scenetest install
```

pnpm's `auto-install-peers` (default in pnpm 10) papers over it for most, but the changelog and docs state the explicit install.

## Verification

- `pnpm build`, `pnpm typecheck`, `pnpm test:unit` — all 7 packages green, 9 new tests in `playwright-install.test.ts`. Re-run after rebasing onto issue-244.
- `pnpm test:e2e` — 14/14.
- Ran the real CLI against the React example with the dev server up: 2/2 scenes, 91/91 assertions. That exercises the lazy runner load and peer resolution end to end.
- Confirmed `examples/react/node_modules/.bin/playwright` is linked after install — the symptom the issue opened on.

CI is unaffected: the e2e job runs in the Playwright container and `pnpm exec playwright --version` resolves through the root `@playwright/test`, which ships its own `playwright` bin. `.github/workflows/tests.yml` is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCHqdNzrsHvkZueSVUmJLt)_