### PR TITLE
feat(scenes): grant clipboard permissions by default, via a permissions record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@ All notable changes to Scenetest are documented here.
 
 **playwright is a peer dependency.** Your project supplies playwright, so its bin is linked in `node_modules/.bin` and one copy backs both the browser download and the run. `scenetest install` downloads the browser builds through the playwright scenetest itself resolves.
 
+**Actors can use the clipboard.** A "copy link" button works without configuration, and a new `permissions` option grants anything else the browser supports.
+
 ### @scenetest/scenes 0.17.0
 * **Breaking:** `playwright` moved from `dependencies` to `peerDependencies` (`>=1.40.0`, not optional). Add it to your project: `pnpm add -D playwright`. Under pnpm's default isolated layout a nested playwright never linked its bin, so `pnpm exec playwright install` failed once a project stopped depending on playwright directly.
 * New `scenetest install [args...]` subcommand — runs `playwright install` against scenetest's own resolved playwright, so the browser builds match the library that launches them. Arguments pass straight through (`scenetest install chromium --with-deps`).
 * A missing playwright or a missing browser build now prints the command that fixes it instead of a module-resolution or launch stack trace.
+* **Actors can use the clipboard by default.** A "copy link" button works without configuration; before, `navigator.clipboard.writeText()` rejected, the app showed an error, and the scene failed on something that works for a real user. ([#243](https://github.com/scenetest/scenetest-js/issues/243))
+* New `permissions` config option — a record of deltas against the defaults, not a list, so adding one permission doesn't revoke the others: `{ geolocation: true }` grants geolocation and keeps the clipboard, `{ 'clipboard-read': false }` drops just that one. Set both clipboard names to `false` to opt out entirely.
+* Permission support differs per browser (chromium has both clipboard permissions, webkit only `clipboard-read`, firefox neither), and Playwright throws `Unknown permission` for a name its map doesn't carry. Scenetest now checks against the configured browser and skips an unsupported name with a warning instead of failing the run at context creation.
+* New `contextOptions` config option — a passthrough to Playwright's `browser.newContext()` for settings scenetest has no option of its own for (geolocation, locale, timezoneId, colorScheme, offline). It merges below `baseUrl`, the active device profile, and warmup storage state, and applies to every context an actor gets, including the temp context warmup runs in. Its own `permissions` key, if set, is passed through as written and overrides `permissions`.
 
 ---
 

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -101,6 +101,18 @@ export default defineConfig({
   reportDir: './scenetest-reports',
   reportFormat: 'html',         // 'html' | 'json' | 'both'
 
+  // Playwright browser-context options, applied to every actor context.
+  // A passthrough for settings scenetest has no option of its own for.
+  // baseUrl, the active device profile, and warmup storage state all
+  // override a key they set.
+  contextOptions: {
+    permissions: ['clipboard-read', 'clipboard-write'],
+    // locale: 'fr-FR',
+    // timezoneId: 'Europe/Paris',
+    // colorScheme: 'dark',
+    // offline: true,
+  },
+
   // Device rotation
   devices: true,                // Use built-in device pool
   // Or provide custom devices:

--- a/docs/public/reference/cli.md
+++ b/docs/public/reference/cli.md
@@ -101,16 +101,22 @@ export default defineConfig({
   reportDir: './scenetest-reports',
   reportFormat: 'html',         // 'html' | 'json' | 'both'
 
+  // Browser permissions, as deltas against the defaults (see below)
+  permissions: {
+    geolocation: true,          // grant on top of the defaults
+    // 'clipboard-read': false, // or drop one of them
+  },
+
   // Playwright browser-context options, applied to every actor context.
   // A passthrough for settings scenetest has no option of its own for.
   // baseUrl, the active device profile, and warmup storage state all
   // override a key they set.
   contextOptions: {
-    permissions: ['clipboard-read', 'clipboard-write'],
-    // locale: 'fr-FR',
+    locale: 'fr-FR',
     // timezoneId: 'Europe/Paris',
     // colorScheme: 'dark',
     // offline: true,
+    // geolocation: { latitude: 48.85, longitude: 2.35 },
   },
 
   // Device rotation
@@ -146,6 +152,60 @@ export default defineConfig({
   afterEach: async (scene, report) => { /* per-scene teardown */ },
 })
 ```
+
+### Permissions
+
+Actors can read and write the clipboard by default, so a "copy link" button
+works without configuration. Without the permission
+`navigator.clipboard.writeText()` rejects with `NotAllowedError`, the app
+catches it and shows an error, and the scene fails on something that works for
+a real user.
+
+`permissions` is a record rather than a list, because a list would mean
+restating the defaults to add anything — `['geolocation']` would silently
+revoke the clipboard. Each entry is a delta:
+
+```typescript
+export default defineConfig({
+  permissions: {
+    geolocation: true,          // granted, and the clipboard stays granted
+    'clipboard-read': false,    // drop just this one
+  },
+})
+```
+
+To turn the defaults off entirely, set both to `false`:
+
+```typescript
+permissions: { 'clipboard-read': false, 'clipboard-write': false }
+```
+
+Worth doing when a scene needs to exercise the denied path — an app that shows
+a "grant clipboard access" prompt never reaches it with the permission granted.
+
+Permission names are [Playwright's](https://playwright.dev/docs/api/class-browsercontext#browser-context-grant-permissions).
+Support differs per browser, and a name the browser doesn't recognise is
+skipped with a warning rather than failing the run:
+
+| Permission | chromium | firefox | webkit |
+|------------|----------|---------|--------|
+| `clipboard-read` | yes | — | yes |
+| `clipboard-write` | yes | — | — |
+| `geolocation` | yes | yes | yes |
+| `notifications` | yes | yes | yes |
+| `camera`, `microphone` | yes | — | — |
+| `persistent-storage`, `push` | — | yes | — |
+
+Firefox has no clipboard permission at all — it gates clipboard writes on a
+user gesture, which a real click satisfies.
+
+The clipboard is a browser-wide resource, not a per-context one. A headless run
+(the default) keeps it inside the browser process. A headed run uses the real
+system clipboard: writes overwrite what you have copied, and `clipboard-read`
+exposes it to the app under test.
+
+For an exact list handed straight to Playwright, set `contextOptions.permissions`
+— it is a passthrough and overrides `permissions` entirely.
 
 ## Team Discovery
 

--- a/packages/scenes/src/__tests__/permissions.test.ts
+++ b/packages/scenes/src/__tests__/permissions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  DEFAULT_GRANTED,
+  SUPPORTED_PERMISSIONS,
+  resolvePermissions,
+  resolveContextOptions,
+} from '../permissions.js'
+
+const silent = () => {}
+
+describe('SUPPORTED_PERMISSIONS', () => {
+  // Mirrors Playwright's per-browser permission maps. Playwright throws
+  // "Unknown permission" at newContext() for anything outside them.
+  it('carries the clipboard permissions each browser accepts', () => {
+    expect(SUPPORTED_PERMISSIONS.chromium).toContain('clipboard-read')
+    expect(SUPPORTED_PERMISSIONS.chromium).toContain('clipboard-write')
+    expect(SUPPORTED_PERMISSIONS.webkit).toContain('clipboard-read')
+    expect(SUPPORTED_PERMISSIONS.webkit).not.toContain('clipboard-write')
+    expect(SUPPORTED_PERMISSIONS.firefox).not.toContain('clipboard-read')
+    expect(SUPPORTED_PERMISSIONS.firefox).not.toContain('clipboard-write')
+  })
+
+  it('grants the clipboard by default', () => {
+    expect(DEFAULT_GRANTED).toEqual(['clipboard-read', 'clipboard-write'])
+  })
+})
+
+describe('resolvePermissions', () => {
+  it('grants the defaults the browser supports', () => {
+    expect(resolvePermissions(undefined, 'chromium', silent)).toEqual(['clipboard-read', 'clipboard-write'])
+    expect(resolvePermissions(undefined, 'webkit', silent)).toEqual(['clipboard-read'])
+    expect(resolvePermissions(undefined, 'firefox', silent)).toEqual([])
+  })
+
+  it('adds a permission without revoking the defaults', () => {
+    expect(resolvePermissions({ geolocation: true }, 'chromium', silent)).toEqual([
+      'clipboard-read',
+      'clipboard-write',
+      'geolocation',
+    ])
+  })
+
+  it('drops just the permission set to false', () => {
+    expect(resolvePermissions({ 'clipboard-read': false }, 'chromium', silent)).toEqual(['clipboard-write'])
+  })
+
+  it('combines an add and a drop', () => {
+    expect(
+      resolvePermissions({ 'clipboard-write': false, geolocation: true }, 'chromium', silent)
+    ).toEqual(['clipboard-read', 'geolocation'])
+  })
+
+  it('opts out of everything when both defaults are false', () => {
+    expect(
+      resolvePermissions({ 'clipboard-read': false, 'clipboard-write': false }, 'chromium', silent)
+    ).toEqual([])
+  })
+
+  it('skips a requested permission the browser does not support, and warns', () => {
+    const warn = vi.fn()
+    expect(resolvePermissions({ camera: true }, 'firefox', warn)).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0][0]).toContain('camera')
+    expect(warn.mock.calls[0][0]).toContain('firefox')
+  })
+
+  it('stays quiet about a default the browser does not support', () => {
+    const warn = vi.fn()
+    resolvePermissions(undefined, 'firefox', warn)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet about an unsupported permission that was turned off anyway', () => {
+    const warn = vi.fn()
+    expect(resolvePermissions({ camera: false }, 'firefox', warn)).toEqual([])
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps a supported permission alongside a skipped one', () => {
+    const warn = vi.fn()
+    expect(resolvePermissions({ geolocation: true, camera: true }, 'firefox', warn)).toEqual(['geolocation'])
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})
+
+describe('resolveContextOptions', () => {
+  it('applies the default permissions when nothing is configured', () => {
+    expect(resolveContextOptions(undefined, undefined, 'chromium', silent)).toEqual({
+      permissions: ['clipboard-read', 'clipboard-write'],
+    })
+  })
+
+  it('returns null when there is nothing to apply', () => {
+    expect(resolveContextOptions(undefined, undefined, 'firefox', silent)).toBeNull()
+  })
+
+  it('keeps passthrough options alongside resolved permissions', () => {
+    expect(resolveContextOptions({ locale: 'fr-FR' }, { geolocation: true }, 'chromium', silent)).toEqual({
+      locale: 'fr-FR',
+      permissions: ['clipboard-read', 'clipboard-write', 'geolocation'],
+    })
+  })
+
+  it('lets a raw contextOptions.permissions array win outright', () => {
+    expect(
+      resolveContextOptions({ permissions: ['geolocation'] }, { geolocation: true }, 'chromium', silent)
+    ).toEqual({ permissions: ['geolocation'] })
+  })
+
+  it('does not mutate the configured options', () => {
+    const contextOptions = { locale: 'fr-FR' }
+    const overrides = { geolocation: true }
+    resolveContextOptions(contextOptions, overrides, 'chromium', silent)
+    expect(contextOptions).toEqual({ locale: 'fr-FR' })
+    expect(overrides).toEqual({ geolocation: true })
+  })
+})

--- a/packages/scenes/src/__tests__/team-manager.test.ts
+++ b/packages/scenes/src/__tests__/team-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { TeamManager } from '../team-manager.js'
+import { DeviceRotation } from '../devices.js'
 import type { ResolvedTeam } from '../types.js'
 import type { StorageState } from '../warmup.js'
 
@@ -218,5 +219,88 @@ describe('TeamManager.getTeams', () => {
     ]
     const manager = new TeamManager(teams)
     expect(manager.getTeams()).toBe(teams)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Config-wide contextOptions passthrough
+// ---------------------------------------------------------------------------
+
+describe('TeamManager contextOptions passthrough', () => {
+  const teams = (): ResolvedTeam[] => [{ actors: { user: { key: 'u1' } }, meta: {} }]
+
+  it('applies config contextOptions to the actor context', async () => {
+    const browser = mockBrowser()
+    const manager = new TeamManager(teams())
+    manager.setBrowser(browser as any)
+    manager.setContextOptions({ permissions: ['clipboard-read', 'clipboard-write'] })
+    const session = await manager.createSession(0, 5000, 500, 'http://localhost:3000')
+
+    await session.getActor('user')
+
+    const opts = browser.newContext.mock.calls[0][0]
+    expect(opts.permissions).toEqual(['clipboard-read', 'clipboard-write'])
+    expect(opts.baseURL).toBe('http://localhost:3000')
+  })
+
+  it('applies config contextOptions via createPage', async () => {
+    const browser = mockBrowser()
+    const manager = new TeamManager(teams())
+    manager.setBrowser(browser as any)
+    manager.setContextOptions({ locale: 'fr-FR', offline: true })
+    const session = await manager.createSession(0, 5000, 500, 'http://localhost:3000')
+
+    await session.createPage('user')
+
+    const opts = browser.newContext.mock.calls[0][0]
+    expect(opts.locale).toBe('fr-FR')
+    expect(opts.offline).toBe(true)
+  })
+
+  it('lets a device profile override a key the config sets', async () => {
+    const browser = mockBrowser()
+    const manager = new TeamManager(teams())
+    manager.setBrowser(browser as any)
+    manager.setContextOptions({ locale: 'fr-FR', viewport: { width: 100, height: 100 } })
+    manager.setDeviceRotation(new DeviceRotation([
+      { name: 'Small', category: 'mobile', contextOptions: { viewport: { width: 390, height: 844 } } },
+    ]))
+    const session = await manager.createSession(0, 5000, 500, 'http://localhost:3000')
+
+    await session.getActor('user')
+
+    const opts = browser.newContext.mock.calls[0][0]
+    // Device wins on viewport, config keeps the keys the device leaves alone
+    expect(opts.viewport).toEqual({ width: 390, height: 844 })
+    expect(opts.locale).toBe('fr-FR')
+  })
+
+  it('applies config contextOptions to the warmup context', async () => {
+    const browser = mockBrowser()
+    const manager = new TeamManager([{
+      actors: { user: { key: 'u1', warmup: async () => {} } },
+      meta: {},
+    }])
+    manager.setBrowser(browser as any)
+    manager.setContextOptions({ permissions: ['clipboard-write'] })
+    const session = await manager.createSession(0, 5000, 500, 'http://localhost:3000')
+
+    await session.getActor('user')
+
+    // First context is the warmup one, second is the actor's
+    const warmupOpts = browser.newContext.mock.calls[0][0]
+    expect(warmupOpts.permissions).toEqual(['clipboard-write'])
+    expect(warmupOpts.baseURL).toBe('http://localhost:3000')
+  })
+
+  it('leaves context options untouched when the config sets none', async () => {
+    const browser = mockBrowser()
+    const manager = new TeamManager(teams())
+    manager.setBrowser(browser as any)
+    const session = await manager.createSession(0, 5000, 500, 'http://localhost:3000')
+
+    await session.getActor('user')
+
+    expect(browser.newContext.mock.calls[0][0]).toEqual({ baseURL: 'http://localhost:3000' })
   })
 })

--- a/packages/scenes/src/permissions.ts
+++ b/packages/scenes/src/permissions.ts
@@ -1,0 +1,113 @@
+import type { BrowserContextOptions } from 'playwright'
+
+/** The browsers the CLI can launch. */
+export type BrowserName = 'chromium' | 'firefox' | 'webkit'
+
+/**
+ * Which permissions to grant, by name.
+ *
+ * A record rather than a list, because some permissions are granted by default
+ * and some are not. A list would mean restating the defaults to add one thing —
+ * `['geolocation']` would silently revoke the clipboard. Each entry is a delta
+ * against {@link DEFAULT_GRANTED}.
+ */
+export type PermissionOverrides = Record<string, boolean>
+
+/**
+ * Permissions granted to every actor unless turned off.
+ *
+ * A "copy link" button is ordinary UI, but the permission behind it has nobody
+ * to grant it in a test run: `navigator.clipboard.writeText()` rejects with
+ * `NotAllowedError`, the app catches it and shows an error, and the scene fails
+ * on something that works for a real user.
+ */
+export const DEFAULT_GRANTED: readonly string[] = ['clipboard-read', 'clipboard-write']
+
+/**
+ * The permission names each browser's Playwright binding accepts.
+ *
+ * Playwright keeps a separate map per browser and throws `Unknown permission`
+ * at `browser.newContext()` for a name its map doesn't carry, so a permission
+ * has to be checked against the browser actually being launched.
+ */
+export const SUPPORTED_PERMISSIONS: Record<BrowserName, readonly string[]> = {
+  chromium: [
+    'geolocation', 'midi', 'notifications', 'camera', 'microphone',
+    'background-sync', 'ambient-light-sensor', 'accelerometer', 'gyroscope',
+    'magnetometer', 'clipboard-read', 'clipboard-write', 'payment-handler',
+    'midi-sysex', 'storage-access', 'local-fonts', 'local-network-access',
+  ],
+  firefox: ['geolocation', 'persistent-storage', 'push', 'notifications'],
+  webkit: ['geolocation', 'notifications', 'clipboard-read'],
+}
+
+/**
+ * Resolve the permission list handed to `browser.newContext()`.
+ *
+ * Starts from {@link DEFAULT_GRANTED} and applies `overrides` on top, so a
+ * config only ever states its deltas: `{ geolocation: true }` adds geolocation
+ * and keeps the clipboard, `{ 'clipboard-read': false }` drops just that one.
+ *
+ * A name the browser doesn't support is dropped rather than thrown on, since
+ * Playwright would otherwise fail the whole run at context creation. Dropping
+ * one the config asked for is reported through `warn`; dropping a default
+ * (`clipboard-write` on webkit, both on firefox) is expected and stays quiet.
+ */
+export function resolvePermissions(
+  overrides: PermissionOverrides | undefined,
+  browser: BrowserName,
+  warn: (message: string) => void = console.warn
+): string[] {
+  const supported = SUPPORTED_PERMISSIONS[browser]
+
+  // Map keeps a stable order: defaults first, then whatever the config adds.
+  const wanted = new Map<string, boolean>(DEFAULT_GRANTED.map((name) => [name, true]))
+  const requested = new Set<string>()
+  for (const [name, grant] of Object.entries(overrides ?? {})) {
+    wanted.set(name, grant)
+    if (grant) requested.add(name)
+  }
+
+  const granted: string[] = []
+  const dropped: string[] = []
+  for (const [name, grant] of wanted) {
+    if (!grant) continue
+    if (supported.includes(name)) {
+      granted.push(name)
+    } else if (requested.has(name)) {
+      dropped.push(name)
+    }
+  }
+
+  if (dropped.length > 0) {
+    warn(
+      `[scenetest] ${browser} has no ${dropped.join(', ')} permission — ` +
+      `not granted. Supported: ${supported.join(', ')}.`
+    )
+  }
+
+  return granted
+}
+
+/**
+ * Build the browser-context options applied to every actor context.
+ *
+ * `contextOptions` is a straight passthrough to Playwright. Its own
+ * `permissions` key, if set, is taken as written and wins over `permissions` —
+ * the escape hatch for handing Playwright an exact list.
+ *
+ * Returns null when there is nothing to apply.
+ */
+export function resolveContextOptions(
+  contextOptions: BrowserContextOptions | undefined,
+  overrides: PermissionOverrides | undefined,
+  browser: BrowserName,
+  warn: (message: string) => void = console.warn
+): BrowserContextOptions | null {
+  const permissions = contextOptions?.permissions ?? resolvePermissions(overrides, browser, warn)
+  const resolved: BrowserContextOptions = {
+    ...contextOptions,
+    ...(permissions.length > 0 ? { permissions } : {}),
+  }
+  return Object.keys(resolved).length > 0 ? resolved : null
+}

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -146,6 +146,11 @@ export class SceneRunner {
       }
     }
 
+    // Pass Playwright context options through to every actor context
+    if (config.contextOptions) {
+      this.teamManager.setContextOptions(config.contextOptions)
+    }
+
     // Set up device rotation if configured
     if (config.devices) {
       const devices = Array.isArray(config.devices) ? config.devices : undefined

--- a/packages/scenes/src/runner.ts
+++ b/packages/scenes/src/runner.ts
@@ -6,6 +6,7 @@ import path from 'path'
 import type { ScenetestConfig, ResolvedTeam, TeamConfig, TeamMeta, RunReport, SceneReport, RegisteredScene } from './types.js'
 import { TeamManager } from './team-manager.js'
 import { DeviceRotation } from './devices.js'
+import { resolveContextOptions } from './permissions.js'
 import { NavigationModeRotation } from './keyboard.js'
 import type { NavigationMode } from './keyboard.js'
 import { sceneRegistry, setCurrentFile, runScene } from './scene.js'
@@ -146,9 +147,15 @@ export class SceneRunner {
       }
     }
 
-    // Pass Playwright context options through to every actor context
-    if (config.contextOptions) {
-      this.teamManager.setContextOptions(config.contextOptions)
+    // Pass Playwright context options through to every actor context, with the
+    // configured browser's default clipboard permissions filled in
+    const contextOptions = resolveContextOptions(
+      config.contextOptions,
+      config.permissions,
+      config.browser ?? 'chromium'
+    )
+    if (contextOptions) {
+      this.teamManager.setContextOptions(contextOptions)
     }
 
     // Set up device rotation if configured

--- a/packages/scenes/src/team-manager.ts
+++ b/packages/scenes/src/team-manager.ts
@@ -1,4 +1,4 @@
-import type { Browser, BrowserContext, Page } from 'playwright'
+import type { Browser, BrowserContext, BrowserContextOptions, Page } from 'playwright'
 import type { TeamConfig, ActorConfig, AssertionResult, TimelineEntry, ScriptWarning, ConsoleError, ErrorSelector, ResolvedTeam, TeamMeta, PageFactory } from './types.js'
 import type { DeviceProfile } from './devices.js'
 import type { StorageState } from './warmup.js'
@@ -23,6 +23,7 @@ export class TeamManager {
   private deviceRotation: DeviceRotation | null = null
   private warmupCache = new WarmupCache()
   private navigationModeRotation: NavigationModeRotation | null = null
+  private contextOptions: BrowserContextOptions | null = null
 
   constructor(teams: ResolvedTeam[]) {
     this.teams = teams
@@ -68,6 +69,14 @@ export class TeamManager {
    */
   getNavigationModeRotation(): NavigationModeRotation | null {
     return this.navigationModeRotation
+  }
+
+  /**
+   * Set the browser-context options applied to every actor context.
+   * Device profiles and warmup storage state still override them.
+   */
+  setContextOptions(options: BrowserContextOptions): void {
+    this.contextOptions = options
   }
 
   /**
@@ -213,7 +222,8 @@ export class TeamManager {
       fuzzyFingers,
       noPanel,
       consoleErrors,
-      errorSelectors
+      errorSelectors,
+      this.contextOptions
     )
   }
 }
@@ -256,7 +266,8 @@ export class TeamSession {
     private fuzzyFingers: boolean = false,
     private noPanel?: boolean,
     consoleErrors?: boolean | 'error' | 'warn',
-    errorSelectors?: ErrorSelector[]
+    errorSelectors?: ErrorSelector[],
+    private contextOptions?: BrowserContextOptions | null
   ) {
     this.meta = meta
     // Default: capture errors
@@ -299,15 +310,16 @@ export class TeamSession {
   }
 
   /**
-   * Build context options for a role, merging device emulation, baseURL,
-   * warmup storageState (lazy — runs on first use), and actor localStorage.
+   * Build context options for a role, merging the config-wide contextOptions,
+   * baseURL, device emulation, warmup storageState (lazy — runs on first use),
+   * and actor localStorage.
    */
   private async buildContextOptions(role: string, device: DeviceProfile | null): Promise<Record<string, unknown>> {
     const config = this.team[role]
 
     // Lazy warmup: runs on first use, cached for subsequent scenes
     const warmupState = config
-      ? await this.warmupCache.ensure(this.browser, config, this.baseUrl ?? '', this.actionTimeout)
+      ? await this.warmupCache.ensure(this.browser, config, this.baseUrl ?? '', this.actionTimeout, this.contextOptions)
       : undefined
     const hasLocalStorage = config?.localStorage && Object.keys(config.localStorage).length > 0
 
@@ -340,6 +352,7 @@ export class TeamSession {
     }
 
     return {
+      ...(this.contextOptions ?? {}),
       ...(this.baseUrl ? { baseURL: this.baseUrl } : {}),
       ...(device ? device.contextOptions : {}),
       ...(storageState ? { storageState } : {}),
@@ -494,6 +507,7 @@ export class TeamSession {
       const deviceName = resolvedDevice?.name
 
       const contextOptions = {
+        ...(this.contextOptions ?? {}),
         ...(this.baseUrl ? { baseURL: this.baseUrl } : {}),
         ...(resolvedDevice ? resolvedDevice.contextOptions : {}),
       }

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -203,12 +203,37 @@ export interface ScenetestConfig extends BaseConfig {
    * built from warmup and actor `localStorage`, so all four still win on a key
    * they set.
    *
+   * For permissions, prefer the `permissions` option — it composes with the
+   * ones scenetest grants by default. A `permissions` array set here is passed
+   * to Playwright as written and overrides it.
+   *
    * @example
    * ```ts
-   * contextOptions: { permissions: ['clipboard-read', 'clipboard-write'] }
+   * contextOptions: { geolocation: { latitude: 48.85, longitude: 2.35 } }
    * ```
    */
   contextOptions?: BrowserContextOptions
+
+  /**
+   * Browser permissions to grant every actor, by name.
+   *
+   * A record of deltas, not a list: clipboard access is granted by default, so
+   * a list would mean restating it to add anything else. `{ geolocation: true }`
+   * adds geolocation and keeps the clipboard.
+   *
+   * Permission names are Playwright's. A name the configured browser doesn't
+   * support is skipped with a warning rather than failing the run — firefox has
+   * no clipboard permission at all, and webkit has only `clipboard-read`.
+   *
+   * @example
+   * ```ts
+   * permissions: {
+   *   geolocation: true,          // grant on top of the defaults
+   *   'clipboard-read': false,    // and drop one of them
+   * }
+   * ```
+   */
+  permissions?: Record<string, boolean>
 
   /**
    * Device rotation: assign each actor a rotating device profile.

--- a/packages/scenes/src/types.ts
+++ b/packages/scenes/src/types.ts
@@ -1,4 +1,4 @@
-import type { Page, BrowserContext, Browser } from 'playwright'
+import type { Page, BrowserContext, Browser, BrowserContextOptions } from 'playwright'
 import type { ScenetestConfig as BaseConfig } from '@scenetest/checks'
 import type { RunEvent, RunSummary, TeamMeta } from '@scenetest/protocol'
 import type { DeviceProfile } from './devices.js'
@@ -191,6 +191,24 @@ export interface ScenetestConfig extends BaseConfig {
    * Overridden by the `SCENETEST_REPORT_TOKEN` env var.
    */
   reportToken?: string
+
+  /**
+   * Playwright browser-context options applied to every actor context.
+   *
+   * A passthrough to `browser.newContext()` for settings scenetest has no
+   * option of its own for — permissions, geolocation, locale, timezone,
+   * color scheme, offline.
+   *
+   * Merged below `baseUrl`, the active device profile, and the storage state
+   * built from warmup and actor `localStorage`, so all four still win on a key
+   * they set.
+   *
+   * @example
+   * ```ts
+   * contextOptions: { permissions: ['clipboard-read', 'clipboard-write'] }
+   * ```
+   */
+  contextOptions?: BrowserContextOptions
 
   /**
    * Device rotation: assign each actor a rotating device profile.

--- a/packages/scenes/src/warmup.ts
+++ b/packages/scenes/src/warmup.ts
@@ -7,7 +7,7 @@
  * stores the result. Same actor key in a later scene gets the cached state.
  */
 
-import type { Browser, Page } from 'playwright'
+import type { Browser, BrowserContextOptions, Page } from 'playwright'
 import type { ActorConfig } from './types.js'
 import { getMacro } from './dsl.js'
 import { resolveSelector } from './selectors.js'
@@ -55,7 +55,8 @@ export class WarmupCache {
     browser: Browser,
     config: ActorConfig,
     baseUrl: string,
-    actionTimeout: number
+    actionTimeout: number,
+    contextOptions?: BrowserContextOptions | null
   ): Promise<StorageState | undefined> {
     if (!config.warmup) return undefined
 
@@ -63,7 +64,7 @@ export class WarmupCache {
     if (existing) return existing
 
     const start = Date.now()
-    const promise = runActorWarmup(browser, config, baseUrl, actionTimeout)
+    const promise = runActorWarmup(browser, config, baseUrl, actionTimeout, contextOptions)
       .then(state => {
         console.log(`    ✓ warmup: ${config.key} (${Date.now() - start}ms)`)
         return state
@@ -212,9 +213,11 @@ export async function runActorWarmup(
   browser: Browser,
   config: ActorConfig,
   baseUrl: string,
-  actionTimeout: number
+  actionTimeout: number,
+  contextOptions?: BrowserContextOptions | null
 ): Promise<StorageState> {
   const context = await browser.newContext({
+    ...(contextOptions ?? {}),
     baseURL: baseUrl,
   })
 


### PR DESCRIPTION
Closes #243.

> **Base branch needs retargeting.** This was opened against the playwright peer-dependency branch, which has since merged as #248. The branch is now rebased onto current `main` and contains only its own three commits, but GitHub refuses a base change ("the pull request is part of a stack"), so someone with stack tooling needs to point it at `main`.

## The problem

A "copy link" button calls `navigator.clipboard.writeText()`, which needs a permission nobody can grant during a test run. It rejects with `NotAllowedError`, the app catches it and shows an error toast, and the scene fails on something that works fine for a real user.

Nothing in `ScenetestConfig` reached `browser.newContext()`. The only way in was a one-entry `devices` pool, which also switches device rotation on for the whole run and stamps `device: Default (desktop)` into every progress and report line.

## What this does

**Clipboard access is on by default.** No configuration needed for a copy button.

**`permissions` is a record, not a list.** Once something defaults on, a list is the wrong shape — Playwright's `permissions` array replaces rather than composes, so `['geolocation']` would silently revoke the clipboard. Each entry is a delta:

```ts
permissions: { geolocation: true }          // clipboard stays granted
permissions: { 'clipboard-read': false }    // drop just that one
permissions: { 'clipboard-read': false, 'clipboard-write': false }   // full opt-out
```

**`contextOptions` is a separate, faithful passthrough.** Everything Playwright's `newContext()` takes that scenetest has no option of its own for — `locale`, `timezoneId`, `colorScheme`, `offline`, `geolocation`. It stays paste-compatible with Playwright snippets, which is why `permissions` lives at the top level instead of inside it. A `permissions` array set in `contextOptions` is still passed through as written and overrides `permissions`.

It merges *below* `baseUrl`, the active device profile, and warmup storage state, so all three still win on a key they set. It reaches every context an actor gets: the initial one, a `switchDevice()` replacement, and the temp context warmup runs in — so a permission or credential warmup needs is there too.

## Per-browser permissions

Playwright keeps a separate permission map per browser and throws `Unknown permission` at `newContext()` for a name its map doesn't carry, so a blanket default would have broken every firefox and webkit run at context creation:

| | `clipboard-read` | `clipboard-write` |
|---|---|---|
| chromium | yes | yes |
| webkit | yes | not supported |
| firefox | not supported | not supported |

Permissions now resolve against the configured browser, and a name it doesn't support is skipped with a warning rather than failing the run. A default the browser lacks is expected and stays quiet; only a name the config asked for is reported. Firefox gets nothing — it gates clipboard writes on a user gesture, which a real click satisfies.

## Worth knowing

The clipboard is a browser-wide resource, not per-context — verified by having one context write and a separate context read the same value back. Headless (the default) keeps it inside the browser process, but a **headed** run uses the real system clipboard: writes overwrite what the developer has copied, and `clipboard-read` exposes it to the app under test. That, and exercising an app's "grant clipboard access" prompt, are the two reasons to opt out.

## Verification

Behaviour driven through the real `SceneRunner` code path against headless Chromium:

```
(nothing configured)                               clipboard=copy ok     geolocation=denied
permissions: { geolocation: true }                 clipboard=copy ok     geolocation=granted
permissions: { 'clipboard-write': false }          clipboard=copy FAILS  geolocation=denied
permissions: { geolocation: true, ...clip false }  clipboard=copy FAILS  geolocation=granted
contextOptions: { permissions: ["geolocation"] }   clipboard=copy FAILS  geolocation=granted
```

New `packages/scenes/src/permissions.ts` holds the support tables and resolution, with 22 unit tests; 5 more in `team-manager.test.ts` cover the merge order and the warmup context. Full workspace build, typecheck and `pnpm -r test` pass on top of current `main`.

## Versioning

Ships as `monorepo 0.19.0 · @scenetest/scenes 0.18.0`, its own release. An earlier revision of this branch folded these notes into the pending `0.18.0` entry, but that release landed on `main` with #248, so adding to it would slot a feature into an entry that is already cut. If `@scenetest/scenes 0.17.0` was never published and you would rather they ship as one release, say so and I will fold it back.